### PR TITLE
fix: put missed assistant message in `Agent` messages

### DIFF
--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -429,21 +429,6 @@ class Agent:
             self._messages = []
         self._component_state.valid = False
 
-    def _append_assistant_text_message(self, reasoning_message: str, output_text_message: str):
-        # if output_text is empty, do nothing
-        if output_text_message.strip() == "":
-            return
-
-        # construct assistant message content considering reasoning message
-        assistant_message_content = output_text_message.strip()
-        if reasoning_message.strip() != "":
-            assistant_message_content = (
-                f"<think>\n{reasoning_message.strip()}\n</think>\n\n" + assistant_message_content
-            )
-
-        # append constructed message content into messages
-        self._messages.append(AIOutputTextMessage(role="assistant", content=assistant_message_content))
-
     def query(
         self,
         message: str,
@@ -472,13 +457,36 @@ class Agent:
 
             reasoning_message = ""
             output_text_message = ""
+
+            def _append_assistant_text_message():
+                nonlocal reasoning_message
+                nonlocal output_text_message
+
+                # if output_text is empty, do nothing
+                if output_text_message.strip() == "":
+                    return
+
+                # construct assistant message content considering reasoning message
+                assistant_message_content = output_text_message.strip()
+                if (enable_reasoning and not ignore_reasoning_messages) and reasoning_message.strip() != "":
+                    # TODO: consider other kinds of reasoning part distinguisher
+                    assistant_message_content = (
+                        f"<think>\n{reasoning_message.strip()}\n</think>\n\n" + assistant_message_content
+                    )
+
+                # append constructed message content into messages
+                self._messages.append(AIOutputTextMessage(role="assistant", content=assistant_message_content))
+
+                reasoning_message = ""
+                output_text_message = ""
+
             for resp in self._runtime.call_iter_method(self._component_state.name, "infer", infer_args):
                 delta = MessageDelta.model_validate(resp)
 
                 if delta.finish_reason is None:
                     output_msg = AIOutputTextMessage.model_validate(delta.message)
 
-                    # accumulate text messages to push in batch
+                    # accumulate text messages to append in batch
                     if output_msg.reasoning:
                         reasoning_message += output_msg.content
                     else:
@@ -493,9 +501,7 @@ class Agent:
                     continue
 
                 if delta.finish_reason == "tool_calls":
-                    self._append_assistant_text_message(reasoning_message, output_text_message)
-                    reasoning_message = ""
-                    output_text_message = ""
+                    _append_assistant_text_message()
 
                     tool_call_message = AIToolCallMessage.model_validate(delta.message)
                     self._messages.append(tool_call_message)
@@ -544,9 +550,7 @@ class Agent:
 
                     output_text_message += output_msg.content
 
-                    self._append_assistant_text_message(reasoning_message, output_text_message)
-                    reasoning_message = ""
-                    output_text_message = ""
+                    _append_assistant_text_message()
 
                     yield AgentResponseOutputText(
                         type="reasoning" if output_msg.reasoning else "output_text",

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -429,6 +429,21 @@ class Agent:
             self._messages = []
         self._component_state.valid = False
 
+    def _append_assistant_text_message(self, reasoning_message: str, output_text_message: str):
+        # if output_text is empty, do nothing
+        if output_text_message.strip() == "":
+            return
+
+        # construct assistant message content considering reasoning message
+        assistant_message_content = output_text_message.strip()
+        if reasoning_message.strip() != "":
+            assistant_message_content = (
+                f"<think>\n{reasoning_message.strip()}\n</think>\n\n" + assistant_message_content
+            )
+
+        # append constructed message content into messages
+        self._messages.append(AIOutputTextMessage(role="assistant", content=assistant_message_content))
+
     def query(
         self,
         message: str,
@@ -455,11 +470,20 @@ class Agent:
             if ignore_reasoning_messages:
                 infer_args["ignore_reasoning_messages"] = ignore_reasoning_messages
 
+            reasoning_message = ""
+            output_text_message = ""
             for resp in self._runtime.call_iter_method(self._component_state.name, "infer", infer_args):
                 delta = MessageDelta.model_validate(resp)
 
                 if delta.finish_reason is None:
                     output_msg = AIOutputTextMessage.model_validate(delta.message)
+
+                    # accumulate text messages to push in batch
+                    if output_msg.reasoning:
+                        reasoning_message += output_msg.content
+                    else:
+                        output_text_message += output_msg.content
+
                     yield AgentResponseOutputText(
                         type="reasoning" if output_msg.reasoning else "output_text",
                         end_of_turn=False,
@@ -469,6 +493,10 @@ class Agent:
                     continue
 
                 if delta.finish_reason == "tool_calls":
+                    self._append_assistant_text_message(reasoning_message, output_text_message)
+                    reasoning_message = ""
+                    output_text_message = ""
+
                     tool_call_message = AIToolCallMessage.model_validate(delta.message)
                     self._messages.append(tool_call_message)
 
@@ -513,6 +541,13 @@ class Agent:
 
                 if delta.finish_reason in ["stop", "length", "error"]:
                     output_msg = AIOutputTextMessage.model_validate(delta.message)
+
+                    output_text_message += output_msg.content
+
+                    self._append_assistant_text_message(reasoning_message, output_text_message)
+                    reasoning_message = ""
+                    output_text_message = ""
+
                     yield AgentResponseOutputText(
                         type="reasoning" if output_msg.reasoning else "output_text",
                         end_of_turn=True,


### PR DESCRIPTION
## Description
Assistant text messages were unintentionally missing from `messages` within the `Agent`.
Although the previous response of AI is relatively meaningless to AI behavior, the gap in the overall context may have affected AI's final response to some extent.
So, this modification may improve the response performance of AI based on Agent.
Practically, some of the weird responses seem to have improved.