### PR TITLE
Fix and unify parameter names related to reasoning

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -505,8 +505,8 @@ export class Agent {
   async *run(
     message: string,
     options?: {
-      reasoning?: boolean;
-      ignore_reasoning?: boolean;
+      enableReasoning?: boolean;
+      ignoreReasoningMessages?: boolean;
     }
   ): AsyncGenerator<AgentResponse> {
     this.messages.push({ role: "user", content: message });
@@ -520,8 +520,8 @@ export class Agent {
           tools: this.tools.map((v) => {
             return { type: "function", function: v.desc };
           }),
-          reasoning: options?.reasoning,
-          ignore_reasoning: options?.ignore_reasoning,
+          enable_reasoning: options?.enableReasoning,
+          ignore_reasoning_messages: options?.ignoreReasoningMessages,
         }
       )) {
         const delta: MessageDelta = resp;

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -80,8 +80,6 @@ describe("Agent", async () => {
   });
 
   after(async () => {
-    console.log("after");
     await rt.stop();
-    console.log("runtime stopped");
   });
 });

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -335,8 +335,8 @@ class Agent:
     async def run(
         self,
         message: str,
-        do_reasoning: Optional[bool] = None,
-        ignore_reasoning: Optional[bool] = None,
+        enable_reasoning: Optional[bool] = None,
+        ignore_reasoning_messages: Optional[bool] = None,
     ) -> AsyncGenerator[AgentResponse, None]:
         self._messages.append(UserMessage(role="user", content=message))
 
@@ -345,10 +345,10 @@ class Agent:
                 "messages": [msg.model_dump() for msg in self._messages],
                 "tools": [{"type": "function", "function": t.desc.model_dump()} for t in self._tools],
             }
-            if do_reasoning is not None:
-                infer_args["reasoning"] = do_reasoning
-            if ignore_reasoning is not None:
-                infer_args["ignore_reasoning"] = ignore_reasoning
+            if enable_reasoning is not None:
+                infer_args["enable_reasoning"] = enable_reasoning
+            if ignore_reasoning_messages is not None:
+                infer_args["ignore_reasoning_messages"] = ignore_reasoning_messages
 
             async for resp in self._runtime.call_iter_method(self._model_info.component_name, "infer", infer_args):
                 delta = MessageDelta.model_validate(resp)

--- a/vm/src/language.cpp
+++ b/vm/src/language.cpp
@@ -167,23 +167,27 @@ std::shared_ptr<const module_t> get_language_module() {
             }
 
             // Get reasoning (optional)
-            bool reasoning = false;
-            if (input_map->contains("reasoning") &&
-                input_map->at("reasoning")->is_type_of<bool_t>())
-              reasoning = *input_map->at<bool_t>("reasoning");
+            bool enable_reasoning = false;
+            if (input_map->contains("enable_reasoning") &&
+                input_map->at("enable_reasoning")->is_type_of<bool_t>())
+              enable_reasoning = *input_map->at<bool_t>("enable_reasoning");
 
             // Get ignore_reasoning (optional)
-            bool ignore_reasoning = false;
-            if (input_map->contains("ignore_reasoning") &&
-                input_map->at("ignore_reasoning")->is_type_of<bool_t>())
-              ignore_reasoning = *input_map->at<bool_t>("ignore_reasoning");
-            component->set_obj("ignore_reasoning",
-                               create<ailoy::bool_t>(ignore_reasoning));
+            bool ignore_reasoning_messages = false;
+            if (input_map->contains("ignore_reasoning_messages") &&
+                input_map->at("ignore_reasoning_messages")
+                    ->is_type_of<bool_t>())
+              ignore_reasoning_messages =
+                  *input_map->at<bool_t>("ignore_reasoning_messages");
+            component->set_obj(
+                "ignore_reasoning_messages",
+                create<ailoy::bool_t>(ignore_reasoning_messages));
 
             // Apply chat template on messages
-            auto prompt = component->get_obj("template_engine")
-                              ->as<chat_template_engine_t>()
-                              ->apply_chat_template(messages, tools, reasoning);
+            auto prompt =
+                component->get_obj("template_engine")
+                    ->as<chat_template_engine_t>()
+                    ->apply_chat_template(messages, tools, enable_reasoning);
 
             // Generate request ID
             uuid_t request_id = generate_uuid();
