### PR TITLE
Validate runtime client before using

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -279,7 +279,7 @@ export class Agent {
     // Skip if the component already exists
     if (this.componentState.valid) return;
 
-    if (!this.runtime.alive) throw Error(`Runtime is currently stopped.`);
+    if (!this.runtime.is_alive()) throw Error(`Runtime is currently stopped.`);
 
     const modelDesc = modelDescriptions[modelName];
 
@@ -313,7 +313,7 @@ export class Agent {
     // Skip if the component not exists
     if (!this.componentState.valid) return;
 
-    if (!this.runtime.alive) {
+    if (!this.runtime.is_alive()) {
       const result = await this.runtime.delete(this.componentState.name);
       if (!result) throw Error(`component delete failed`);
     }
@@ -573,7 +573,7 @@ export class Agent {
     if (!this.componentState.valid)
       throw Error(`Agent is not valid. Create one or define newly.`);
 
-    if (!this.runtime.alive) throw Error(`Runtime is currently stopped.`);
+    if (!this.runtime.is_alive()) throw Error(`Runtime is currently stopped.`);
 
     this.messages.push({ role: "user", content: message });
 

--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -279,6 +279,8 @@ export class Agent {
     // Skip if the component already exists
     if (this.componentState.valid) return;
 
+    if (!this.runtime.alive) throw Error(`Runtime is currently stopped.`);
+
     const modelDesc = modelDescriptions[modelName];
 
     // Add model name into attrs
@@ -311,8 +313,10 @@ export class Agent {
     // Skip if the component not exists
     if (!this.componentState.valid) return;
 
-    const result = await this.runtime.delete(this.componentState.name);
-    if (!result) throw Error(`component delete failed`);
+    if (!this.runtime.alive) {
+      const result = await this.runtime.delete(this.componentState.name);
+      if (!result) throw Error(`component delete failed`);
+    }
 
     // Clear messages
     if (this.messages.length > 0 && this.messages[0].role === "system")
@@ -566,6 +570,8 @@ export class Agent {
       ignoreReasoningMessages?: boolean;
     }
   ): AsyncGenerator<AgentResponse> {
+    if (!this.runtime.alive) throw Error(`Runtime is currently stopped.`);
+
     this.messages.push({ role: "user", content: message });
 
     let isToolCalled = false;

--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -570,6 +570,9 @@ export class Agent {
       ignoreReasoningMessages?: boolean;
     }
   ): AsyncGenerator<AgentResponse> {
+    if (!this.componentState.valid)
+      throw Error(`Agent is not valid. Create one or define newly.`);
+
     if (!this.runtime.alive) throw Error(`Runtime is currently stopped.`);
 
     this.messages.push({ role: "user", content: message });

--- a/bindings/js-node/src/runtime.ts
+++ b/bindings/js-node/src/runtime.ts
@@ -44,6 +44,8 @@ export class Runtime {
    */
   private listener: Promise<void> | null;
 
+  alive: boolean = false;
+
   constructor(url: string = "inproc://") {
     this.url = url;
     this.resolvers = new Map();
@@ -62,18 +64,23 @@ export class Runtime {
     return new Promise<void>(async (resolve, reject) => {
       this.registerResolver(txid, resolve, reject);
       while (this.resolvers.has(txid)) await this.listen();
+      this.alive = true;
     });
   }
 
   stop(): Promise<void> {
-    const txid = generateUUID();
-    if (!this.client.send_type1(txid, "disconnect"))
-      throw Error("Disconnection failed");
-    return new Promise<void>(async (resolve, reject) => {
-      this.registerResolver(txid, resolve, reject);
-      while (this.resolvers.has(txid)) await this.listen();
-      stopThreads(this.url);
-    });
+    if (this.alive) {
+      const txid = generateUUID();
+      if (!this.client.send_type1(txid, "disconnect"))
+        throw Error("Disconnection failed");
+      return new Promise<void>(async (resolve, reject) => {
+        this.registerResolver(txid, resolve, reject);
+        while (this.resolvers.has(txid)) await this.listen();
+        stopThreads(this.url);
+        this.alive = false;
+      });
+    }
+    return Promise.resolve();
   }
 
   async call(funcName: string, inputs: any = null): Promise<any> {

--- a/bindings/js-node/src/runtime.ts
+++ b/bindings/js-node/src/runtime.ts
@@ -44,7 +44,7 @@ export class Runtime {
    */
   private listener: Promise<void> | null;
 
-  alive: boolean = false;
+  private alive: boolean = false;
 
   constructor(url: string = "inproc://") {
     this.url = url;
@@ -81,6 +81,10 @@ export class Runtime {
       });
     }
     return Promise.resolve();
+  }
+
+  is_alive(): boolean {
+    return this.alive;
   }
 
   async call(funcName: string, inputs: any = null): Promise<any> {

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -422,7 +422,8 @@ class Agent:
         """
         if not self._component_state.valid:
             return
-        self._runtime.delete(self._component_state.name)
+        if self._runtime._client is not None:
+            self._runtime.delete(self._component_state.name)
         if len(self._messages) > 0 and self._messages[0].role == "system":
             self._messages = [self._messages[0]]
         else:

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -388,8 +388,8 @@ class Agent:
         if self._component_state.valid:
             return
 
-        if self._runtime._client is None:
-            raise ValueError("Runtime is not valid.")
+        if not self._runtime.alive:
+            raise ValueError("Runtime is currently stopped.")
 
         if model_name not in model_descriptions:
             raise ValueError(f"Model `{model_name}` not supported")
@@ -425,7 +425,7 @@ class Agent:
         """
         if not self._component_state.valid:
             return
-        if self._runtime._client is not None:
+        if self._runtime.alive:
             self._runtime.delete(self._component_state.name)
         if len(self._messages) > 0 and self._messages[0].role == "system":
             self._messages = [self._messages[0]]
@@ -447,8 +447,8 @@ class Agent:
         :param ignore_reasoning_messages: If True, reasoning steps are not included in the response stream. (default: False)
         :yield: AgentResponse output of the LLM inference or tool calls
         """  # noqa: E501
-        if self._runtime._client is None:
-            raise ValueError("Runtime is not valid.")
+        if not self._runtime.alive:
+            raise ValueError("Runtime is currently stopped.")
 
         self._messages.append(UserMessage(role="user", content=message))
 

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -447,6 +447,9 @@ class Agent:
         :param ignore_reasoning_messages: If True, reasoning steps are not included in the response stream. (default: False)
         :yield: AgentResponse output of the LLM inference or tool calls
         """  # noqa: E501
+        if not self._component_state.valid:
+            raise ValueError("Agent is not valid. Create one or define newly.")
+
         if not self._runtime.alive:
             raise ValueError("Runtime is currently stopped.")
 

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -388,6 +388,9 @@ class Agent:
         if self._component_state.valid:
             return
 
+        if self._runtime._client is None:
+            raise ValueError("Runtime is not valid.")
+
         if model_name not in model_descriptions:
             raise ValueError(f"Model `{model_name}` not supported")
 
@@ -444,6 +447,9 @@ class Agent:
         :param ignore_reasoning_messages: If True, reasoning steps are not included in the response stream. (default: False)
         :yield: AgentResponse output of the LLM inference or tool calls
         """  # noqa: E501
+        if self._runtime._client is None:
+            raise ValueError("Runtime is not valid.")
+
         self._messages.append(UserMessage(role="user", content=message))
 
         is_tool_called = False

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -388,7 +388,7 @@ class Agent:
         if self._component_state.valid:
             return
 
-        if not self._runtime.alive:
+        if not self._runtime.is_alive():
             raise ValueError("Runtime is currently stopped.")
 
         if model_name not in model_descriptions:
@@ -425,8 +425,10 @@ class Agent:
         """
         if not self._component_state.valid:
             return
-        if self._runtime.alive:
+
+        if self._runtime.is_alive():
             self._runtime.delete(self._component_state.name)
+
         if len(self._messages) > 0 and self._messages[0].role == "system":
             self._messages = [self._messages[0]]
         else:
@@ -450,7 +452,7 @@ class Agent:
         if not self._component_state.valid:
             raise ValueError("Agent is not valid. Create one or define newly.")
 
-        if not self._runtime.alive:
+        if not self._runtime.is_alive():
             raise ValueError("Runtime is currently stopped.")
 
         self._messages.append(UserMessage(role="user", content=message))

--- a/bindings/python/ailoy/runtime.py
+++ b/bindings/python/ailoy/runtime.py
@@ -41,7 +41,7 @@ class RuntimeBase:
         self.stop()
 
     def stop(self):
-        if self._client:
+        if self.alive:
             txid = self._send_type1("disconnect")
             if not txid:
                 raise RuntimeError("Disconnection failed")
@@ -51,6 +51,10 @@ class RuntimeBase:
                 raise RuntimeError("Disconnection failed")
             self._client = None
             stop_threads(self.address)
+
+    @property
+    def alive(self):
+        return self._client is not None
 
     def _send_type1(self, ptype: Literal["connect", "disconnect"]) -> Optional[str]:
         txid = generate_uuid()

--- a/bindings/python/ailoy/runtime.py
+++ b/bindings/python/ailoy/runtime.py
@@ -41,7 +41,7 @@ class RuntimeBase:
         self.stop()
 
     def stop(self):
-        if self.alive:
+        if self.is_alive():
             txid = self._send_type1("disconnect")
             if not txid:
                 raise RuntimeError("Disconnection failed")
@@ -52,8 +52,7 @@ class RuntimeBase:
             self._client = None
             stop_threads(self.address)
 
-    @property
-    def alive(self):
+    def is_alive(self):
         return self._client is not None
 
     def _send_type1(self, ptype: Literal["connect", "disconnect"]) -> Optional[str]:


### PR DESCRIPTION
## Ticket
resolves #63 

## Description
Not only an agent can be deleted after the runtime has stopped when the program terminates, but an agent can also use an invalid runtime anytime in some circumstances. (See the following code.)
So we should raise an error properly when the agent try to use it instead of preventing that situation.


```python
rt = Runtime()
rt.stop()
agent = Agent(rt, ...)  # AttributeError: 'NoneType' object has no attribute 'send_type2'
```

However, in `Agent.delete()`, it could be better to just skip the Runtime task rather than raising errors.