### PR TITLE
refactor: use huggingface model id instead of custom id for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Ailoy supports the following operating systems:
 - Linux (x86, with Vulkan)
 
 Currently, the following AI models are supported:
-- qwen3-0.6b (on-device)
-- qwen3-1.7b (on-device)
-- qwen3-4b (on-device)
-- qwen3-8b (on-device)
+- Qwen/Qwen3-0.6B (on-device)
+- Qwen/Qwen3-1.7B (on-device)
+- Qwen/Qwen3-4B (on-device)
+- Qwen/Qwen3-8B (on-device)
 - gpt-4o (API key needed)
 
 ## Getting Started
@@ -30,7 +30,7 @@ import {
 } from "ailoy-js-node";
 
 const rt = await startRuntime();
-const agent = await createAgent(rt, {model: {name: "qwen3-0.6b"}});
+const agent = await createAgent(rt, {model: {name: "Qwen/Qwen3-0.6B"}});
 for await (const resp of agent.query("When is your cut-off date?")) {
   agent.print(resp);
 }
@@ -46,7 +46,7 @@ For more details, refer to `bindings/js-node/README.md`.
 from ailoy import Runtime, Agent
 
 rt = Runtime()
-agent = Agent(rt, model_name="qwen3-8b")
+agent = Agent(rt, model_name="Qwen/Qwen3-8B")
 for resp in agent.query("When is your cut-off date?"):
     resp.print()
 agent.delete()

