### PR TITLE
remove global stop

### DIFF
--- a/broker/src/broker.cpp
+++ b/broker/src/broker.cpp
@@ -50,7 +50,6 @@ size_t broker_start(const std::string &url) {
   // Stop signals
   std::shared_ptr<stop_t> stop = std::make_shared<stop_t>();
   stops.insert_or_assign(url, stop);
-  stop_t::global_stop.set_monitor(monitor);
   stop->set_monitor(monitor);
 
   while (true) {

--- a/core/src/thread.cpp
+++ b/core/src/thread.cpp
@@ -33,6 +33,4 @@ void notify_t::set_monitor(std::shared_ptr<monitor_t> monitor) {
   on_monitor_set();
 }
 
-stop_t stop_t::global_stop(true);
-
 } // namespace ailoy


### PR DESCRIPTION
While I'm digging into #21 , I found that the default signal handler is enough to handle this issue.

Just keep default signal handler will stop all thread properly.

So I removed global_stop concepts from the library.

One execption is while downloading something(`recv()` call). `sa_restart` is enabled by default, so It'll automatically retries - hanging.

See: https://www.gnu.org/software/libc/manual/html_node/Flags-for-Sigaction.html

@khj809 