@@ -200,15 +204,16 @@ std::shared_ptr<const module_t> get_language_module() {
             // Get saved values & objects
             auto request_id = state->as<string_t>();
             auto engine = component->get_obj("engine")->as<mlc_llm_engine_t>();
-            const bool ignore_reasoning =
-                *component->get_obj("ignore_reasoning")->as<ailoy::bool_t>();
+            const bool ignore_reasoning_messages =
+                *component->get_obj("ignore_reasoning_messages")
+                     ->as<ailoy::bool_t>();
 
             // check if delta needs to be dismissed
             auto dismiss_delta =
-                [ignore_reasoning](nlohmann::json delta) -> bool {
+                [ignore_reasoning_messages](nlohmann::json delta) -> bool {
               // case 1) dismiss if ignore option is set and output is reasoning
-              bool dismiss_reasoning =
-                  (ignore_reasoning && delta.value("reasoning", false));
+              bool dismiss_reasoning = (ignore_reasoning_messages &&
+                                        delta.value("reasoning", false));
               // case 2) wait during content is empty and no tool calls exist
               bool wait_valid_tool_call_output =
                   ((delta.value("content", "") == "") &&
@@ -292,15 +297,16 @@ std::shared_ptr<const module_t> get_language_module() {
             }
 
             // Get reasoning (optional)
-            bool reasoning = false;
-            if (input_map->contains("reasoning"))
-              if (input_map->at("reasoning")->is_type_of<bool_t>())
-                reasoning = *input_map->at<bool_t>("reasoning");
+            bool enable_reasoning = false;
+            if (input_map->contains("enable_reasoning"))
+              if (input_map->at("enable_reasoning")->is_type_of<bool_t>())
+                enable_reasoning = *input_map->at<bool_t>("enable_reasoning");
 
             // Apply chat template on messages
-            auto prompt = component->get_obj("template_engine")
-                              ->as<chat_template_engine_t>()
-                              ->apply_chat_template(messages, tools, reasoning);
+            auto prompt =
+                component->get_obj("template_engine")
+                    ->as<chat_template_engine_t>()
+                    ->apply_chat_template(messages, tools, enable_reasoning);
 
             auto outputs = create<map_t>();
             outputs->insert_or_assign("prompt", create<string_t>(prompt));

--- a/vm/src/mlc_llm/chat_template_engine.cpp
+++ b/vm/src/mlc_llm/chat_template_engine.cpp
@@ -25,7 +25,7 @@ chat_template_engine_t::make_from_config_file(
 
 const std::string chat_template_engine_t::apply_chat_template(
     const nlohmann::json &messages, const nlohmann::json &tools,
-    const bool reasoning, const bool add_generation_prompt) {
+    const bool enable_reasoning, const bool add_generation_prompt) {
   minja::chat_template_inputs inputs;
   inputs.messages = messages;
   if (!tools.is_null())
@@ -33,7 +33,7 @@ const std::string chat_template_engine_t::apply_chat_template(
   inputs.add_generation_prompt = add_generation_prompt;
   // TODO: consider other ways of enable/disable reasoning
   //       & models without reasoning
-  if (!reasoning)
+  if (!enable_reasoning)
     inputs.extra_context = {{"enable_thinking", false}};
   minja::chat_template_options options;
   return template_->apply(inputs, options);

--- a/vm/src/mlc_llm/chat_template_engine.hpp
+++ b/vm/src/mlc_llm/chat_template_engine.hpp
@@ -21,9 +21,11 @@ public:
   static std::shared_ptr<chat_template_engine_t>
   make_from_config_file(std::filesystem::path config_file_path);
 
-  const std::string apply_chat_template(
-      const nlohmann::json &messages, const nlohmann::json &tools = {},
-      const bool reasoning = false, const bool add_generation_prompt = true);
+  const std::string
+  apply_chat_template(const nlohmann::json &messages,
+                      const nlohmann::json &tools = {},
+                      const bool enable_reasoning = false,
+                      const bool add_generation_prompt = true);
 
   bool is_botc_token(const std::string token) { return token == botc_token_; }
 


### PR DESCRIPTION
- `reasoning`, `do_reasoning` -> `enable_reasoning`
- `ignore_reasoning` -> `ignore_reasoning_messages`