### PR TITLE
refactor: rename `universal tool` -> `builtin tool`

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -170,8 +170,8 @@ export interface ToolDescription {
   };
 }
 
-export interface ToolDefinitionBuiltIn {
-  type: "built-in";
+export interface ToolDefinitionBuiltin {
+  type: "builtin";
   description: ToolDescription;
   behavior: {
     outputPath?: string;
@@ -190,7 +190,7 @@ export interface ToolDefinitionRESTAPI {
   };
 }
 
-export type ToolDefinition = ToolDefinitionBuiltIn | ToolDefinitionRESTAPI;
+export type ToolDefinition = ToolDefinitionBuiltin | ToolDefinitionRESTAPI;
 
 export type ToolAuthenticator = (request: {
   url: string;
@@ -343,9 +343,9 @@ export class Agent {
     return this.addTool({ desc, call: f });
   }
 
-  addBuiltInTool(
-    /** The built-in tool definition */
-    tool: ToolDefinitionBuiltIn
+  addBuiltinTool(
+    /** The built in tool definition */
+    tool: ToolDefinitionBuiltin
   ): boolean {
     const call = async (inputs: any) => {
       // Validation
@@ -468,8 +468,8 @@ export class Agent {
       if (tool.type == "restapi") {
         const result = this.addRESTAPITool(tool, args?.authenticator);
         if (!result) return false;
-      } else if (tool.type == "built-in") {
-        const result = this.addBuiltInTool(tool);
+      } else if (tool.type == "builtin") {
+        const result = this.addBuiltinTool(tool);
         if (!result) return false;
       }
     }

--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -170,8 +170,8 @@ export interface ToolDescription {
   };
 }
 
-export interface ToolDefinitionUniversal {
-  type: "universal";
+export interface ToolDefinitionBuiltIn {
+  type: "built-in";
   description: ToolDescription;
   behavior: {
     outputPath?: string;
@@ -190,7 +190,7 @@ export interface ToolDefinitionRESTAPI {
   };
 }
 
-export type ToolDefinition = ToolDefinitionUniversal | ToolDefinitionRESTAPI;
+export type ToolDefinition = ToolDefinitionBuiltIn | ToolDefinitionRESTAPI;
 
 export type ToolAuthenticator = (request: {
   url: string;
@@ -343,9 +343,9 @@ export class Agent {
     return this.addTool({ desc, call: f });
   }
 
-  addUniversalTool(
-    /** The universal tool definition */
-    tool: ToolDefinitionUniversal
+  addBuiltInTool(
+    /** The built-in tool definition */
+    tool: ToolDefinitionBuiltIn
   ): boolean {
     const call = async (inputs: any) => {
       // Validation
@@ -468,8 +468,8 @@ export class Agent {
       if (tool.type == "restapi") {
         const result = this.addRESTAPITool(tool, args?.authenticator);
         if (!result) return false;
-      } else if (tool.type == "universal") {
-        const result = this.addUniversalTool(tool);
+      } else if (tool.type == "built-in") {
+        const result = this.addBuiltInTool(tool);
         if (!result) return false;
       }
     }

--- a/bindings/js-node/src/index.ts
+++ b/bindings/js-node/src/index.ts
@@ -7,7 +7,7 @@ export type {
   AgentResponse,
   ToolAuthenticator,
   ToolDescription,
-  ToolDefinitionUniversal,
+  ToolDefinitionBuiltIn,
   ToolDefinitionRESTAPI,
   ToolDefinition,
 } from "./agent";

--- a/bindings/js-node/src/index.ts
+++ b/bindings/js-node/src/index.ts
@@ -7,7 +7,7 @@ export type {
   AgentResponse,
   ToolAuthenticator,
   ToolDescription,
-  ToolDefinitionBuiltIn,
+  ToolDefinitionBuiltin,
   ToolDefinitionRESTAPI,
   ToolDefinition,
 } from "./agent";

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -7,6 +7,21 @@ describe("Agent", async () => {
     rt = await startRuntime("inproc://");
   });
 
+  it("Tool Call: calculator tools", async () => {
+    const ex = await defineAgent(rt, "qwen3-8b");
+    ex.addToolsFromPreset("calculator");
+
+    const query = "Please calculate this formula: floor(ln(exp(e))+cos(2*pi))";
+    process.stdout.write(`\nQuery: ${query}`);
+
+    process.stdout.write(`\nAssistant: `);
+    for await (const resp of ex.run(query)) {
+      printAgentResponse(resp);
+    }
+
+    await ex.delete();
+  });
+
   it("Tool Call: frankfurter tools", async () => {
     const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
     agent.addToolsFromPreset("frankfurter");

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -225,7 +225,7 @@ AgentResponse = Union[
 
 ## Types and functions related to Tools
 
-ToolDefinition = Union["BuiltInToolDefinition", "RESTAPIToolDefinition"]
+ToolDefinition = Union["BuiltinToolDefinition", "RESTAPIToolDefinition"]
 
 
 class ToolDescription(BaseModel):
@@ -248,13 +248,13 @@ class ToolParametersProperty(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class BuiltInToolDefinition(BaseModel):
-    type: Literal["built-in"]
+class BuiltinToolDefinition(BaseModel):
+    type: Literal["builtin"]
     description: ToolDescription
-    behavior: "BuiltInToolBehavior"
+    behavior: "BuiltinToolBehavior"
 
 
-class BuiltInToolBehavior(BaseModel):
+class BuiltinToolBehavior(BaseModel):
     output_path: Optional[str] = Field(default=None, alias="outputPath")
     model_config = ConfigDict(populate_by_name=True)
 
@@ -546,16 +546,16 @@ class Agent:
         """
         self.add_tool(Tool(desc=ToolDescription.model_validate(desc), call_fn=f))
 
-    def add_built_in_tool(self, tool_def: BuiltInToolDefinition) -> bool:
+    def add_built_in_tool(self, tool_def: BuiltinToolDefinition) -> bool:
         """
-        Adds a built-in tool.
+        Adds a built in tool.
 
-        :param tool_def: The built-in tool definition.
+        :param tool_def: The built in tool definition.
         :returns: True if the tool was successfully added.
-        :raises ValueError: If the tool type is not "built-in" or required inputs are missing.
+        :raises ValueError: If the tool type is not "builtin" or required inputs are missing.
         """
-        if tool_def.type != "built-in":
-            raise ValueError('Tool type is not "built-in"')
+        if tool_def.type != "builtin":
+            raise ValueError('Tool type is not "builtin"')
 
         def call(**inputs: dict[str, Any]) -> Any:
             required = tool_def.description.parameters.required or []
@@ -662,8 +662,8 @@ class Agent:
         data: dict[str, dict[str, Any]] = json.loads(preset_json.read_text())
         for tool_name, tool_def in data.items():
             tool_type = tool_def.get("type", None)
-            if tool_type == "built-in":
-                self.add_built_in_tool(BuiltInToolDefinition.model_validate(tool_def))
+            if tool_type == "builtin":
+                self.add_built_in_tool(BuiltinToolDefinition.model_validate(tool_def))
             elif tool_type == "restapi":
                 self.add_restapi_tool(RESTAPIToolDefinition.model_validate(tool_def), authenticator=authenticator)
             else:

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -546,7 +546,7 @@ class Agent:
         """
         self.add_tool(Tool(desc=ToolDescription.model_validate(desc), call_fn=f))
 
-    def add_built_in_tool(self, tool_def: BuiltinToolDefinition) -> bool:
+    def add_builtin_tool(self, tool_def: BuiltinToolDefinition) -> bool:
         """
         Adds a built in tool.
 
@@ -663,7 +663,7 @@ class Agent:
         for tool_name, tool_def in data.items():
             tool_type = tool_def.get("type", None)
             if tool_type == "builtin":
-                self.add_built_in_tool(BuiltinToolDefinition.model_validate(tool_def))
+                self.add_builtin_tool(BuiltinToolDefinition.model_validate(tool_def))
             elif tool_type == "restapi":
                 self.add_restapi_tool(RESTAPIToolDefinition.model_validate(tool_def), authenticator=authenticator)
             else:

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -225,7 +225,7 @@ AgentResponse = Union[
 
 ## Types and functions related to Tools
 
-ToolDefinition = Union["UniversalToolDefinition", "RESTAPIToolDefinition"]
+ToolDefinition = Union["BuiltInToolDefinition", "RESTAPIToolDefinition"]
 
 
 class ToolDescription(BaseModel):
@@ -248,13 +248,13 @@ class ToolParametersProperty(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class UniversalToolDefinition(BaseModel):
-    type: Literal["universal"]
+class BuiltInToolDefinition(BaseModel):
+    type: Literal["built-in"]
     description: ToolDescription
-    behavior: "UniversalToolBehavior"
+    behavior: "BuiltInToolBehavior"
 
 
-class UniversalToolBehavior(BaseModel):
+class BuiltInToolBehavior(BaseModel):
     output_path: Optional[str] = Field(default=None, alias="outputPath")
     model_config = ConfigDict(populate_by_name=True)
 
@@ -546,16 +546,16 @@ class Agent:
         """
         self.add_tool(Tool(desc=ToolDescription.model_validate(desc), call_fn=f))
 
-    def add_universal_tool(self, tool_def: UniversalToolDefinition) -> bool:
+    def add_built_in_tool(self, tool_def: BuiltInToolDefinition) -> bool:
         """
-        Adds a universal tool.
+        Adds a built-in tool.
 
-        :param tool_def: The universal tool definition.
+        :param tool_def: The built-in tool definition.
         :returns: True if the tool was successfully added.
-        :raises ValueError: If the tool type is not "universal" or required inputs are missing.
+        :raises ValueError: If the tool type is not "built-in" or required inputs are missing.
         """
-        if tool_def.type != "universal":
-            raise ValueError('Tool type is not "universal"')
+        if tool_def.type != "built-in":
+            raise ValueError('Tool type is not "built-in"')
 
         def call(**inputs: dict[str, Any]) -> Any:
             required = tool_def.description.parameters.required or []
@@ -662,8 +662,8 @@ class Agent:
         data: dict[str, dict[str, Any]] = json.loads(preset_json.read_text())
         for tool_name, tool_def in data.items():
             tool_type = tool_def.get("type", None)
-            if tool_type == "universal":
-                self.add_universal_tool(UniversalToolDefinition.model_validate(tool_def))
+            if tool_type == "built-in":
+                self.add_built_in_tool(BuiltInToolDefinition.model_validate(tool_def))
             elif tool_type == "restapi":
                 self.add_restapi_tool(RESTAPIToolDefinition.model_validate(tool_def), authenticator=authenticator)
             else:

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -548,9 +548,9 @@ class Agent:
 
     def add_builtin_tool(self, tool_def: BuiltinToolDefinition) -> bool:
         """
-        Adds a built in tool.
+        Adds a built-in tool.
 
-        :param tool_def: The built in tool definition.
+        :param tool_def: The built-in tool definition.
         :returns: True if the tool was successfully added.
         :raises ValueError: If the tool type is not "builtin" or required inputs are missing.
         """

--- a/docs/docs/concepts/tools.mdx
+++ b/docs/docs/concepts/tools.mdx
@@ -18,7 +18,7 @@ The `description` field defines how the AI understands and uses the tool. It fol
 
 ### Behavior
 
-The `behavior` field defines how the tool actually behaves when invoked. This varies depending on the tool type. For example, a REST API tool includes the endpoint URL, HTTP method, and headers. A native tool may define a Python or Node.js function, while a built-in tool delegates the behavior to a pre-defined module.
+The `behavior` field defines how the tool actually behaves when invoked. This varies depending on the tool type. For example, a REST API tool includes the endpoint URL, HTTP method, and headers. A native tool may define a Python or Node.js function, while a builtin tool delegates the behavior to a pre-defined module.
 
 To see the examples, take a look at the **[Out-of-the-box tools](#out-of-the-box-tools)** section.
 
@@ -103,19 +103,19 @@ agent.addRESTAPITool(
 ```
 </CodeTabs>
 
-### Built-in tools
+### Builtin tools
 
-Built-in tools uses the function of Ailoy’s internal module system. It work across all the environments supported. These tools are pre-registered and can be referenced by name.
+Builtin tools uses the function of Ailoy’s internal module system. It work across all the environments supported. These tools are pre-registered and can be referenced by name.
 
 #### Behavior
 
 Defined by preset behavior implemented inside Ailoy. The only thing defined outside of Ailoy is the JMESPath query string(`outputPath`) to process the raw results of the function into useful data.
 
-***Tool definition*** for a built-in tool looks like:
+***Tool definition*** for a builtin tool looks like:
 
 ```json
 {
-  "type": "built-in",
+  "type": "builtin",
   "description": {...},
   "behavior": {
     "outputPath": "value"
@@ -123,7 +123,7 @@ Defined by preset behavior implemented inside Ailoy. The only thing defined outs
 }
 ```
 
-> *Built-in tools are not designed to be added at runtime.*
+> *Builtin tools are not designed to be added at runtime.*
 
 ### Native tools
 

--- a/docs/docs/concepts/tools.mdx
+++ b/docs/docs/concepts/tools.mdx
@@ -18,7 +18,7 @@ The `description` field defines how the AI understands and uses the tool. It fol
 
 ### Behavior
 
-The `behavior` field defines how the tool actually behaves when invoked. This varies depending on the tool type. For example, a REST API tool includes the endpoint URL, HTTP method, and headers. A native tool may define a Python or Node.js function, while a builtin tool delegates the behavior to a pre-defined module.
+The `behavior` field defines how the tool actually behaves when invoked. This varies depending on the tool type. For example, a REST API tool includes the endpoint URL, HTTP method, and headers. A native tool may define a Python or Node.js function, while a built-in tool delegates the behavior to a pre-defined module.
 
 To see the examples, take a look at the **[Out-of-the-box tools](#out-of-the-box-tools)** section.
 
@@ -103,15 +103,15 @@ agent.addRESTAPITool(
 ```
 </CodeTabs>
 
-### Builtin tools
+### Built-in tools
 
-Builtin tools uses the function of Ailoy’s internal module system. It work across all the environments supported. These tools are pre-registered and can be referenced by name.
+Built-in tools uses the function of Ailoy’s internal module system. It work across all the environments supported. These tools are pre-registered and can be referenced by name.
 
 #### Behavior
 
 Defined by preset behavior implemented inside Ailoy. The only thing defined outside of Ailoy is the JMESPath query string(`outputPath`) to process the raw results of the function into useful data.
 
-***Tool definition*** for a builtin tool looks like:
+***Tool definition*** for a built-in tool looks like:
 
 ```json
 {
@@ -123,7 +123,7 @@ Defined by preset behavior implemented inside Ailoy. The only thing defined outs
 }
 ```
 
-> *Builtin tools are not designed to be added at runtime.*
+> *Built-in tools are not designed to be added at runtime.*
 
 ### Native tools
 

--- a/presets/tools/calculator.json
+++ b/presets/tools/calculator.json
@@ -1,6 +1,6 @@
 {
     "calculator": {
-        "type": "universal",
+        "type": "built-in",
         "description": {
             "name": "calculator",
             "description": "Evaluate the given mathematical expression. It is recommended to be used when there is something to calculate.",

--- a/presets/tools/calculator.json
+++ b/presets/tools/calculator.json
@@ -1,6 +1,6 @@
 {
     "calculator": {
-        "type": "built-in",
+        "type": "builtin",
         "description": {
             "name": "calculator",
             "description": "Evaluate the given mathematical expression. It is recommended to be used when there is something to calculate.",


### PR DESCRIPTION
## Description
As we decided to call the 'universal tool' as 'built-in tool', renaming it.