--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -57,10 +57,10 @@ interface MessageDelta {
 /** Types for LLM Model Definitions */
 
 export type TVMModelName =
-  | "qwen3-8b"
-  | "qwen3-4b"
-  | "qwen3-1.7b"
-  | "qwen3-0.6b";
+  | "Qwen/Qwen3-8B"
+  | "Qwen/Qwen3-4B"
+  | "Qwen/Qwen3-1.7B"
+  | "Qwen/Qwen3-0.6B";
 
 export type OpenAIModelName = "gpt-4o";
 
@@ -73,25 +73,25 @@ interface ModelDescription {
 }
 
 const modelDescriptions: Record<ModelName, ModelDescription> = {
-  "qwen3-8b": {
+  "Qwen/Qwen3-8B": {
     modelId: "Qwen/Qwen3-8B",
     componentType: "tvm_language_model",
     defaultSystemMessage:
       "You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
   },
-  "qwen3-4b": {
+  "Qwen/Qwen3-4B": {
     modelId: "Qwen/Qwen3-4B",
     componentType: "tvm_language_model",
     defaultSystemMessage:
       "You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
   },
-  "qwen3-1.7b": {
+  "Qwen/Qwen3-1.7B": {
     modelId: "Qwen/Qwen3-1.7B",
     componentType: "tvm_language_model",
     defaultSystemMessage:
       "You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
   },
-  "qwen3-0.6b": {
+  "Qwen/Qwen3-0.6B": {
     modelId: "Qwen/Qwen3-0.6B",
     componentType: "tvm_language_model",
     defaultSystemMessage:

--- a/bindings/js-node/src/vector_store.ts
+++ b/bindings/js-node/src/vector_store.ts
@@ -2,7 +2,7 @@ import type { NDArray } from "ailoy_addon.node";
 
 import { Runtime, generateUUID } from "./runtime";
 
-export type EmbeddingModelName = "bge-m3";
+export type EmbeddingModelName = "BAAI/bge-m3";
 
 export type VectorStoreName = "faiss" | "chromadb";
 
@@ -14,7 +14,7 @@ interface EmbeddingModelDescription {
 
 const modelDescriptions: Record<EmbeddingModelName, EmbeddingModelDescription> =
   {
-    "bge-m3": {
+    "BAAI/bge-m3": {
       modelId: "BAAI/bge-m3",
       componentType: "tvm_embedding_model",
       dimension: 1024,

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -8,7 +8,7 @@ describe("Agent", async () => {
   });
 
   it("Tool Call: frankfurter tools", async () => {
-    const agent = await defineAgent(rt, "qwen3-8b");
+    const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
     agent.addToolsFromPreset("frankfurter");
 
     const query =
@@ -23,7 +23,7 @@ describe("Agent", async () => {
   });
 
   it("Tool Call: Custom function tools", async () => {
-    const agent = await defineAgent(rt, "qwen3-8b");
+    const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
     agent.addJSFunctionTool(
       {
         name: "get_current_temperature",
@@ -68,7 +68,7 @@ describe("Agent", async () => {
   });
 
   it("Tool Call: Github MCP tools", async () => {
-    const agent = await defineAgent(rt, "qwen3-8b");
+    const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
     await agent.addToolsFromMcpServer(
       {
         command: "npx",

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -84,7 +84,7 @@ class MessageDelta(BaseModel):
 
 ## Types for LLM Model Definitions
 
-TVMModelName = Literal["qwen3-0.6b", "qwen3-1.7b", "qwen3-4b", "qwen3-8b"]
+TVMModelName = Literal["Qwen/Qwen3-0.6B", "Qwen/Qwen3-1.7B", "Qwen/Qwen3-4B", "Qwen/Qwen3-8B"]
 OpenAIModelName = Literal["gpt-4o"]
 ModelName = Union[TVMModelName, OpenAIModelName]
 
@@ -107,22 +107,22 @@ class ModelDescription(BaseModel):
 
 
 model_descriptions: dict[ModelName, ModelDescription] = {
-    "qwen3-0.6b": ModelDescription(
+    "Qwen/Qwen3-0.6B": ModelDescription(
         model_id="Qwen/Qwen3-0.6B",
         component_type="tvm_language_model",
         default_system_message="You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
     ),
-    "qwen3-1.7b": ModelDescription(
+    "Qwen/Qwen3-1.7B": ModelDescription(
         model_id="Qwen/Qwen3-1.7B",
         component_type="tvm_language_model",
         default_system_message="You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
     ),
-    "qwen3-4b": ModelDescription(
+    "Qwen/Qwen3-4B": ModelDescription(
         model_id="Qwen/Qwen3-4B",
         component_type="tvm_language_model",
         default_system_message="You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",
     ),
-    "qwen3-8b": ModelDescription(
+    "Qwen/Qwen3-8B": ModelDescription(
         model_id="Qwen/Qwen3-8B",
         component_type="tvm_language_model",
         default_system_message="You are Qwen, created by Alibaba Cloud. You are a helpful assistant.",

--- a/bindings/python/ailoy/vector_store.py
+++ b/bindings/python/ailoy/vector_store.py
@@ -42,7 +42,7 @@ class VectorStore:
     def __init__(
         self,
         runtime: Runtime,
-        embedding_model_name: Literal["bge-m3"],
+        embedding_model_name: Literal["BAAI/bge-m3"],
         vector_store_name: Literal["faiss", "chromadb"],
         url: Optional[str] = None,
         collection: Optional[str] = None,
@@ -53,7 +53,7 @@ class VectorStore:
         Creates an instance.
 
         :param runtime: The runtime environment used to manage components.
-        :param embedding_model_name: The name of the embedding model to use. Currently it only supports `bge-m3`.
+        :param embedding_model_name: The name of the embedding model to use. Currently it only supports `BAAI/bge-m3`.
         :param url: (ChromaDB only) URL of the database.
         :param collection: (ChromaDB only) The collection name of the database.
         :param vector_store_name: The name of the vector store provider (One of faiss or chromaDB).
@@ -86,7 +86,7 @@ class VectorStore:
 
     def define(
         self,
-        embedding_model_name: Literal["bge-m3"],
+        embedding_model_name: Literal["BAAI/bge-m3"],
         vector_store_name: Literal["faiss", "chromadb"],
         url: Optional[str] = None,
         collection: Optional[str] = None,
@@ -104,7 +104,7 @@ class VectorStore:
         dimension = 1024
 
         # Initialize embedding model
-        if embedding_model_name == "bge-m3":
+        if embedding_model_name == "BAAI/bge-m3":
             dimension = 1024
             self._runtime.define(
                 "tvm_embedding_model",

--- a/bindings/python/tests/test_0_runtime_sync.py
+++ b/bindings/python/tests/test_0_runtime_sync.py
@@ -27,7 +27,7 @@ def test_spell(runtime: Runtime):
 
 
 def test_vectorstore(runtime: Runtime):
-    with VectorStore(runtime, "bge-m3", "faiss") as vs:
+    with VectorStore(runtime, "BAAI/bge-m3", "faiss") as vs:
         doc1 = "BGE M3 is an embedding model supporting dense retrieval, lexical matching and multi-vector interaction."
         doc2 = "BM25 is a bag-of-words retrieval function that ranks a set of documents based on the query terms appearing in each document"  # noqa: E501
         vs.insert(document=doc1, metadata={"value": "BGE-M3"})

--- a/bindings/python/tests/test_2_agent.py
+++ b/bindings/python/tests/test_2_agent.py
@@ -15,7 +15,7 @@ def runtime():
 
 @pytest.fixture(scope="module")
 def agent(runtime: Runtime):
-    with Agent(runtime, model_name="qwen3-8b") as agent:
+    with Agent(runtime, model_name="Qwen/Qwen3-8B") as agent:
         yield agent
 
 
@@ -110,7 +110,7 @@ def test_simple_rag_pipeline(runtime: Runtime, agent: Agent):
     agent._messages.clear()
     agent._tools.clear()
 
-    with VectorStore(runtime, embedding_model_name="bge-m3", vector_store_name="faiss") as vs:
+    with VectorStore(runtime, embedding_model_name="BAAI/bge-m3", vector_store_name="faiss") as vs:
         vs.insert(
             "Ailoy is a lightweight library for building AI applications — such as **agent systems** or **RAG pipelines** — with ease. It is designed to enable AI features effortlessly, one can just import and use.",  # noqa: E501
         )

--- a/examples/movie_agent_js_node/src/index.ts
+++ b/examples/movie_agent_js_node/src/index.ts
@@ -28,7 +28,7 @@ async function main() {
 
   console.log("Initializing AI...");
 
-  const agent = await defineAgent(rt, "qwen3-8b");
+  const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
   agent.addToolsFromPreset("tmdb", {
     authenticator: bearerAutenticator(tmdbApiKey),
   });

--- a/examples/news_agent_js_node/src/index.ts
+++ b/examples/news_agent_js_node/src/index.ts
@@ -19,7 +19,7 @@ function getUserInput(query: string): Promise<string> {
 async function main() {
   const rt = await startRuntime();
 
-  const agent = await defineAgent(rt, "qwen3-8b");
+  const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
 
   let nytimesApiKey = process.env.NYTIMES_API_KEY;
   if (nytimesApiKey === undefined) {

--- a/examples/python/mcp_github_agent.py
+++ b/examples/python/mcp_github_agent.py
@@ -12,7 +12,7 @@ def main():
     if github_pat is None:
         github_pat = input("Enter GITHUB_PERSONAL_ACCESS_TOKEN: ")
 
-    with Agent(rt, model_name="qwen3-8b") as agent:
+    with Agent(rt, model_name="Qwen/Qwen3-8B") as agent:
         agent.add_tools_from_mcp_server(
             StdioServerParameters(
                 command="npx",

--- a/examples/python/movie_agent.py
+++ b/examples/python/movie_agent.py
@@ -12,7 +12,7 @@ async def main():
     if tmdb_api_key is None:
         tmdb_api_key = input("Enter TMDB API Key: ")
 
-    agent = Agent(rt, model_name="qwen3-8b")
+    agent = Agent(rt, model_name="Qwen/Qwen3-4B")
 
     agent.add_tools_from_preset("tmdb", authenticator=BearerAuthenticator(tmdb_api_key))
 

--- a/examples/python/movie_agent.py
+++ b/examples/python/movie_agent.py
@@ -12,7 +12,7 @@ async def main():
     if tmdb_api_key is None:
         tmdb_api_key = input("Enter TMDB API Key: ")
 
-    agent = Agent(rt, model_name="Qwen/Qwen3-4B")
+    agent = Agent(rt, model_name="Qwen/Qwen3-8B")
 
     agent.add_tools_from_preset("tmdb", authenticator=BearerAuthenticator(tmdb_api_key))
 

--- a/examples/python/news_agent.py
+++ b/examples/python/news_agent.py
@@ -11,7 +11,7 @@ async def main():
     if nytimes_api_key is None:
         nytimes_api_key = input("Enter New York Times API Key: ")
 
-    with Agent(rt, model_name="qwen3-8b") as agent:
+    with Agent(rt, model_name="Qwen/Qwen3-8B") as agent:
 
         def nytimes_authenticator(request):
             from urllib.parse import parse_qsl, urlencode, urlparse

--- a/examples/simple_rag_electron/src/ipc.ts
+++ b/examples/simple_rag_electron/src/ipc.ts
@@ -13,7 +13,11 @@ export const initializeComponents = async (mainWindow: BrowserWindow) => {
   }
 
   if (vectorstore === undefined) {
-    vectorstore = await ailoy.defineVectorStore(runtime, "bge-m3", "faiss");
+    vectorstore = await ailoy.defineVectorStore(
+      runtime,
+      "BAAI/bge-m3",
+      "faiss"
+    );
   }
 
   if (agent === undefined) {
@@ -22,7 +26,7 @@ export const initializeComponents = async (mainWindow: BrowserWindow) => {
       "Loading AI model...",
       false
     );
-    agent = await ailoy.defineAgent(runtime, "qwen3-8b");
+    agent = await ailoy.defineAgent(runtime, "Qwen/Qwen3-8B");
     mainWindow.webContents.send("indicate-loading", "", true);
   }
 };


### PR DESCRIPTION
## Description
Use huggingface model ids for Agent, VectorStore APIs just like Runtime APIs, not to confuse users.