### PR TITLE
Rename python package: `ailoy` -> `ailoy-py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import {
 ### Python
 
 ```sh
-pip install ailoy
+pip install ailoy-py
 ```
 
 ```python

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,8 +1,32 @@
-# Ailoy Python Runtime
+# ailoy-py
+
+Python binding for Ailoy runtime APIs.
+
+See our [documentation](https://brekkylab.github.io/ailoy) for more details.
 
 ## Install
+
 ```bash
-pip install ailoy
+pip install ailoy-py
+```
+
+## Quickstart
+
+```python
+from ailoy import Runtime, Agent
+
+# The runtime must be started to use Ailoy
+rt = Runtime()
+
+# Defines an agent
+# During this step, the model parameters are downloaded and the LLM is set up for execution
+with Agent(rt, model_name="Qwen/Qwen3-0.6B") as agent:
+    # This is where the actual LLM call happens
+    for resp in agent.query("Please give me a short poem about AI"):
+        agent.print(resp)
+
+# Stop the runtime
+rt.stop()
 ```
 
 ## Building from source
@@ -24,11 +48,6 @@ pip install ailoy
 - BLAS
 - LAPACK
 - Vulkan SDK (if you are using vulkan)
-
-```bash
-cd bindings/js-node
-npm run build
-```
 
 
 ### Setup development environment

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,9 +1,24 @@
 [project]
-name = "ailoy"
+name = "ailoy-py"
 version = "0.0.1"
-description = "Ailoy runtime library"
+description = "Python binding for Ailoy runtime APIs"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
+authors = [
+    {name = "Brekkylab Inc.", email = "contact@brekkylab.com"}
+]
+license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "anyio>=4.9.0",
     "jmespath>=1.0.1",


### PR DESCRIPTION
Currently we're having trouble on uploading our package to PyPI due to the reason explained in https://github.com/pypi/support/issues/6451.
The response from PyPI has been extremely slow, making it unclear when we will be able to use the name `ailoy`. Therefore, it has become inevitable for us to change and use the package name as `ailoy-py` for a while.
