### PR TITLE
Fix: Agent loop behavior on tool calls

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -514,6 +514,7 @@ export class Agent {
           }
         }
       });
+      await client.close();
 
       return parsedContent;
     };
@@ -548,6 +549,7 @@ export class Agent {
         continue;
       await this.addMcpTool(params, tool);
     }
+    await client.close();
   }
 
   getAvailableTools(): Array<ToolDescription> {
@@ -565,6 +567,8 @@ export class Agent {
     }
   ): AsyncGenerator<AgentResponse> {
     this.messages.push({ role: "user", content: message });
+
+    let isToolCalled = false;
 
     while (true) {
       let reasoningMessage = "";
@@ -629,6 +633,7 @@ export class Agent {
 
         // This means AI requested tool calls
         if (delta.finish_reason === "tool_calls") {
+          isToolCalled = true;
           _pushAssistantTextMessage();
 
           const toolCallMessage = delta.message as AIToolCallMessage;
@@ -680,12 +685,9 @@ export class Agent {
               content: toolCallResult,
             };
           }
-          // Infer again with a new request
-          break;
         }
-
         // This means AI finished its answer
-        if (
+        else if (
           delta.finish_reason === "stop" ||
           delta.finish_reason === "length" ||
           delta.finish_reason === "error"
@@ -702,10 +704,20 @@ export class Agent {
             role: "assistant",
             content: message.content,
           };
-          // Finish this AsyncGenerator
-          return;
+
+          // Finish this infer
+          break;
         }
       }
+
+      // Infer again if tool calls happened
+      if (isToolCalled) {
+        isToolCalled = false;
+        continue;
+      }
+
+      // Finish this generator
+      return;
     }
   }
 

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -27,7 +27,7 @@ describe("Agent", async () => {
     agent.addToolsFromPreset("frankfurter");
 
     const query =
-      "I want to buy 100 U.S. Dollar with my Korean Won. How much do I need to take?";
+      "I want to buy 100 U.S. Dollar and 100 EUR with my Korean Won. How much do I need to take?";
     console.log(`Query: ${query}`);
 
     for await (const resp of agent.query(query)) {


### PR DESCRIPTION
Previously, we exited the `infer` loop as soon as tool calls were encountered and their results were evaluated. However, it turns out we should only break the loop when the infer request returns a finish reason of `"stop"`.

This PR addresses the issue by introducing an `is_tool_called` flag and rerunning `infer` if it's set. As a result, the condition for completing the `query` generator has been updated: it now checks not only for a `"stop"` finish reason but also ensures that no tool calls were triggered.

## Additional Fixes
* Added `await client.close()` in the JS Agent's MCP functions to ensure the MCP server process terminates correctly.
