### PR TITLE
Capture sigint while downloading models

### DIFF
--- a/vm/src/mlc_llm/embedding_model.cpp
+++ b/vm/src/mlc_llm/embedding_model.cpp
@@ -235,8 +235,13 @@ create_tvm_embedding_model_component(std::shared_ptr<const value_t> inputs) {
     return outputs;
   };
 
-  auto tvm_embedding_model =
-      create<tvm_embedding_model_t>(model_name, quantization);
+  std::shared_ptr<tvm_embedding_model_t> tvm_embedding_model;
+  try {
+    tvm_embedding_model =
+        create<tvm_embedding_model_t>(model_name, quantization);
+  } catch (const ailoy::runtime_error e) {
+    return ailoy::error_output_t(e.what());
+  }
 
   auto tokenizer = create<tokenizer_t>(tvm_embedding_model->get_model_path() /
                                        "tokenizer.json");

--- a/vm/src/mlc_llm/language_model.cpp
+++ b/vm/src/mlc_llm/language_model.cpp
@@ -103,7 +103,13 @@ create_tvm_language_model_component(std::shared_ptr<const value_t> inputs) {
 #endif
 
   // Get engine
-  auto engine = get_mlc_llm_engine(model, quantization, device, mode);
+  std::shared_ptr<mlc_llm_engine_t> engine;
+  try {
+    engine = get_mlc_llm_engine(model, quantization, device, mode);
+  } catch (const ailoy::runtime_error e) {
+    return error_output_t(e.what());
+  }
+
   if (engine->get_last_error().has_value())
     return error_output_t(engine->get_last_error().value());
 

--- a/vm/src/mlc_llm/mlc_llm_engine.cpp
+++ b/vm/src/mlc_llm/mlc_llm_engine.cpp
@@ -21,14 +21,19 @@ mlc_llm_engine_t::mlc_llm_engine_t(const std::string &model_name,
   auto device_type_str = tvm::runtime::DLDeviceType2Str(device.device_type);
 
   // Download model
-  auto [model_path, model_lib_path] =
+  model_cache_get_result_t get_model_result =
       get_model(model_name, quantization, device_type_str);
-  model_path_ = model_path;
+  if (!get_model_result.success) {
+    throw ailoy::runtime_error(get_model_result.error_message.value());
+  }
+
+  model_path_ = get_model_result.model_path.value();
 
   // Configuration for engine creation
   picojson::object engine_config_json;
-  engine_config_json["model"] = picojson::value(model_path.string());
-  engine_config_json["model_lib"] = picojson::value(model_lib_path.string());
+  engine_config_json["model"] = picojson::value(model_path_.string());
+  engine_config_json["model_lib"] =
+      picojson::value(get_model_result.model_lib_path.value().string());
   engine_config_json["mode"] = picojson::value(mode);
 
   // Create engine

--- a/vm/src/mlc_llm/model_cache.cpp
+++ b/vm/src/mlc_llm/model_cache.cpp
@@ -25,8 +25,6 @@
 #include "exception.hpp"
 #include "thread.hpp"
 
-using namespace std::chrono_literals;
-
 namespace ailoy {
 
 struct utsname {

--- a/vm/src/mlc_llm/model_cache.cpp
+++ b/vm/src/mlc_llm/model_cache.cpp
@@ -1,5 +1,7 @@
 #include "model_cache.hpp"
 
+#include <atomic>
+#include <csignal>
 #include <fstream>
 #include <regex>
 #include <string>
@@ -149,6 +151,31 @@ std::string sha1_checksum(const std::filesystem::path &filepath) {
   return result.str();
 }
 
+class SigintCatcher {
+public:
+  SigintCatcher() {
+    // Save previous handler and install ours
+    previous_handler_ = std::signal(SIGINT, &SigintCatcher::handle_signal);
+    interrupted_.store(false);
+  }
+
+  ~SigintCatcher() {
+    // Restore previous signal handler
+    std::signal(SIGINT, previous_handler_);
+  }
+
+  static bool interrupted() { return interrupted_.load(); }
+
+private:
+  static void handle_signal(int /*signum*/) { interrupted_.store(true); }
+
+  static std::atomic<bool> interrupted_;
+  using SignalHandler = void (*)(int);
+  SignalHandler previous_handler_;
+};
+
+std::atomic<bool> SigintCatcher::interrupted_{false};
+
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -202,14 +229,20 @@ void download_file(httplib::Client &client, const std::string &remote_path,
   ofs.write(res->body.c_str(), res->body.size());
 }
 
-void download_file_with_progress(
+std::pair<bool, std::string> download_file_with_progress(
     httplib::Client &client, const std::string &remote_path,
     const fs::path &local_path,
     std::function<bool(uint64_t, uint64_t)> progress_callback) {
+  SigintCatcher sigint;
+
   size_t existing_size = 0;
   httplib::Result res = client.Get(
       ("/" + remote_path).c_str(),
       [&](const char *data, size_t data_length) {
+        // Exit on SIGINT
+        if (SigintCatcher::interrupted())
+          return false;
+
         std::ofstream ofs(local_path, existing_size > 0
                                           ? std::ios::app | std::ios::binary
                                           : std::ios::binary);
@@ -221,10 +254,18 @@ void download_file_with_progress(
       progress_callback);
   if (!res || (res->status != httplib::OK_200 &&
                res->status != httplib::PartialContent_206)) {
-    throw ailoy::exception(
-        "Failed to download " + remote_path + ": HTTP " +
-        (res ? std::to_string(res->status) : httplib::to_string(res.error())));
+    // If SIGINT interrupted, just return;
+    if (SigintCatcher::interrupted())
+      return std::make_pair<bool, std::string>(
+          false, "Interrupted while downloading the model");
+
+    return std::make_pair<bool, std::string>(
+        false, "Failed to download " + remote_path + ": HTTP " +
+                   (res ? std::to_string(res->status)
+                        : httplib::to_string(res.error())));
   }
+
+  return std::make_pair<bool, std::string>(true, "");
 }
 
 fs::path get_model_base_path(const std::string &model_name,
@@ -246,11 +287,13 @@ void remove_model(const std::string &model_name,
   }
 }
 
-std::tuple<std::filesystem::path, std::filesystem::path>
+model_cache_get_result_t
 get_model(const std::string &model_name, const std::string &quantization,
           const std::string &target_device,
           std::optional<model_cache_callback_t> callback,
           bool print_progress_bar) {
+  model_cache_get_result_t result{.success = false};
+
   auto client = httplib::Client(get_models_url());
   client.set_connection_timeout(10, 0);
   client.set_read_timeout(60, 0);
@@ -276,8 +319,9 @@ get_model(const std::string &model_name, const std::string &quantization,
   // Read and parse manifest.json
   std::ifstream manifest_file(manifest_path);
   if (!manifest_file.is_open()) {
-    throw ailoy::exception("Failed to open manifest.json at " +
-                           manifest_path.string());
+    result.error_message =
+        "Failed to open manifest.json at " + manifest_path.string();
+    return result;
   }
 
   json manifest;
@@ -287,14 +331,17 @@ get_model(const std::string &model_name, const std::string &quantization,
     // Remove manifest.json if it's not a valid format
     manifest_file.close();
     fs::remove(manifest_path);
-    throw ailoy::exception("Failed to parse manifest.json: " +
-                           std::string(e.what()));
+
+    result.error_message =
+        "Failed to parse manifest.json: " + std::string(e.what());
+    return result;
   }
   manifest_file.close();
 
   // Get files from "files" section
   if (!manifest.contains("files") || !manifest["files"].is_array()) {
-    throw ailoy::exception("Manifest is missing a valid 'files' array");
+    result.error_message = "Manifest is missing a valid 'files' array";
+    return result;
   }
 
   std::vector<std::string> files_to_download;
@@ -322,16 +369,23 @@ get_model(const std::string &model_name, const std::string &quantization,
         indicators::option::ShowElapsedTime{true});
     auto bar_idx = bars.push_back(std::move(bar));
 
-    download_file_with_progress(
-        client, (model_base_path / file).string(), local_path,
-        [&](uint64_t current, uint64_t total) {
-          float progress = static_cast<float>(current) / total * 100;
-          if (callback.has_value())
-            callback.value()(i, total_files, file, progress);
-          if (print_progress_bar)
-            bars[bar_idx].set_progress(progress);
-          return true;
-        });
+    auto [download_success, download_error_message] =
+        download_file_with_progress(
+            client, (model_base_path / file).string(), local_path,
+            [&](uint64_t current, uint64_t total) {
+              float progress = static_cast<float>(current) / total * 100;
+              if (callback.has_value())
+                callback.value()(i, total_files, file, progress);
+              if (print_progress_bar)
+                bars[bar_idx].set_progress(progress);
+              return true;
+            });
+
+    if (!download_success) {
+      result.error_message = download_error_message;
+      return result;
+    }
+
     if (print_progress_bar)
       bars[bar_idx].mark_as_completed();
   }
@@ -344,7 +398,10 @@ get_model(const std::string &model_name, const std::string &quantization,
   std::string model_lib_file = manifest["lib"].get<std::string>();
   fs::path model_lib_path = model_cache_path / model_lib_file;
 
-  return std::make_tuple(model_cache_path, model_lib_path);
+  result.success = true;
+  result.model_path = model_cache_path;
+  result.model_lib_path = model_lib_path;
+  return result;
 }
 
 } // namespace ailoy

--- a/vm/src/mlc_llm/model_cache.cpp
+++ b/vm/src/mlc_llm/model_cache.cpp
@@ -23,7 +23,6 @@
 #include <openssl/sha.h>
 
 #include "exception.hpp"
-#include "thread.hpp"
 
 namespace ailoy {
 
@@ -241,7 +240,7 @@ std::pair<bool, std::string> download_file_with_progress(
       ("/" + remote_path).c_str(),
       [&](const char *data, size_t data_length) {
         // Exit on SIGINT
-        if (ailoy::stop_t::global_stop)
+        if (sigint.interrupted())
           return false;
 
         std::ofstream ofs(local_path, existing_size > 0
@@ -256,7 +255,7 @@ std::pair<bool, std::string> download_file_with_progress(
   if (!res || (res->status != httplib::OK_200 &&
                res->status != httplib::PartialContent_206)) {
     // If SIGINT interrupted, just return;
-    if (ailoy::stop_t::global_stop)
+    if (sigint.interrupted())
       return std::make_pair<bool, std::string>(
           false, "Interrupted while downloading the model");
 

--- a/vm/src/mlc_llm/model_cache.cpp
+++ b/vm/src/mlc_llm/model_cache.cpp
@@ -239,7 +239,7 @@ std::pair<bool, std::string> download_file_with_progress(
   httplib::Result res = client.Get(
       ("/" + remote_path).c_str(),
       [&](const char *data, size_t data_length) {
-        // Exit on SIGINT
+        // Stop on SIGINT
         if (sigint.interrupted())
           return false;
 
@@ -254,11 +254,12 @@ std::pair<bool, std::string> download_file_with_progress(
       progress_callback);
   if (!res || (res->status != httplib::OK_200 &&
                res->status != httplib::PartialContent_206)) {
-    // If SIGINT interrupted, just return;
+    // If SIGINT interrupted, return error message about interrupted
     if (sigint.interrupted())
       return std::make_pair<bool, std::string>(
           false, "Interrupted while downloading the model");
 
+    // Otherwise, return error message about HTTP error
     return std::make_pair<bool, std::string>(
         false, "Failed to download " + remote_path + ": HTTP " +
                    (res ? std::to_string(res->status)

--- a/vm/src/mlc_llm/model_cache.hpp
+++ b/vm/src/mlc_llm/model_cache.hpp
@@ -13,17 +13,24 @@ using model_cache_callback_t =
                        const float          // current_file_progress
                        )>;
 
+struct model_cache_get_result_t {
+  bool success;
+  std::optional<std::filesystem::path> model_path = std::nullopt;
+  std::optional<std::filesystem::path> model_lib_path = std::nullopt;
+  std::optional<std::string> error_message = std::nullopt;
+};
+
 /**
  * @brief Get the cache root directory. If the AILOY_CACHE_ROOT environment
  * variable is set, it will be used; otherwise, the default path will be used.
  */
 std::filesystem::path get_cache_root();
 
-std::tuple<std::filesystem::path, std::filesystem::path>
+model_cache_get_result_t
 get_model(const std::string &model_name, const std::string &quantization,
           const std::string &target_device,
           std::optional<model_cache_callback_t> callback = std::nullopt,
-          bool print_progress_bar = false);
+          bool print_progress_bar = true);
 
 void remove_model(const std::string &model_name,
                   const std::string &quantization);


### PR DESCRIPTION
- Added `SigintCatcher` which registers sigint handler and restores it via RAII pattern.
- `download_file_with_progress()` initializes the above `SigintCatcher` at the beginning, and returns the corresponding error message immediately when SIGINT has been detected.
- `get_model` now returns a struct `model_cache_get_result_t` which stores `success` and optional `error_message`. The users of `get_model` (currently including `tvm_model_t` and `mlc_llm_engine_t`) are responsible for handling errors when `success` is false. Components (`tvm_embedding_model` and `tvm_language_model`) may return `error_output_t` if such exception has been catched.
- Added a test case `SigintWhileGetModel` for testing SIGINT situations.
- Decided to show progress bars by default, which looks better for user experiences.

Verified that users can do ctrl+c while downloading models, and this results in `RuntimeError` instead of abort.
```python
>>> rt.define("tvm_language_model", "lm0", {"model": "Qwen/Qwen3-0.6B"})
Downloading params_shard_0.bin [██████▊                                           ] 13% [00m:00s]                                               
^CTraceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    rt.define("tvm_language_model", "lm0", {"model": "Qwen/Qwen3-0.6B"})
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/haejoonkim/Desktop/workspace/BrekkyLab/ailoy/bindings/python/ailoy/runtime.py", line 147, in define
    raise RuntimeError(packet["body"]["reason"])
RuntimeError: Interrupted while downloading the model
```

Note that this was tested on MacOS only, but I believe it works well on Linux too. Not sure for Windows.