### PR TITLE
fix: set to use UTF-8 on Windows environment

### DIFF
--- a/vm/src/mlc_llm/model_cache.cpp
+++ b/vm/src/mlc_llm/model_cache.cpp
@@ -501,6 +501,10 @@ download_model(const std::string &model_id, const std::string &quantization,
     }
   }
 
+#ifdef _WIN32
+  SetConsoleOutputCP(CP_UTF8);    // to print progress properly on Windows
+#endif
+
   indicators::DynamicProgress<indicators::BlockProgressBar> bars;
   bars.set_option(indicators::option::HideBarWhenComplete{true});
 


### PR DESCRIPTION
## Description
The default 'code page' is not UTF-8 in Windows environment, so the progress bars were shown improperly in Windows consoles.
- Some characters like `■` or `°`  were shown as broken.
- Progress bars are not overwritten, but printed in new lines for every updates.

So we need to set the code page as `CP_UTF8` explicitly in the code.

Special thanks to @chachaAA!

## Preview

### Before (CP_949)
![image](https://github.com/user-attachments/assets/dd0ba4af-51bb-47c3-a48a-ccc76c5630c1)

### After (CP_UTF8)
![Photo_2025-05-27-00-54-39](https://github.com/user-attachments/assets/dfac5c5f-63fe-411c-8e6b-c0129da88e46)
