### PR TITLE
Device selection

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -770,6 +770,8 @@ export async function defineAgent(
   args?: {
     /** Optional system message to set the initial assistant context */
     systemMessage?: string;
+    /** Optional device id to set the device id to run LLM model */
+    device?: number;
     /** A parameter for API key usage.
      * This field is ignored if the model does not require authentication. */
     apiKey?: string;
@@ -782,6 +784,7 @@ export async function defineAgent(
 
   // Attribute input for call `rt.define`
   let attrs: Record<string, any> = {};
+  if (args_.device) attrs["device"] = args_.device;
   if (args_.apiKey) attrs["api_key"] = args_.apiKey;
 
   await agent.define(modelName, attrs);

--- a/bindings/js-node/src/vector_store.ts
+++ b/bindings/js-node/src/vector_store.ts
@@ -180,6 +180,7 @@ export async function defineVectorStore(
   modelName: EmbeddingModelName,
   vectorStoreName: VectorStoreName,
   args?: {
+    device?: number;
     url?: string;
     collection?: string;
   }
@@ -190,6 +191,7 @@ export async function defineVectorStore(
 
   // Attribute input for call `rt.define(embedding_model)`
   let embeddingAttrs: Record<string, any> = {};
+  if (args_.device) embeddingAttrs["device"] = args_.device;
 
   // Attribute input for call `rt.define(vector_store)`
   let vectorStoreAttrs: Record<string, any> = {};

--- a/bindings/python/ailoy/vector_store.py
+++ b/bindings/python/ailoy/vector_store.py
@@ -109,16 +109,19 @@ class VectorStore:
             self._runtime.define(
                 "tvm_embedding_model",
                 self._component_state.embedding_model_name,
-                {"model": "BAAI/bge-m3"},
+                {
+                    "model": "BAAI/bge-m3",
+                    **embedding_model_attrs,
+                },
             )
         else:
             raise NotImplementedError(f"Unsupprted embedding model: {embedding_model_name}")
 
         # Initialize vector store
         if vector_store_name == "faiss":
-            if "dimension" not in embedding_model_attrs:
-                embedding_model_attrs["dimension"] = dimension
-            self._runtime.define("faiss_vector_store", self._component_state.vector_store_name, embedding_model_attrs)
+            if "dimension" not in vector_store_attrs:
+                vector_store_attrs["dimension"] = dimension
+            self._runtime.define("faiss_vector_store", self._component_state.vector_store_name, vector_store_attrs)
         elif vector_store_name == "chromadb":
             if "url" not in vector_store_attrs:
                 vector_store_attrs["url"] = url

--- a/vm/src/mlc_llm/embedding_model.hpp
+++ b/vm/src/mlc_llm/embedding_model.hpp
@@ -31,7 +31,7 @@ private:
 class tvm_embedding_model_t : public object_t {
 public:
   tvm_embedding_model_t(const std::string &model_name,
-                        const std::string &quantization);
+                        const std::string &quantization, DLDevice device);
 
   void postprocess_embedding_ndarray(const tvm::runtime::NDArray &from,
                                      tvm::runtime::NDArray &to);
@@ -43,20 +43,6 @@ public:
   }
 
 private:
-  std::shared_ptr<tvm_model_t> prepare_engine(const std::string &model_name,
-                                              const std::string &quantization) {
-    // Parse device
-// @jhlee: TODO implement other environment
-#if defined(USE_METAL)
-    auto device = DLDevice{kDLMetal, 0};
-#elif defined(USE_VULKAN)
-    auto device = DLDevice{kDLVulkan, 0};
-#else
-    auto device = DLDevice{kDLCPU, 0};
-#endif
-    return create<tvm_model_t>(model_name, quantization, device);
-  }
-
   tvm::runtime::PackedFunc fprefill_;
   std::shared_ptr<tvm_model_t> engine_ = nullptr;
 };

--- a/vm/src/mlc_llm/tvm_model.hpp
+++ b/vm/src/mlc_llm/tvm_model.hpp
@@ -1,15 +1,49 @@
 #pragma once
 
+#include <optional>
+
 #include <nlohmann/json.hpp>
+#include <tvm/runtime/device_api.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/relax_vm/ndarray_cache_support.h>
 
+#include "logging.hpp"
 #include "module.hpp"
 #include "value.hpp"
 
 namespace ailoy {
 
 std::shared_ptr<ndarray_t> ndarray_from_tvm(tvm::runtime::NDArray ndarray);
+
+static bool tvm_device_exist(DLDevice device) {
+  tvm::runtime::TVMRetValue rv;
+  tvm::runtime::DeviceAPI::Get(device, true)
+      ->GetAttr(device, tvm::runtime::DeviceAttrKind::kExist, &rv);
+  return rv;
+}
+
+static std::optional<DLDevice> get_tvm_device(int32_t device_id) {
+#if defined(USE_METAL)
+  auto device_type = kDLMetal;
+#elif defined(USE_VULKAN)
+  auto device_type = kDLVulkan;
+#else
+  auto device_type = kDLCPU;
+#endif
+
+  auto device_type_str = tvm::runtime::DLDeviceType2Str(device_type);
+  if (tvm_device_exist(DLDevice{device_type, device_id})) {
+    debug("using device {}:{}", device_type_str, device_id);
+    return DLDevice{device_type, device_id};
+  } else if (tvm_device_exist(DLDevice{device_type, 0})) {
+    info("Device {}:{} doesn't exist, use {}:0 instead.", device_type_str,
+         device_id, device_type_str);
+    return DLDevice{device_type, 0};
+  } else {
+    debug("No {} device is detected.", device_type_str);
+    return std::nullopt;
+  }
+}
 
 class tvm_model_t {
 public:

--- a/vm/tests/test_tvm_embedding_model.cpp
+++ b/vm/tests/test_tvm_embedding_model.cpp
@@ -4,6 +4,14 @@
 #include "mlc_llm/embedding_model.hpp"
 #include "module.hpp"
 
+TEST(EmbeddingModelTest, TestDeviceOne) {
+  auto create_tvm_embedding_model =
+      ailoy::get_language_module()->factories.at("tvm_embedding_model");
+  auto attrs = ailoy::create<ailoy::map_t>();
+  attrs->insert_or_assign("device", ailoy::create<ailoy::int_t>(1));
+  auto embedding_model = std::get<0>(create_tvm_embedding_model(attrs));
+}
+
 TEST(EmbeddingModelTest, TestTokenize) {
   auto create_tvm_embedding_model =
       ailoy::get_language_module()->factories.at("tvm_embedding_model");

--- a/vm/tests/test_tvm_language_model.cpp
+++ b/vm/tests/test_tvm_language_model.cpp
@@ -60,6 +60,17 @@ void print_llm_output(std::shared_ptr<ailoy::map_t> delta,
   print_llm_output(delta);
 }
 
+TEST(LanguageModelTest, TestDeviceOne) {
+  auto in = ailoy::create<ailoy::map_t>();
+  in->insert_or_assign("model",
+                       ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
+  in->insert_or_assign("device", ailoy::create<ailoy::int_t>(1));
+  auto language_model_opt =
+      ailoy::get_language_module()->factories.at("tvm_language_model")(in);
+  ASSERT_EQ(language_model_opt.index(), 0);
+  auto language_model = std::get<0>(language_model_opt);
+}
+
 TEST(LanguageModelTest, TestInfer) {
   std::shared_ptr<ailoy::component_t> language_model;
   {
@@ -92,15 +103,16 @@ TEST(LanguageModelTest, TestInfer) {
 }
 
 TEST(LanguageModelTest, TestMultiTurnChat) {
-  auto create_language_model =
-      ailoy::get_language_module()->factories.at("tvm_language_model");
-  auto attrs = ailoy::create<ailoy::map_t>();
-  attrs->insert_or_assign("model",
-                          ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
-  auto language_model_opt = create_language_model(attrs);
-  ASSERT_EQ(language_model_opt.index(), 0);
-  auto language_model = std::get<0>(language_model_opt);
-
+  std::shared_ptr<ailoy::component_t> language_model;
+  {
+    auto in = ailoy::create<ailoy::map_t>();
+    in->insert_or_assign("model",
+                         ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
+    auto language_model_opt =
+        ailoy::get_language_module()->factories.at("tvm_language_model")(in);
+    ASSERT_EQ(language_model_opt.index(), 0);
+    language_model = std::get<0>(language_model_opt);
+  }
   {
     auto in = ailoy::create<ailoy::map_t>();
     auto messages =
@@ -122,15 +134,16 @@ TEST(LanguageModelTest, TestMultiTurnChat) {
 }
 
 TEST(LanguageModelTest, TestChatReasoning) {
-  auto create_language_model =
-      ailoy::get_language_module()->factories.at("tvm_language_model");
-  auto attrs = ailoy::create<ailoy::map_t>();
-  attrs->insert_or_assign("model",
-                          ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
-  auto language_model_opt = create_language_model(attrs);
-  ASSERT_EQ(language_model_opt.index(), 0);
-  auto language_model = std::get<0>(language_model_opt);
-
+  std::shared_ptr<ailoy::component_t> language_model;
+  {
+    auto in = ailoy::create<ailoy::map_t>();
+    in->insert_or_assign("model",
+                         ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
+    auto language_model_opt =
+        ailoy::get_language_module()->factories.at("tvm_language_model")(in);
+    ASSERT_EQ(language_model_opt.index(), 0);
+    language_model = std::get<0>(language_model_opt);
+  }
   {
     auto in = ailoy::create<ailoy::map_t>();
     auto messages =
@@ -155,15 +168,16 @@ TEST(LanguageModelTest, TestChatReasoning) {
 }
 
 TEST(LanguageModelTest, TestChatReasoningIgnored) {
-  auto create_language_model =
-      ailoy::get_language_module()->factories.at("tvm_language_model");
-  auto attrs = ailoy::create<ailoy::map_t>();
-  attrs->insert_or_assign("model",
-                          ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
-  auto language_model_opt = create_language_model(attrs);
-  ASSERT_EQ(language_model_opt.index(), 0);
-  auto language_model = std::get<0>(language_model_opt);
-
+  std::shared_ptr<ailoy::component_t> language_model;
+  {
+    auto in = ailoy::create<ailoy::map_t>();
+    in->insert_or_assign("model",
+                         ailoy::create<ailoy::string_t>("Qwen/Qwen3-8B"));
+    auto language_model_opt =
+        ailoy::get_language_module()->factories.at("tvm_language_model")(in);
+    ASSERT_EQ(language_model_opt.index(), 0);
+    language_model = std::get<0>(language_model_opt);
+  }
   {
     auto in = ailoy::create<ailoy::map_t>();
     auto messages =


### PR DESCRIPTION
## Ticket
#20 

## Description
Add feature to get device id (as `int_t` or `uint_t` value) as component attribute, then use the device with that device id.
Device type is still set by the target environment, but the device id can be configured.

First, it checks if a device with the given device id exists, and if so, it uses it.
If not, it checks again with id 0, and if so, it uses it(logs this situation with `info` level), otherwise it returns `error_output_t`.

## Changes
- Code for getting the device for embedding models and language models is integrated.
  - `tvm_model_t::prepare_engine()` is removed.
  - `tvm_embedding_model_t` gets device instead of getting it internally.
- Added test to try to get the device with id `1`