### PR TITLE
Docstring-based `add_py_function_tool()`

### DIFF
--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -16,12 +16,13 @@ from urllib.parse import urlencode, urlparse, urlunparse
 import jmespath
 import mcp
 import mcp.types as mcp_types
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from rich.console import Console
 from rich.panel import Panel
 
 from ailoy.ailoy_py import generate_uuid
 from ailoy.runtime import Runtime
+from ailoy.tools import DocstringParsingException, TypeHintParsingException, get_json_schema
 
 __all__ = ["Agent"]
 
@@ -576,14 +577,27 @@ class Agent:
             return
         self._tools.append(tool)
 
-    def add_py_function_tool(self, desc: dict, f: Callable[..., Any]):
+    def add_py_function_tool(self, f: Callable[..., Any], desc: Optional[dict] = None):
         """
         Adds a Python function as a tool using callable.
 
-        :param desc: Tool descriotion.
         :param f: Function will be called when the tool invocation occured.
+        :param desc: Tool description.
         """
-        self.add_tool(Tool(desc=ToolDescription.model_validate(desc), call_fn=f))
+        tool_description = None
+        if desc is not None:
+            try:
+                tool_description = ToolDescription.model_validate(desc)
+            except ValidationError:
+                pass
+
+        if tool_description is None:
+            try:
+                tool_description = ToolDescription.model_validate(get_json_schema(f).get("function"))
+            except (TypeHintParsingException, DocstringParsingException) as e:
+                ValueError("Failed to parse docstring", e)
+
+        self.add_tool(Tool(desc=tool_description, call_fn=f))
 
     def add_builtin_tool(self, tool_def: BuiltinToolDefinition) -> bool:
         """

--- a/bindings/python/ailoy/tools.py
+++ b/bindings/python/ailoy/tools.py
@@ -1,0 +1,205 @@
+import inspect
+import json
+import re
+import types
+from typing import (
+    Any,
+    Callable,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+description_re = re.compile(r"^(.*?)[\n\s]*(Args:|Returns:|Raises:|\Z)", re.DOTALL)
+# Extracts the Args: block from the docstring
+args_re = re.compile(r"\n\s*Args:\n\s*(.*?)[\n\s]*(Returns:|Raises:|\Z)", re.DOTALL)
+# Splits the Args: block into individual arguments
+args_split_re = re.compile(
+    r"""
+(?:^|\n)  # Match the start of the args block, or a newline
+\s*(\w+):\s*  # Capture the argument name and strip spacing
+(.*?)\s*  # Capture the argument description, which can span multiple lines, and strip trailing spacing
+(?=\n\s*\w+:|\Z)  # Stop when you hit the next argument or the end of the block
+""",
+    re.DOTALL | re.VERBOSE,
+)
+# Extracts the Returns: block from the docstring, if present. Note that most chat templates ignore the return type/doc!
+returns_re = re.compile(r"\n\s*Returns:\n\s*(.*?)[\n\s]*(Raises:|\Z)", re.DOTALL)
+
+
+class TypeHintParsingException(Exception):
+    """Exception raised for errors in parsing type hints to generate JSON schemas"""
+
+    pass
+
+
+class DocstringParsingException(Exception):
+    """Exception raised for errors in parsing docstrings to generate JSON schemas"""
+
+    pass
+
+
+def _get_json_schema_type(param_type: str) -> dict[str, str]:
+    type_mapping = {
+        int: {"type": "integer"},
+        float: {"type": "number"},
+        str: {"type": "string"},
+        bool: {"type": "boolean"},
+        type(None): {"type": "null"},
+        Any: {},
+    }
+    # if is_vision_available():
+    #     type_mapping[Image] = {"type": "image"}
+    # if is_torch_available():
+    #     type_mapping[Tensor] = {"type": "audio"}
+    return type_mapping.get(param_type, {"type": "object"})
+
+
+def _parse_type_hint(hint: str) -> dict:
+    origin = get_origin(hint)
+    args = get_args(hint)
+
+    if origin is None:
+        try:
+            return _get_json_schema_type(hint)
+        except KeyError:
+            raise TypeHintParsingException(
+                "Couldn't parse this type hint, likely due to a custom class or object: ", hint
+            )
+
+    elif origin is Union or (hasattr(types, "UnionType") and origin is types.UnionType):
+        # Recurse into each of the subtypes in the Union, except None, which is handled separately at the end
+        subtypes = [_parse_type_hint(t) for t in args if t is not type(None)]
+        if len(subtypes) == 1:
+            # A single non-null type can be expressed directly
+            return_dict = subtypes[0]
+        elif all(isinstance(subtype["type"], str) for subtype in subtypes):
+            # A union of basic types can be expressed as a list in the schema
+            return_dict = {"type": sorted([subtype["type"] for subtype in subtypes])}
+        else:
+            # A union of more complex types requires "anyOf"
+            return_dict = {"anyOf": subtypes}
+        if type(None) in args:
+            return_dict["nullable"] = True
+        return return_dict
+
+    elif origin is list:
+        if not args:
+            return {"type": "array"}
+        else:
+            # Lists can only have a single type argument, so recurse into it
+            return {"type": "array", "items": _parse_type_hint(args[0])}
+
+    elif origin is tuple:
+        if not args:
+            return {"type": "array"}
+        if len(args) == 1:
+            raise TypeHintParsingException(
+                f"The type hint {str(hint).replace('typing.', '')} is a Tuple with a single element, which "
+                "we do not automatically convert to JSON schema as it is rarely necessary. If this input can contain "
+                "more than one element, we recommend "
+                "using a List[] type instead, or if it really is a single element, remove the Tuple[] wrapper and just "
+                "pass the element directly."
+            )
+        if ... in args:
+            raise TypeHintParsingException(
+                "Conversion of '...' is not supported in Tuple type hints. "
+                "Use List[] types for variable-length"
+                " inputs instead."
+            )
+        return {"type": "array", "prefixItems": [_parse_type_hint(t) for t in args]}
+
+    elif origin is dict:
+        # The JSON equivalent to a dict is 'object', which mandates that all keys are strings
+        # However, we can specify the type of the dict values with "additionalProperties"
+        out = {"type": "object"}
+        if len(args) == 2:
+            out["additionalProperties"] = _parse_type_hint(args[1])
+        return out
+
+    raise TypeHintParsingException("Couldn't parse this type hint, likely due to a custom class or object: ", hint)
+
+
+def _convert_type_hints_to_json_schema(func: Callable) -> dict:
+    type_hints = get_type_hints(func)
+    signature = inspect.signature(func)
+    required = []
+    for param_name, param in signature.parameters.items():
+        if param.annotation == inspect.Parameter.empty:
+            raise TypeHintParsingException(f"Argument {param.name} is missing a type hint in function {func.__name__}")
+        if param.default == inspect.Parameter.empty:
+            required.append(param_name)
+
+    properties = {}
+    for param_name, param_type in type_hints.items():
+        properties[param_name] = _parse_type_hint(param_type)
+
+    schema = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+
+    return schema
+
+
+def parse_google_format_docstring(docstring: str) -> tuple[Optional[str], Optional[dict], Optional[str]]:
+    """
+    Parses a Google-style docstring to extract the function description,
+    argument descriptions, and return description.
+
+    Args:
+        docstring (str): The docstring to parse.
+
+    Returns:
+        The function description, arguments, and return description.
+    """
+
+    # Extract the sections
+    description_match = description_re.search(docstring)
+    args_match = args_re.search(docstring)
+    returns_match = returns_re.search(docstring)
+
+    # Clean and store the sections
+    description = description_match.group(1).strip() if description_match else None
+    docstring_args = args_match.group(1).strip() if args_match else None
+    returns = returns_match.group(1).strip() if returns_match else None
+
+    # Parsing the arguments into a dictionary
+    if docstring_args is not None:
+        docstring_args = "\n".join([line for line in docstring_args.split("\n") if line.strip()])  # Remove blank lines
+        matches = args_split_re.findall(docstring_args)
+        args_dict = {match[0]: re.sub(r"\s*\n+\s*", " ", match[1].strip()) for match in matches}
+    else:
+        args_dict = {}
+
+    return description, args_dict, returns
+
+
+def get_json_schema(func: Callable) -> dict:
+    doc = inspect.getdoc(func)
+    if not doc:
+        raise DocstringParsingException(f"Cannot generate JSON schema for {func.__name__} because it has no docstring!")
+    doc = doc.strip()
+    main_doc, param_descriptions, return_doc = parse_google_format_docstring(doc)
+
+    json_schema = _convert_type_hints_to_json_schema(func)
+    if (return_dict := json_schema["properties"].pop("return", None)) is not None:
+        if return_doc is not None:  # We allow a missing return docstring since most templates ignore it
+            return_dict["description"] = return_doc
+    for arg, schema in json_schema["properties"].items():
+        if arg not in param_descriptions:
+            raise DocstringParsingException(
+                f"Cannot generate JSON schema for {func.__name__} because the docstring has no description for the argument '{arg}'"
+            )
+        desc = param_descriptions[arg]
+        enum_choices = re.search(r"\(choices:\s*(.*?)\)\s*$", desc, flags=re.IGNORECASE)
+        if enum_choices:
+            schema["enum"] = [c.strip() for c in json.loads(enum_choices.group(1))]
+            desc = enum_choices.string[: enum_choices.start()].strip()
+        schema["description"] = desc
+
+    output = {"name": func.__name__, "description": main_doc, "parameters": json_schema}
+    if return_dict is not None:
+        output["return"] = return_dict
+    return {"type": "function", "function": output}

--- a/bindings/python/tests/test_2_agent.py
+++ b/bindings/python/tests/test_2_agent.py
@@ -41,6 +41,15 @@ def test_tool_call_frankfurter(agent: Agent):
 
 def test_tool_call_py_function(agent: Agent):
     def get_current_temperature(location: str, unit: str):
+        """
+        Get the current temperature at a location.
+
+        Args:
+            location: The location to get the temperature for, in the format "City, Country"
+            unit: The unit to return the temperature in. (choices: ["celsius", "fahrenheit"])
+        Returns:
+            The current temperature at the specified location in the specified units, as a float.
+        """
         if unit == "celsius":
             return 25
         elif unit == "fahrenheit":
@@ -49,32 +58,33 @@ def test_tool_call_py_function(agent: Agent):
 
     agent._messages.clear()
     agent._tools.clear()
-    agent.add_py_function_tool(
-        desc={
-            "name": "get_current_temperature",
-            "description": "Get the current temperature at a location.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": 'The location to get the temperature for, in the format "City, Country"',
-                    },
-                    "unit": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The unit to return the temperature in.",
-                    },
-                },
-                "required": ["location", "unit"],
-            },
-            "return": {
-                "type": "number",
-                "description": "The current temperature at the specified location in the specified units, as a float.",
-            },
-        },
-        f=get_current_temperature,
-    )
+    agent.add_py_function_tool(f=get_current_temperature)
+    # agent.add_py_function_tool(
+    #     f=get_current_temperature,
+    #     desc={
+    #         "name": "get_current_temperature",
+    #         "description": "Get the current temperature at a location.",
+    #         "parameters": {
+    #             "type": "object",
+    #             "properties": {
+    #                 "location": {
+    #                     "type": "string",
+    #                     "description": 'The location to get the temperature for, in the format "City, Country"',
+    #                 },
+    #                 "unit": {
+    #                     "type": "string",
+    #                     "enum": ["celsius", "fahrenheit"],
+    #                     "description": "The unit to return the temperature in.",
+    #                 },
+    #             },
+    #             "required": ["location", "unit"],
+    #         },
+    #         "return": {
+    #             "type": "number",
+    #             "description": "The current temperature at the specified location in the specified units, as a float.",
+    #         },
+    #     },
+    # )
     tool_names = set([tool.desc.name for tool in agent._tools])
     assert "get_current_temperature" in tool_names
 

--- a/docs/docs/concepts/tools.mdx
+++ b/docs/docs/concepts/tools.mdx
@@ -151,8 +151,8 @@ def a_useful_function_impl(arg0, arg1):
 
 with Agent(...) as agent:
     agent.add_py_function_tool(
-        desc={...},      # Tool description
         f=a_useful_function_impl,
+        desc={...},      # Tool description
     )
 ```
 


### PR DESCRIPTION
## Ticket
#38

## Description
Add feature to put python callable to the `add_py_function_tool()` without extra tool description JSON document, the function's docstring is parsed into the tool description(JSON Schema format).

Now it only supports google-style docstring just like the transformers.

### A Breaking Change
The parameter order of the `add_py_function_tool()` is changed
from: `def add_py_function_tool(self, desc: dict, f: Callable[..., Any]):`
to: `def add_py_function_tool(self, f: Callable[..., Any], desc: Optional[dict] = None):`
in order to make the tool description optional.

This had better to be merged quickly not to confuse users.
