### PR TITLE
Fix(python): `attrs` kwargs not changed on Agent and VectorStore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
-# # Remove 3rdparty libraries from dependencies
-# install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
-
 # Some platform-specific global options
 if(APPLE)
     add_compile_definitions(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(APPLE)
         OUTPUT_VARIABLE MACOS_SDK_PATH
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    set(CMAKE_OSX_SYSROOT ${MACOS_SDK_PATH})
+    set(CMAKE_OSX_SYSROOT "${MACOS_SDK_PATH}")
 endif()
 
 # Some platform-specific global options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 ﻿cmake_minimum_required(VERSION 3.28)
-project(ailoy C CXX)
 
 # Compatibility with CMake < 3.5 has been removed from CMake>=4.0.
 # Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
@@ -7,11 +6,27 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 endif()
 
-include(FetchContent)
-
 # Avoid FetchContent warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-    cmake_policy(SET CMP0135 NEW)
+cmake_policy(SET CMP0135 NEW)
+
+##################
+# Global options #
+##################
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+if(APPLE)
+    # Support OSX>=14.0
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
+
+    # If using Homebrew LLVM, explicitly tell the compiler to use the macOS system SDK.
+    execute_process(
+        COMMAND xcrun --sdk macosx --show-sdk-path
+        OUTPUT_VARIABLE MACOS_SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(CMAKE_OSX_SYSROOT ${MACOS_SDK_PATH})
 endif()
 
 # Some platform-specific global options
@@ -23,17 +38,10 @@ elseif(MSVC)
     add_compile_options(/utf-8)
 endif()
 
-
-##################
-# Global options #
-##################
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 14.4)
-endif()
+#################
+# Project ailoy #
+#################
+project(ailoy C CXX)
 
 set(AILOY_WITH_TEST ON CACHE BOOL "Build test")
 if(DEFINED EMSCRIPTEN)
@@ -50,6 +58,8 @@ set(MLC_LLM_ROOT "" CACHE PATH "Root directory of mlc-llm. If AILOY_WITH_MLC_LLM
 if(AILOY_USE_DUMMY_OPENMP)
     list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/_deps/dummy_openmp/cmake")
 endif()
+
+include(FetchContent)
     
 FetchContent_Declare(magic_enum URL https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.7.tar.gz EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(magic_enum)

--- a/bindings/js-node/README.md
+++ b/bindings/js-node/README.md
@@ -50,7 +50,7 @@ import { startRuntime, defineAgent } from "ailoy-node";
   - LLVM Clang >= 17
   - Apple Clang >= 15
   - MSVC >= 19.29
-- CMake >= 3.24.0
+- CMake >= 3.28.0
 - Git
 - OpenSSL
 - Rust & Cargo >= 1.82.0

--- a/bindings/js-node/package.json
+++ b/bindings/js-node/package.json
@@ -91,5 +91,13 @@
         "chalk": "^5.4.1",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.0"
-    }
+    },
+    "engines": {
+        "node": ">=20 <25"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ]
 }

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -8,18 +8,18 @@ describe("Agent", async () => {
   });
 
   it("Tool Call: calculator tools", async () => {
-    const ex = await defineAgent(rt, "qwen3-8b");
-    ex.addToolsFromPreset("calculator");
+    const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
+    agent.addToolsFromPreset("calculator");
 
     const query = "Please calculate this formula: floor(ln(exp(e))+cos(2*pi))";
     process.stdout.write(`\nQuery: ${query}`);
 
     process.stdout.write(`\nAssistant: `);
-    for await (const resp of ex.run(query)) {
-      printAgentResponse(resp);
+    for await (const resp of agent.query(query)) {
+      agent.print(resp);
     }
 
-    await ex.delete();
+    await agent.delete();
   });
 
   it("Tool Call: frankfurter tools", async () => {

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -10,16 +10,6 @@ if(DEFINED SKBUILD)
     pybind11_add_module(ailoy_py ${AILOY_PY_SRCS})
     target_link_libraries(ailoy_py PUBLIC ailoy_core_obj ailoy_broker_client_obj ailoy_broker_obj ailoy_vm_obj)
 
-    if(APPLE)
-        # If using Homebrew LLVM, explicitly tell the compiler to use the macOS system SDK.
-        execute_process(
-            COMMAND xcrun --sdk macosx --show-sdk-path
-            OUTPUT_VARIABLE MACOS_SDK_PATH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        target_compile_options(ailoy_py PUBLIC -isysroot ${MACOS_SDK_PATH})
-        target_link_options(ailoy_py PUBLIC -isysroot ${MACOS_SDK_PATH})
-    endif()
     if(MSVC)
         target_compile_definitions(ailoy_py PRIVATE NOMINMAX)
     endif()

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -40,7 +40,7 @@ rt.stop()
   - LLVM Clang >= 17
   - Apple Clang >= 15
   - MSVC >= 19.29
-- CMake >= 3.24.0
+- CMake >= 3.28.0
 - Git
 - OpenSSL
 - Rust & Cargo >= 1.82.0

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -337,7 +337,7 @@ class Agent:
         model_name: ModelName,
         system_message: Optional[str] = None,
         api_key: Optional[str] = None,
-        attrs: dict[str, Any] = dict(),
+        **attrs,
     ):
         """
         Create an instance.
@@ -366,7 +366,7 @@ class Agent:
         self._tools: list[Tool] = []
 
         # Define the component
-        self.define(model_name, api_key=api_key, attrs=attrs)
+        self.define(model_name, api_key=api_key, **attrs)
 
     def __del__(self):
         self.delete()
@@ -377,7 +377,7 @@ class Agent:
     def __exit__(self, type, value, traceback):
         self.delete()
 
-    def define(self, model_name: ModelName, api_key: Optional[str] = None, attrs: dict[str, Any] = dict()) -> None:
+    def define(self, model_name: ModelName, api_key: Optional[str] = None, **attrs) -> None:
         """
         Initializes the agent by defining its model in the runtime.
         This must be called before running the agent. If already initialized, this is a no-op.

--- a/bindings/python/ailoy/vector_store.py
+++ b/bindings/python/ailoy/vector_store.py
@@ -46,8 +46,8 @@ class VectorStore:
         vector_store_name: Literal["faiss", "chromadb"],
         url: Optional[str] = None,
         collection: Optional[str] = None,
-        embedding_model_attrs: dict[str, Any] = dict(),
-        vector_store_attrs: dict[str, Any] = dict(),
+        embedding_model_attrs: Optional[dict[str, Any]] = None,
+        vector_store_attrs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an instance.
@@ -69,10 +69,10 @@ class VectorStore:
         self.define(
             embedding_model_name,
             vector_store_name,
-            url,
-            collection,
-            embedding_model_attrs,
-            vector_store_attrs,
+            url=url,
+            collection=collection,
+            embedding_model_attrs=embedding_model_attrs,
+            vector_store_attrs=vector_store_attrs,
         )
 
     def __del__(self):
@@ -90,8 +90,8 @@ class VectorStore:
         vector_store_name: Literal["faiss", "chromadb"],
         url: Optional[str] = None,
         collection: Optional[str] = None,
-        embedding_model_attrs: dict[str, Any] = dict(),
-        vector_store_attrs: dict[str, Any] = dict(),
+        embedding_model_attrs: Optional[dict[str, Any]] = None,
+        vector_store_attrs: Optional[dict[str, Any]] = None,
     ):
         """
         Defines the embedding model and vector store components to the runtime.
@@ -111,13 +111,14 @@ class VectorStore:
                 self._component_state.embedding_model_name,
                 {
                     "model": "BAAI/bge-m3",
-                    **embedding_model_attrs,
+                    **(embedding_model_attrs or {}),
                 },
             )
         else:
             raise NotImplementedError(f"Unsupprted embedding model: {embedding_model_name}")
 
         # Initialize vector store
+        vector_store_attrs = vector_store_attrs or {}
         if vector_store_name == "faiss":
             if "dimension" not in vector_store_attrs:
                 vector_store_attrs["dimension"] = dimension

--- a/examples/simple_rag_electron/README.md
+++ b/examples/simple_rag_electron/README.md
@@ -1,0 +1,15 @@
+# Ailoy Electron RAG Example
+
+This example demonstrates how to quickly build a simple Electron app with Retrieval-Augmented Generation (RAG) using Ailoy’s `Agent` and `VectorStore`.
+
+For more details on RAG, refer to the [documentation](https://brekkylab.github.io/ailoy/docs/tutorial/rag-with-vector-store).
+
+## Quickstart
+
+```bash
+# Install dependencies, including ailoy-node
+npm install
+
+# Start the development server
+npm run start
+```

--- a/examples/simple_rag_electron/README.md
+++ b/examples/simple_rag_electron/README.md
@@ -4,6 +4,8 @@ This example demonstrates how to quickly build a simple Electron app with Retrie
 
 For more details on RAG, refer to the [documentation](https://brekkylab.github.io/ailoy/docs/tutorial/rag-with-vector-store).
 
+https://github.com/user-attachments/assets/c33d24c3-3a9a-4376-9f1c-187fe92f5cd4
+
 ## Quickstart
 
 ```bash

--- a/examples/simple_rag_electron/package-lock.json
+++ b/examples/simple_rag_electron/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ailoy-node": "file:../../bindings/js-node",
+        "ailoy-node": "^0.0.1",
         "electron-squirrel-startup": "^1.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -43,14 +43,24 @@
     "../../bindings/js-node": {
       "name": "ailoy-node",
       "version": "0.0.1",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",
-        "jmespath": "^0.16.0"
+        "boxen": "^8.0.1",
+        "chalk": "^5.4.1",
+        "cli-table3": "^0.6.5",
+        "commander": "^14.0.0",
+        "jmespath": "^0.16.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "bin": {
+        "ailoy": "dist/cli.cjs"
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -64,6 +74,7 @@
         "cmake-js": "^7.3.0",
         "mocha": "^11.2.2",
         "node-addon-api": "^8.3.1",
+        "prebuild": "^13.0.1",
         "rollup": "^4.40.2",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-dts": "^6.2.1",
@@ -71,10 +82,21 @@
         "ts-mocha": "^11.1.0",
         "tslib": "^2.8.1",
         "tsx": "^4.19.3",
+        "typedoc": "^0.28.4",
         "typescript": "^5.6.3"
       },
       "optionalDependencies": {
         "@rollup/rollup-win32-x64-msvc": "^4.40.2"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -968,6 +990,294 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.0.tgz",
+      "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -1451,7 +1761,6 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -1526,12 +1835,47 @@
       }
     },
     "node_modules/ailoy-node": {
-      "resolved": "../../bindings/js-node",
-      "link": true
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ailoy-node/-/ailoy-node-0.0.1.tgz",
+      "integrity": "sha512-r6KvKCJjRaifcKOwgn/W10GvY5QA7p3fERtZ4lHBacPWN4fIqKuWy6aJT9GML+iUKdeKSjmS26El7D7rKXt71A==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.2",
+        "boxen": "^8.0.1",
+        "chalk": "^5.4.1",
+        "cli-table3": "^0.6.5",
+        "commander": "^14.0.0",
+        "jmespath": "^0.16.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "bin": {
+        "ailoy": "dist/cli.cjs"
+      }
+    },
+    "node_modules/ailoy-node/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ailoy-node/node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1542,6 +1886,44 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1571,7 +1953,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1630,7 +2011,6 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-includes": {
@@ -1779,7 +2159,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1809,7 +2188,6 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -1824,7 +2202,6 @@
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -1847,7 +2224,6 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -1855,7 +2231,6 @@
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/boolean": {
@@ -1863,6 +2238,131 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1886,7 +2386,6 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1922,7 +2421,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2037,7 +2535,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2049,7 +2546,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2068,6 +2564,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {
@@ -2143,6 +2651,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
       "dev": true,
@@ -2166,6 +2686,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-truncate": {
@@ -2301,7 +2865,6 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -2312,7 +2875,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2320,7 +2882,6 @@
     },
     "node_modules/cookie": {
       "version": "0.7.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2328,8 +2889,20 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2343,7 +2916,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2431,7 +3003,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2447,7 +3018,6 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -2461,13 +3031,21 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2528,7 +3106,6 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2536,7 +3113,6 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -2545,7 +3121,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.0.3",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2598,7 +3173,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2616,7 +3190,6 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron": {
@@ -3126,7 +3699,6 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3155,7 +3727,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3260,7 +3831,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3268,7 +3838,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3276,7 +3845,6 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3379,7 +3947,6 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3666,7 +4233,6 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3676,6 +4242,27 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "1.0.0",
@@ -3766,6 +4353,15 @@
         "which": "bin/which"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "dev": true,
@@ -3773,7 +4369,6 @@
     },
     "node_modules/express": {
       "version": "4.21.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3816,6 +4411,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
     "node_modules/express-ws": {
       "version": "5.0.2",
       "dev": true,
@@ -3832,7 +4442,6 @@
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3840,7 +4449,6 @@
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -3864,7 +4472,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3895,7 +4502,6 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3967,7 +4573,6 @@
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -3984,7 +4589,6 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3992,7 +4596,6 @@
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -4056,7 +4659,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4064,11 +4666,16 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4113,7 +4720,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4173,6 +4779,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-folder-size": {
       "version": "2.0.1",
       "dev": true,
@@ -4188,7 +4806,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4238,7 +4855,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4277,6 +4893,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4389,7 +5011,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4478,7 +5099,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4503,7 +5123,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4524,7 +5143,6 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -4584,7 +5202,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -4595,7 +5212,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4667,7 +5283,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -4713,7 +5328,6 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -4970,6 +5584,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "dev": true,
@@ -5134,7 +5754,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -5143,6 +5762,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-yaml": {
@@ -5168,7 +5796,6 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5467,7 +6094,6 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5475,7 +6101,6 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5496,7 +6121,6 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5512,7 +6136,6 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5532,7 +6155,6 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -5543,7 +6165,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5551,7 +6172,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5589,7 +6209,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5689,9 +6308,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5711,6 +6335,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -5723,7 +6353,6 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5736,7 +6365,6 @@
     },
     "node_modules/node-abi": {
       "version": "3.74.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5843,9 +6471,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5930,7 +6566,6 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -5941,7 +6576,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6155,7 +6789,6 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6179,7 +6812,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6192,7 +6824,6 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -6243,6 +6874,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/plist": {
@@ -6315,6 +6955,32 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -6358,7 +7024,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -6370,7 +7035,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6379,7 +7043,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6387,7 +7050,6 @@
     },
     "node_modules/qs": {
       "version": "6.13.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -6431,7 +7093,6 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6439,7 +7100,6 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -6449,6 +7109,36 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -6570,7 +7260,6 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6816,6 +7505,31 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -6858,7 +7572,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6908,7 +7621,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -6917,7 +7629,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6934,7 +7645,6 @@
     },
     "node_modules/send": {
       "version": "0.19.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -6957,7 +7667,6 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6965,12 +7674,10 @@
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7005,7 +7712,6 @@
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -7062,12 +7768,10 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7078,7 +7782,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7086,7 +7789,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7104,7 +7806,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7119,7 +7820,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7136,7 +7836,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7156,6 +7855,51 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -7297,7 +8041,6 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7305,7 +8048,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7407,7 +8149,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7529,6 +8270,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "dev": true,
@@ -7616,7 +8391,6 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -7718,6 +8492,18 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -7742,7 +8528,6 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -7888,7 +8673,6 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7896,7 +8680,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7916,12 +8699,10 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -7943,7 +8724,6 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8073,7 +8853,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8166,6 +8945,71 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -8228,7 +9072,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -8370,6 +9213,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.32",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.32.tgz",
+      "integrity": "sha512-OSm2xTIRfW8CV5/QKgngwmQW/8aPfGdaQFlrGoErlgg/Epm7cjb6K6VEyExfe65a3VybUOnu381edLb0dfJl0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/examples/simple_rag_electron/package-lock.json
+++ b/examples/simple_rag_electron/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ailoy-node": "^0.0.1",
         "electron-squirrel-startup": "^1.0.1",
+        "marked-react": "^3.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -6078,6 +6079,30 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/marked-react/-/marked-react-3.0.0.tgz",
+      "integrity": "sha512-We5IPtdfarVIqypy4LmQ3O8xe9Hk8EBNs4MRUYg5077mbD7GJ+rmV9XAPJ0XK8LfQkCOwGv4I7niXWLXWywyoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^15.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || >=17.0.0"
       }
     },
     "node_modules/matcher": {

--- a/examples/simple_rag_electron/package.json
+++ b/examples/simple_rag_electron/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "ailoy-node": "^0.0.1",
     "electron-squirrel-startup": "^1.0.1",
+    "marked-react": "^3.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   }

--- a/examples/simple_rag_electron/package.json
+++ b/examples/simple_rag_electron/package.json
@@ -40,7 +40,7 @@
     "vite-plugin-static-copy": "^2.3.1"
   },
   "dependencies": {
-    "ailoy-node": "file:../../bindings/js-node",
+    "ailoy-node": "^0.0.1",
     "electron-squirrel-startup": "^1.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/examples/simple_rag_electron/src/global.d.ts
+++ b/examples/simple_rag_electron/src/global.d.ts
@@ -5,17 +5,20 @@ import type {
 
 export interface IElectronAPI {
   openFile: () => Promise<string>;
+  updateVectorStore: (document: string) => Promise<void>;
   retrieveSimilarDocuments: (
     query: string
   ) => Promise<Array<VectorStoreRetrieveItem>>;
   inferLanguageModel: (message: string) => Promise<void>;
+
   onIndicateLoading: (
     callback: (indicator: string, finished: boolean) => void
   ) => void;
-  onTextLoadProgress: (
+  onVectorStoreUpdateStarted: (callback: () => void) => void;
+  onVectorStoreUpdateProgress: (
     callback: (loaded: number, total: number) => void
   ) => void;
-  onFileSelected: (callback: () => void) => void;
+  onVectorStoreUpdateFinished: (callback: () => void) => void;
   onAssistantAnswer: (callback: (delta: MessageDelta) => void) => void;
 }
 

--- a/examples/simple_rag_electron/src/ipc.ts
+++ b/examples/simple_rag_electron/src/ipc.ts
@@ -39,39 +39,42 @@ export const registerIpcHandlers = async (mainWindow: BrowserWindow) => {
     });
 
     if (!result.canceled && result.filePaths.length > 0) {
-      mainWindow.webContents.send("file-selected");
-
       const content = await fs.readFile(result.filePaths[0], "utf-8");
-
-      await vectorstore.clear();
-
-      // split texts into chunks
-      const { chunks }: { chunks: Array<string> } = await runtime.call(
-        "split_text",
-        {
-          text: content,
-          chunk_size: 500,
-          chunk_overlap: 200,
-        }
-      );
-
-      let chunkIdx = 0;
-      for (const chunk of chunks) {
-        await vectorstore.insert({
-          document: chunk,
-          metadata: null,
-        });
-        mainWindow.webContents.send(
-          "text-load-progress",
-          chunkIdx + 1,
-          chunks.length
-        );
-        chunkIdx += 1;
-      }
-
       return content;
     }
     return null;
+  });
+
+  ipcMain.handle("update-vector-store", async (event, document: string) => {
+    mainWindow.webContents.send("vector-store-update-started");
+
+    await vectorstore.clear();
+
+    // split texts into chunks
+    const { chunks }: { chunks: Array<string> } = await runtime.call(
+      "split_text",
+      {
+        text: document,
+        chunk_size: 500,
+        chunk_overlap: 200,
+      }
+    );
+
+    let chunkIdx = 0;
+    for (const chunk of chunks) {
+      await vectorstore.insert({
+        document: chunk,
+        metadata: null,
+      });
+      mainWindow.webContents.send(
+        "vector-store-update-progress",
+        chunkIdx + 1,
+        chunks.length
+      );
+      chunkIdx += 1;
+    }
+
+    mainWindow.webContents.send("vector-store-update-finished");
   });
 
   ipcMain.handle("retrieve-similar-documents", async (event, query: string) => {
@@ -88,7 +91,9 @@ export const registerIpcHandlers = async (mainWindow: BrowserWindow) => {
 
 export const removeIpcHandlers = () => {
   ipcMain.removeHandler("open-file");
-  ipcMain.removeHandler("submit-query");
+
+  ipcMain.removeHandler("retrieve-similar-documents");
+  ipcMain.removeHandler("infer-language-model");
 };
 
 export const destroyComponents = async () => {

--- a/examples/simple_rag_electron/src/ipc.ts
+++ b/examples/simple_rag_electron/src/ipc.ts
@@ -91,7 +91,7 @@ export const registerIpcHandlers = async (mainWindow: BrowserWindow) => {
 
 export const removeIpcHandlers = () => {
   ipcMain.removeHandler("open-file");
-
+  ipcMain.removeHandler("update-vector-store");
   ipcMain.removeHandler("retrieve-similar-documents");
   ipcMain.removeHandler("infer-language-model");
 };

--- a/examples/simple_rag_electron/src/ui/app.tsx
+++ b/examples/simple_rag_electron/src/ui/app.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Markdown from "marked-react";
 
 import "./index.css";
 
@@ -130,8 +131,10 @@ Query: ${query}
         </div>
         <div className="w-1/2 p-4 overflow-auto">
           {messages.map((message, index) => (
-            <div key={index} className="mb-2 p-2 border rounded">
-              {message.role}: {message.content}
+            <div key={index} className="mb-2 p-2 border rounded overflow-scroll">
+              <Markdown>
+                {`${message.role}: ${message.content}`}
+              </Markdown>
             </div>
           ))}
         </div>

--- a/examples/simple_rag_electron/src/ui/app.tsx
+++ b/examples/simple_rag_electron/src/ui/app.tsx
@@ -13,6 +13,7 @@ const App: React.FC = () => {
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>("loaded");
   const [loadingIndicator, setLoadingIndicator] = useState<string>("");
   const [textContent, setTextContent] = useState("");
+  const [currentContent, setCurrentContent] = useState("");
   const [query, setQuery] = useState("");
 
   const [messages, setMessages] = useState<Array<Message>>([]);
@@ -24,12 +25,18 @@ const App: React.FC = () => {
       setLoadingIndicator(indicator);
       setLoadingStatus(finished ? "loaded" : "loading");
     });
-    window.electronAPI.onTextLoadProgress((loaded: number, total: number) => {
-      const progress = Math.round((100 * loaded) / total);
-      setLoadingIndicator(`Loading texts to vector store: ${progress}%`);
-    });
-    window.electronAPI.onFileSelected(() => {
+    window.electronAPI.onVectorStoreUpdateStarted(() => {
       setLoadingStatus("loading");
+    });
+    window.electronAPI.onVectorStoreUpdateProgress(
+      (loaded: number, total: number) => {
+        const progress = Math.round((100 * loaded) / total);
+        setLoadingIndicator(`Loading texts to vector store: ${progress}%`);
+      }
+    );
+    window.electronAPI.onVectorStoreUpdateFinished(() => {
+      setLoadingStatus("loaded");
+      setLoadingIndicator("");
     });
     window.electronAPI.onAssistantAnswer((resp: AgentResponse) => {
       if (resp.type === "output_text") {
@@ -47,8 +54,14 @@ const App: React.FC = () => {
 
   const handleFileLoad = async () => {
     const content = await window.electronAPI.openFile();
-    setLoadingStatus("loaded");
-    setTextContent(content);
+    // setLoadingStatus("loaded");
+    setCurrentContent(content);
+  };
+
+  const handleUpdateVectorStore = async () => {
+    if (textContent === currentContent || currentContent === "") return;
+    setTextContent(currentContent);
+    await window.electronAPI.updateVectorStore(currentContent);
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -77,25 +90,42 @@ Query: ${query}
 `;
 
     setIsAnswering(true);
-    window.electronAPI.inferLanguageModel(
-      augmentedPrompt
-    );
+    window.electronAPI.inferLanguageModel(augmentedPrompt);
   };
 
   return (
     <main className="h-screen flex flex-col">
       <div className="flex flex-1 overflow-hidden">
         <div className="w-1/2 p-4 flex flex-col ">
-          <button
-            className="mb-4 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer"
-            onClick={handleFileLoad}
-          >
-            Load Text File
-          </button>
+          <div className="w-full flex space-between gap-2">
+            <button
+              className="w-full mb-4 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer"
+              onClick={handleFileLoad}
+            >
+              Load Text File
+            </button>
+            <button
+              className="mb-4 bg-yellow-400 text-white px-1 py-1 rounded cursor-pointer disabled:opacity-50 disabled:cursor-default"
+              disabled={textContent === currentContent || currentContent === ""}
+              onClick={handleUpdateVectorStore}
+            >
+              <svg
+                width="30px"
+                height="30px"
+                viewBox="0 0 50 50"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M25 38c-7.2 0-13-5.8-13-13 0-3.2 1.2-6.2 3.3-8.6l1.5 1.3C15 19.7 14 22.3 14 25c0 6.1 4.9 11 11 11 1.6 0 3.1-.3 4.6-1l.8 1.8c-1.7.8-3.5 1.2-5.4 1.2z" />
+                <path d="M34.7 33.7l-1.5-1.3c1.8-2 2.8-4.6 2.8-7.3 0-6.1-4.9-11-11-11-1.6 0-3.1.3-4.6 1l-.8-1.8c1.7-.8 3.5-1.2 5.4-1.2 7.2 0 13 5.8 13 13 0 3.1-1.2 6.2-3.3 8.6z" />
+                <path d="M18 24h-2v-6h-6v-2h8z" />
+                <path d="M40 34h-8v-8h2v6h6z" />
+              </svg>
+            </button>
+          </div>
           <textarea
             className="w-full h-full border rounded p-2"
-            value={textContent}
-            readOnly
+            value={currentContent}
+            onChange={(e) => setCurrentContent(e.target.value)}
           />
         </div>
         <div className="w-1/2 p-4 overflow-auto">

--- a/examples/simple_rag_electron/src/ui/app.tsx
+++ b/examples/simple_rag_electron/src/ui/app.tsx
@@ -55,7 +55,6 @@ const App: React.FC = () => {
 
   const handleFileLoad = async () => {
     const content = await window.electronAPI.openFile();
-    // setLoadingStatus("loaded");
     setCurrentContent(content);
   };
 
@@ -98,29 +97,19 @@ Query: ${query}
     <main className="h-screen flex flex-col">
       <div className="flex flex-1 overflow-hidden">
         <div className="w-1/2 p-4 flex flex-col ">
-          <div className="w-full flex space-between gap-2">
+          <div className="w-full flex justify-between gap-2">
             <button
-              className="w-full mb-4 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer"
+              className="mb-4 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer"
               onClick={handleFileLoad}
             >
               Load Text File
             </button>
             <button
-              className="mb-4 bg-yellow-400 text-white px-1 py-1 rounded cursor-pointer disabled:opacity-50 disabled:cursor-default"
+              className="mb-4 bg-yellow-400 px-4 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-default"
               disabled={textContent === currentContent || currentContent === ""}
               onClick={handleUpdateVectorStore}
             >
-              <svg
-                width="30px"
-                height="30px"
-                viewBox="0 0 50 50"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M25 38c-7.2 0-13-5.8-13-13 0-3.2 1.2-6.2 3.3-8.6l1.5 1.3C15 19.7 14 22.3 14 25c0 6.1 4.9 11 11 11 1.6 0 3.1-.3 4.6-1l.8 1.8c-1.7.8-3.5 1.2-5.4 1.2z" />
-                <path d="M34.7 33.7l-1.5-1.3c1.8-2 2.8-4.6 2.8-7.3 0-6.1-4.9-11-11-11-1.6 0-3.1.3-4.6 1l-.8-1.8c1.7-.8 3.5-1.2 5.4-1.2 7.2 0 13 5.8 13 13 0 3.1-1.2 6.2-3.3 8.6z" />
-                <path d="M18 24h-2v-6h-6v-2h8z" />
-                <path d="M40 34h-8v-8h2v6h6z" />
-              </svg>
+              Update Vectorstore
             </button>
           </div>
           <textarea

--- a/examples/simple_rag_electron/vite.main.config.mts
+++ b/examples/simple_rag_electron/vite.main.config.mts
@@ -8,15 +8,11 @@ const targetsToCopy: string[] = [
   "node_modules/ailoy-node/dist/ailoy_addon.node",
 ];
 if (os.platform() === "darwin") {
-  targetsToCopy.push(
-    "node_modules/ailoy-node/dist/libtvm_runtime.dylib",
-    "node_modules/ailoy-node/dist/libomp.dylib"
-  );
+  targetsToCopy.push("node_modules/ailoy-node/dist/*.dylib");
 } else if (os.platform() === "win32") {
-  targetsToCopy.push(
-    "node_modules/ailoy-node/dist/tvm_runtime.dll",
-    "node_modules/ailoy-node/dist/mlc_llm.dll"
-  );
+  targetsToCopy.push("node_modules/ailoy-node/dist/*.dll");
+} else if (os.platform() === "linux") {
+  targetsToCopy.push("node_modules/ailoy-node/dist/*.so");
 }
 
 // https://vitejs.dev/config

--- a/examples/simple_rag_electron/vite.main.config.mts
+++ b/examples/simple_rag_electron/vite.main.config.mts
@@ -7,7 +7,12 @@ process.stdout.write(`Platform: ${os.platform()}`);
 const targetsToCopy: string[] = [
   "node_modules/ailoy-node/dist/ailoy_addon.node",
 ];
-if (os.platform() === "win32") {
+if (os.platform() === "darwin") {
+  targetsToCopy.push(
+    "node_modules/ailoy-node/dist/libtvm_runtime.dylib",
+    "node_modules/ailoy-node/dist/libomp.dylib"
+  );
+} else if (os.platform() === "win32") {
   targetsToCopy.push(
     "node_modules/ailoy-node/dist/tvm_runtime.dll",
     "node_modules/ailoy-node/dist/mlc_llm.dll"

--- a/vm/src/mlc_llm/language_model.cpp
+++ b/vm/src/mlc_llm/language_model.cpp
@@ -116,7 +116,9 @@ create_tvm_language_model_component(std::shared_ptr<const value_t> inputs) {
   // Get engine
   std::shared_ptr<mlc_llm_engine_t> engine;
   try {
-    engine = get_mlc_llm_engine(model, quantization, device, mode);
+    // TODO(@khj809): share parameters when multiple engines are created in
+    // order to reduce memory usages
+    engine = create<mlc_llm_engine_t>(model, quantization, device, mode);
   } catch (const ailoy::runtime_error e) {
     return error_output_t(e.what());
   }

--- a/vm/src/mlc_llm/mlc_llm_engine.cpp
+++ b/vm/src/mlc_llm/mlc_llm_engine.cpp
@@ -12,9 +12,6 @@ using namespace mlc::llm::json_ffi;
 
 namespace ailoy {
 
-static std::unordered_map<std::string, std::shared_ptr<mlc_llm_engine_t>>
-    engines;
-
 mlc_llm_engine_t::mlc_llm_engine_t(const std::string &model_name,
                                    const std::string &quantization,
                                    DLDevice device, const std::string &mode) {
@@ -23,6 +20,8 @@ mlc_llm_engine_t::mlc_llm_engine_t(const std::string &model_name,
   debug("Using device {}:{}", device_type_str, device_.device_id);
 
   // Download model
+  debug("Downloading model: {}, quantization: {}, device: {}", model_name,
+        quantization, device_type_str);
   model_cache_download_result_t download_model_result =
       download_model(model_name, quantization, device_type_str);
   if (!download_model_result.success) {
@@ -351,18 +350,6 @@ mlc_llm_engine_t::get_response_from_stream_output(
     }
   }
   return responses;
-}
-
-std::shared_ptr<mlc_llm_engine_t>
-get_mlc_llm_engine(const std::string &model_name,
-                   const std::string &quantization, DLDevice device,
-                   const std::string &mode) {
-  auto key = model_name + quantization +
-             std::string(tvm::runtime::DLDeviceType2Str(device.device_type));
-  if (engines.find(key) == engines.end())
-    engines.insert_or_assign(
-        key, create<mlc_llm_engine_t>(model_name, quantization, device, mode));
-  return engines.at(key);
 }
 
 } // namespace ailoy

--- a/vm/src/mlc_llm/mlc_llm_engine.hpp
+++ b/vm/src/mlc_llm/mlc_llm_engine.hpp
@@ -84,9 +84,4 @@ private:
   std::optional<std::string> last_error_;
 };
 
-std::shared_ptr<mlc_llm_engine_t>
-get_mlc_llm_engine(const std::string &model_name,
-                   const std::string &quantization, DLDevice device,
-                   const std::string &mode = "interactive");
-
 } // namespace ailoy


### PR DESCRIPTION
Resolves #67 
- Fix the bug that keyword parameters `attrs` does not being changed on next instance initializations (for both `Agent` and `VectorStore`)
- `mlc_llm_engine_t` object is not being freed since its reference count remains in unordered_map `engines`. This unordered_map was initially introduced for reusing parameters and saving memory usages, but we need to find another way to achieve this (left TODO comments).