### PR TITLE
Pass function as authenticator

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -190,36 +190,32 @@ export interface ToolDefinitionRESTAPI {
 
 export type ToolDefinition = ToolDefinitionUniversal | ToolDefinitionRESTAPI;
 
-export interface ToolAuthenticator {
-  apply: (request: {
-    url: string;
-    headers: { [k: string]: string };
-    [k: string]: any;
-  }) => {
-    url: string;
-    headers: { [k: string]: string };
-    [k: string]: any;
-  };
-}
+export type ToolAuthenticator = (request: {
+  url: string;
+  headers: { [k: string]: string };
+  [k: string]: any;
+}) => {
+  url: string;
+  headers: { [k: string]: string };
+  [k: string]: any;
+};
 
 export function bearerAutenticator(
   token: string,
   bearerFormat: string = "Bearer"
 ): ToolAuthenticator {
-  return {
-    apply: (request: {
-      url: string;
-      headers: { [k: string]: string };
-      [k: string]: any;
-    }) => {
-      return {
-        ...request,
-        headers: {
-          ...request.headers,
-          Authorization: `${bearerFormat} ${token}`,
-        },
-      };
-    },
+  return (request: {
+    url: string;
+    headers: { [k: string]: string };
+    [k: string]: any;
+  }) => {
+    return {
+      ...request,
+      headers: {
+        ...request.headers,
+        Authorization: `${bearerFormat} ${token}`,
+      },
+    };
   };
 }
 
@@ -433,7 +429,7 @@ export class Agent {
           };
 
       // Apply authentication
-      const request = auth ? auth.apply(requestNoAuth) : requestNoAuth;
+      const request = auth ? auth(requestNoAuth) : requestNoAuth;
 
       // Call
       let output: any;

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -573,8 +573,12 @@ class Agent:
                 request["body"] = body
 
             # Apply authentication
-            if authenticator is not None:
+            if hasattr(authenticator, "apply"):
                 request = authenticator.apply(request)
+            elif callable(authenticator):
+                request = authenticator(request)
+            else:
+                pass
 
             # Call HTTP request
             output = None

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -241,6 +241,9 @@ class Tool:
 
 
 class ToolAuthenticator(ABC):
+    def __call__(self, request: dict[str, Any]) -> dict[str, Any]:
+        return self.apply(request)
+
     @abstractmethod
     def apply(self, request: dict[str, Any]) -> dict[str, Any]:
         pass
@@ -519,7 +522,7 @@ class Agent:
     def add_restapi_tool(
         self,
         tool_def: RESTAPIToolDefinition,
-        authenticator: Optional[Union[ToolAuthenticator, Callable[[dict[str, Any]], dict[str, Any]]]] = None,
+        authenticator: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None,
     ) -> bool:
         """
         Adds a REST API tool that performs external HTTP requests.
@@ -573,12 +576,8 @@ class Agent:
                 request["body"] = body
 
             # Apply authentication
-            if hasattr(authenticator, "apply"):
-                request = authenticator.apply(request)
-            elif callable(authenticator):
+            if callable(authenticator):
                 request = authenticator(request)
-            else:
-                pass
 
             # Call HTTP request
             output = None
@@ -593,7 +592,9 @@ class Agent:
 
         return self.add_tool(Tool(desc=tool_def.description, call_fn=call))
 
-    def add_tools_from_preset(self, preset_name: str, authenticator: Optional[ToolAuthenticator] = None):
+    def add_tools_from_preset(
+        self, preset_name: str, authenticator: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None
+    ):
         """
         Loads tools from a predefined JSON preset file.
 

--- a/examples/python/news_agent.py
+++ b/examples/python/news_agent.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+
+from ailoy import Runtime, Agent
+
+from common import print_agent_response
+
+
+async def main():
+    rt = Runtime()
+
+    nytimes_api_key = os.environ.get("NYTIMES_API_KEY", None)
+    if nytimes_api_key is None:
+        nytimes_api_key = input("Enter New York Times API Key: ")
+
+    with Agent(rt, model_name="qwen3-8b") as agent:
+
+        def nytimes_authenticator(request):
+            from urllib.parse import parse_qsl, urlencode, urlparse
+
+            parts = urlparse(request.get("url", ""))
+            qs = {**dict(parse_qsl(parts.query)), "api-key": nytimes_api_key}
+            parts = parts._replace(query=urlencode(qs))
+            return {**request, "url": parts.geturl()}
+
+        agent.add_tools_from_preset(
+            "nytimes",
+            authenticator=nytimes_authenticator,
+        )
+
+        print('Simple news assistant (Please type "exit" to stop conversation)')
+
+        while True:
+            query = input("\nUser: ")
+
+            if query == "exit":
+                break
+
+            if query == "":
+                continue
+
+            for resp in agent.run(query):
+                print_agent_response(resp)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/presets/tools/tmdb.json
+++ b/presets/tools/tmdb.json
@@ -136,7 +136,7 @@
         "type": "restapi",
         "description": {
             "name": "tmdb_movie_watch_providers",
-            "description": "Get the list of streaming providers we have for a movie.",
+            "description": "Get the list of streaming providers we have for a movie in some coutries.",
             "parameters": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Description
During writing the example code for NY Times tool, I realized that there is no handy way to authenticate the REST requests through the query params in python. (in node.js, anonymous class object can cover this.)

So I changed functions to get the proper 'callable' instead of `ToolAuthenticator`. 
I just added `__call__()` into the `ToolAuthenticator` to make it callable, so existing `ToolAuthenticator` is still available.
```python
# Apply authentication
if callable(authenticator):
    request = authenticator(request)
```

To apply this on nodejs, It is just using the function.

Request for comments on this kind of changes on API!