### PR TITLE
Deprecated typing

### DIFF
--- a/examples/python/movie_agent.py
+++ b/examples/python/movie_agent.py
@@ -18,7 +18,7 @@ async def main():
 
     agent.add_tools_from_preset("tmdb", authenticator=BearerAuthenticator(tmdb_api_key))
 
-    print('Simple Github assistant (Please type "exit" to stop conversation)')
+    print('Simple movie assistant (Please type "exit" to stop conversation)')
 
     while True:
         query = input("\nUser: ")
@@ -31,6 +31,8 @@ async def main():
 
         for resp in agent.run(query):
             print_agent_response(resp)
+
+    agent.delete()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Some typing classes (like `List`, `Tuple`, etc.) are deprecated and replaced by pre-existing classes from python 3.9.
If we don't need to support python 3.8 or below(these versions are in end-of-life.), we had better not to use those classes.
So this PR just replace those with the existing classes

## Note
`typing.Union[T, U]` and `typing.Optional[T] == typing.Union[T, None]` can be replaced with `T | U` and `T | None` from python 3.10. But we still need to python 3.9 and these are not even deprecated, so those would remains.