### PR TITLE
build: bump `tokenizers-cpp` version as latest

### DIFF
--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -70,13 +70,13 @@ if(AILOY_WITH_MLC_LLM)
             FetchContent_Declare(
                 mlc-llm
                 GIT_REPOSITORY https://github.com/brekkylab/mlc-llm.git
-                GIT_TAG 026f91859dddc10ecf96bdaf85f7f3576d73e161
+                GIT_TAG 3b8165524fdb79fd3255395432ac70a7734a22ef
             )
         else()
             FetchContent_Declare(
                 mlc-llm
                 GIT_REPOSITORY https://github.com/brekkylab/mlc-llm.git
-                GIT_TAG 026f91859dddc10ecf96bdaf85f7f3576d73e161
+                GIT_TAG 3b8165524fdb79fd3255395432ac70a7734a22ef
                 PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/cmake/mlc_llm.patch
             )
             set(MLC_LLM_PATCH_APPLIED ON CACHE BOOL "MLC_LLM patch file applied" FORCE)


### PR DESCRIPTION
## Ticket
#5 

## Description
The latest version of `tokenizers-cpp` can set the target macOS version. (added at https://github.com/mlc-ai/tokenizers-cpp/pull/52)
But the `tokenizers-cpp` version that the `mlc-llm` is using is [4bb7533](https://github.com/mlc-ai/tokenizers-cpp/tree/4bb753377680e249345b54c6b10e6d0674c8af03) which doesn't have that.
So let the `mlc-llm` use the latest `tokenizers-cpp` [here](https://github.com/brekkylab/mlc-llm/commits/3b8165524fdb79fd3255395432ac70a7734a22ef/), and ailoy use the `mlc-llm`.

## Requirements
The macOS version setting merged into `tokenizers-cpp` later than its `huggingface/tokenizers` update to `0.21.0` (at https://github.com/mlc-ai/tokenizers-cpp/pull/62), we need to use `0.21.0` for this.
And the `0.21.0` of `huggingface/tokenizers` includes [`std::option::Option::is_none_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or) which is added rust `1.8.20`, so we need rust version `>= 1.82.0`.