### PR TITLE
Persistent MCP Server Lifecycle Management

### DIFF
--- a/bindings/js-node/src/mcp.ts
+++ b/bindings/js-node/src/mcp.ts
@@ -1,0 +1,84 @@
+import * as MCPClient from "@modelcontextprotocol/sdk/client/index.js";
+import * as MCPClientStdio from "@modelcontextprotocol/sdk/client/stdio.js";
+
+class MCPServer {
+  readonly name: string;
+  #params: MCPClientStdio.StdioServerParameters;
+  #client: MCPClient.Client;
+  #connected: boolean = false;
+
+  constructor(name: string, params: MCPClientStdio.StdioServerParameters) {
+    this.name = name;
+    this.#params = params;
+    this.#client = new MCPClient.Client({
+      name,
+      version: "dummy-version",
+    });
+  }
+
+  async start() {
+    if (this.#connected) return;
+    const transport = new MCPClientStdio.StdioClientTransport(this.#params);
+    await this.#client.connect(transport);
+    this.#connected = true;
+  }
+
+  async cleanup() {
+    if (!this.#connected) return;
+    await this.#client.close();
+    this.#connected = false;
+  }
+
+  async listTools() {
+    if (!this.#connected) {
+      throw Error("MCP server not initialized");
+    }
+
+    const { tools } = await this.#client.listTools();
+    return tools;
+  }
+
+  async callTool(
+    tool: Awaited<ReturnType<MCPClient.Client["listTools"]>>["tools"][number],
+    inputs?: { [x: string]: unknown }
+  ) {
+    try {
+      const result = await this.#client.callTool({
+        name: tool.name,
+        arguments: inputs,
+      });
+      const content = result.content as Array<any>;
+      const parsedContent = content.map((item) => {
+        if (item.type === "text") {
+          // Text Content
+          try {
+            // Try to deserialize as JSON
+            const parsed = JSON.parse(item.text);
+            return JSON.stringify(parsed);
+          } catch (err) {
+            // Return as-is if not deserializable
+            return item.text;
+          }
+        } else if (item.type === "image") {
+          // Image Content
+          return item.data;
+        } else if (item.type === "resource") {
+          // Resource Content
+          if (item.resource.text !== undefined) {
+            // Text Resource
+            return item.resource.text;
+          } else {
+            // Blob Resource
+            return item.resource.blob;
+          }
+        }
+      });
+      return parsedContent;
+    } catch (err) {
+      console.error(`Error executing tool ${tool.name}: ${err}`);
+      throw err;
+    }
+  }
+}
+
+export default MCPServer;

--- a/bindings/js-node/src/mcp.ts
+++ b/bindings/js-node/src/mcp.ts
@@ -1,6 +1,15 @@
 import * as MCPClient from "@modelcontextprotocol/sdk/client/index.js";
 import * as MCPClientStdio from "@modelcontextprotocol/sdk/client/stdio.js";
 
+/**
+ * MCPServer provides a high-level interface for interacting with an MCP stdio server
+ * using the official MCP JavaScript SDK.
+ *
+ * - It manages a single `MCPClient.Client` instance and connects via `StdioClientTransport`.
+ * - The connection lifecycle is handled through the `start()` and `cleanup()` methods.
+ * - Tools can be discovered with `listTools()`, and invoked using `callTool()`.
+ * - Unlike in Python, this class does not use subprocesses; it runs entirely within the calling Node.js process.
+ */
 class MCPServer {
   readonly name: string;
   #params: MCPClientStdio.StdioServerParameters;

--- a/bindings/js-node/tests/agent.spec.ts
+++ b/bindings/js-node/tests/agent.spec.ts
@@ -85,6 +85,7 @@ describe("Agent", async () => {
   it("Tool Call: Github MCP tools", async () => {
     const agent = await defineAgent(rt, "Qwen/Qwen3-8B");
     await agent.addToolsFromMcpServer(
+      "github",
       {
         command: "npx",
         args: ["-y", "@modelcontextprotocol/server-github"],

--- a/bindings/python/ailoy/mcp.py
+++ b/bindings/python/ailoy/mcp.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+import threading
+from concurrent.futures import Future
+from contextlib import AsyncExitStack
+from typing import Any, Coroutine
+
+import mcp.types as mcp_types
+from mcp import ClientSession, StdioServerParameters
+from mcp import Tool as MCPTool
+from mcp.client.stdio import stdio_client
+
+
+class MCPServer:
+    def __init__(self, name: str, params: StdioServerParameters):
+        self.name = name
+        self.params = params
+
+        self._session: ClientSession | None = None
+        self._cleanup_lock: asyncio.Lock = asyncio.Lock()
+        self._exit_stack: AsyncExitStack = AsyncExitStack()
+
+        self._loop = asyncio.new_event_loop()
+        self._queue = asyncio.Queue[tuple[Coroutine, Future]]()
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+
+        self._thread = threading.Thread(target=self._start_loop, daemon=True)
+        self._thread.start()
+        self._ready.wait()
+
+    def _start_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._thread_loop())
+
+    async def _thread_loop(self):
+        try:
+            await self._initialize()
+            self._ready.set()
+
+            while not self._stop.is_set():
+                try:
+                    coro, fut = await asyncio.wait_for(self._queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+
+                try:
+                    result = await coro()
+                    fut.set_result(result)
+                except Exception as e:
+                    fut.set_exception(e)
+
+        finally:
+            await self._cleanup()
+
+    def _run(self, coro):
+        self._ready.wait()
+        fut = Future()
+        self._loop.call_soon_threadsafe(lambda: self._queue.put_nowait((coro, fut)))
+        return fut.result()
+
+    async def _initialize(self):
+        try:
+            stdio_transport = await self._exit_stack.enter_async_context(stdio_client(self.params))
+            read, write = stdio_transport
+            session = await self._exit_stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+            self._session = session
+        except Exception:
+            await self._cleanup()
+            raise
+
+    async def _list_tools(self):
+        if not self._session:
+            raise RuntimeError("MCP server not initialized")
+
+        resp = await self._session.list_tools()
+        return resp.tools
+
+    async def _call_tool(self, tool: MCPTool, arguments: dict[str, Any]):
+        if not self._session:
+            raise RuntimeError("MCP server not initialized")
+
+        try:
+            result = await self._session.call_tool(tool.name, arguments)
+            contents: list[str] = []
+            for item in result.content:
+                if isinstance(item, mcp_types.TextContent):
+                    try:
+                        content = json.loads(item.text)
+                        contents.append(json.dumps(content))
+                    except json.JSONDecodeError:
+                        contents.append(item.text)
+                elif isinstance(item, mcp_types.ImageContent):
+                    contents.append(item.data)
+                elif isinstance(item, mcp_types.EmbeddedResource):
+                    if isinstance(item.resource, mcp_types.TextResourceContents):
+                        contents.append(item.resource.text)
+                    else:
+                        contents.append(item.resource.blob)
+            return contents
+        except Exception as e:
+            print(f"Error executing tool {tool.name}: {e}")
+            raise
+
+    async def _cleanup(self):
+        async with self._cleanup_lock:
+            try:
+                await self._exit_stack.aclose()
+                self._session = None
+            except Exception as e:
+                print(f"Error during cleanup of MCP server {self.name}: {e}")
+
+    def list_tools(self) -> list[MCPTool]:
+        return self._run(lambda: self._list_tools())
+
+    def call_tool(self, tool: MCPTool, arguments: dict[str, Any]) -> list[str]:
+        return self._run(lambda: self._call_tool(tool, arguments))
+
+    def cleanup(self) -> None:
+        self._stop.set()
+        self._thread.join()

--- a/bindings/python/ailoy/mcp.py
+++ b/bindings/python/ailoy/mcp.py
@@ -1,122 +1,153 @@
 import asyncio
 import json
-import threading
-from concurrent.futures import Future
-from contextlib import AsyncExitStack
-from typing import Any, Coroutine
+import multiprocessing
+from multiprocessing.connection import Connection
+from typing import Annotated, Any, Literal, Union
 
 import mcp.types as mcp_types
-from mcp import ClientSession, StdioServerParameters
 from mcp import Tool as MCPTool
-from mcp.client.stdio import stdio_client
+from mcp.client.session import ClientSession
+from mcp.client.stdio import (
+    StdioServerParameters,
+    stdio_client,
+)
+from pydantic import BaseModel, Field, TypeAdapter
+
+
+class ListToolsRequest(BaseModel):
+    type: Literal["list_tools"] = "list_tools"
+
+
+class CallToolRequest(BaseModel):
+    type: Literal["call_tool"] = "call_tool"
+    tool: MCPTool
+    arguments: dict[str, Any]
+
+
+class ShutdownRequest(BaseModel):
+    type: Literal["shutdown"] = "shutdown"
+
+
+# Requests (main -> subprocess)
+RequestMessage = Annotated[Union[ListToolsRequest, CallToolRequest, ShutdownRequest], Field(discriminator="type")]
+
+
+class ResultMessage(BaseModel):
+    type: Literal["result"] = "result"
+    result: Any
+
+
+class ErrorMessage(BaseModel):
+    type: Literal["error"] = "error"
+    error: str
+
+
+# Response (subprocess -> main)
+ResponseMessage = Annotated[Union[ResultMessage, ErrorMessage], Field(discriminator="type")]
 
 
 class MCPServer:
+    """
+    MCPServer manages a subprocess that acts as a bridge between an MCP stdio server and the main process.
+
+    - The subprocess communicates with the MCP stdio server using the `ClientSession` provided by the MCP SDK.
+    - Communication between the main process and the subprocess is handled through a multiprocessing Pipe.
+      Messages sent over this Pipe are serialized and deserialized using structured Pydantic models:
+        - `RequestMessage` for requests from the main process to the subprocess.
+        - `ResponseMessage` for responses from the subprocess to the main process.
+
+    This design ensures:
+    - Type-safe, structured inter-process communication.
+    - Synchronous interaction with an asynchronous MCP session (via message passing).
+    - Subprocess lifecycle control (including initialization and shutdown).
+    """
+
     def __init__(self, name: str, params: StdioServerParameters):
         self.name = name
         self.params = params
 
-        self._session: ClientSession | None = None
-        self._cleanup_lock: asyncio.Lock = asyncio.Lock()
-        self._exit_stack: AsyncExitStack = AsyncExitStack()
+        self._parent_conn, self._child_conn = multiprocessing.Pipe()
+        self._proc = multiprocessing.Process(target=self._run_process, args=(self._child_conn,))
+        self._proc.start()
 
-        self._loop = asyncio.new_event_loop()
-        self._queue = asyncio.Queue[tuple[Coroutine, Future]]()
-        self._ready = threading.Event()
-        self._stop = threading.Event()
+        # Wait for subprocess to signal initialization complete
+        self._recv_response()
 
-        self._thread = threading.Thread(target=self._start_loop, daemon=True)
-        self._thread.start()
-        self._ready.wait()
+    def __del__(self):
+        self.cleanup()
 
-    def _start_loop(self):
-        asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._thread_loop())
+    def _run_process(self, conn: Connection):
+        asyncio.run(self._process_main(conn))
 
-    async def _thread_loop(self):
-        try:
-            await self._initialize()
-            self._ready.set()
-
-            while not self._stop.is_set():
+    async def _process_main(self, conn: Connection):
+        async with stdio_client(self.params) as (read, write):
+            async with ClientSession(read, write) as session:
+                # Notify to main process that the initialization has been finished and ready to receive requests
                 try:
-                    coro, fut = await asyncio.wait_for(self._queue.get(), timeout=0.1)
-                except asyncio.TimeoutError:
-                    continue
-
-                try:
-                    result = await coro()
-                    fut.set_result(result)
+                    await session.initialize()
+                    conn.send(ResultMessage(result=True).model_dump())
                 except Exception as e:
-                    fut.set_exception(e)
+                    conn.send(ErrorMessage(error=f"Failed to initialize MCP subprocess: {e}").model_dump())
 
-        finally:
-            await self._cleanup()
+                while True:
+                    if not conn.poll(0.1):
+                        await asyncio.sleep(0.1)
+                        continue
 
-    def _run(self, coro):
-        self._ready.wait()
-        fut = Future()
-        self._loop.call_soon_threadsafe(lambda: self._queue.put_nowait((coro, fut)))
-        return fut.result()
-
-    async def _initialize(self):
-        try:
-            stdio_transport = await self._exit_stack.enter_async_context(stdio_client(self.params))
-            read, write = stdio_transport
-            session = await self._exit_stack.enter_async_context(ClientSession(read, write))
-            await session.initialize()
-            self._session = session
-        except Exception:
-            await self._cleanup()
-            raise
-
-    async def _list_tools(self):
-        if not self._session:
-            raise RuntimeError("MCP server not initialized")
-
-        resp = await self._session.list_tools()
-        return resp.tools
-
-    async def _call_tool(self, tool: MCPTool, arguments: dict[str, Any]):
-        if not self._session:
-            raise RuntimeError("MCP server not initialized")
-
-        try:
-            result = await self._session.call_tool(tool.name, arguments)
-            contents: list[str] = []
-            for item in result.content:
-                if isinstance(item, mcp_types.TextContent):
                     try:
-                        content = json.loads(item.text)
-                        contents.append(json.dumps(content))
-                    except json.JSONDecodeError:
-                        contents.append(item.text)
-                elif isinstance(item, mcp_types.ImageContent):
-                    contents.append(item.data)
-                elif isinstance(item, mcp_types.EmbeddedResource):
-                    if isinstance(item.resource, mcp_types.TextResourceContents):
-                        contents.append(item.resource.text)
-                    else:
-                        contents.append(item.resource.blob)
-            return contents
-        except Exception as e:
-            print(f"Error executing tool {tool.name}: {e}")
-            raise
+                        raw = conn.recv()
+                        req = TypeAdapter(RequestMessage).validate_python(raw)
 
-    async def _cleanup(self):
-        async with self._cleanup_lock:
-            try:
-                await self._exit_stack.aclose()
-                self._session = None
-            except Exception as e:
-                print(f"Error during cleanup of MCP server {self.name}: {e}")
+                        if isinstance(req, ListToolsRequest):
+                            result = await session.list_tools()
+                            conn.send(ResultMessage(result=result.tools).model_dump())
+
+                        elif isinstance(req, CallToolRequest):
+                            result = await session.call_tool(req.tool.name, req.arguments)
+                            contents: list[str] = []
+                            for item in result.content:
+                                if isinstance(item, mcp_types.TextContent):
+                                    try:
+                                        content = json.loads(item.text)
+                                        contents.append(json.dumps(content))
+                                    except json.JSONDecodeError:
+                                        contents.append(item.text)
+                                elif isinstance(item, mcp_types.ImageContent):
+                                    contents.append(item.data)
+                                elif isinstance(item, mcp_types.EmbeddedResource):
+                                    if isinstance(item.resource, mcp_types.TextResourceContents):
+                                        contents.append(item.resource.text)
+                                    else:
+                                        contents.append(item.resource.blob)
+                            conn.send(ResultMessage(result=contents).model_dump())
+
+                        elif isinstance(req, ShutdownRequest):
+                            break
+
+                    except Exception as e:
+                        conn.send(ErrorMessage(error=str(e)).model_dump())
+
+    def _send_request(self, msg: RequestMessage):
+        self._parent_conn.send(msg.model_dump())
+
+    def _recv_response(self) -> ResultMessage:
+        raw = self._parent_conn.recv()
+        msg = TypeAdapter(ResponseMessage).validate_python(raw)
+        if isinstance(msg, ErrorMessage):
+            raise RuntimeError(msg.error)
+        return msg
 
     def list_tools(self) -> list[MCPTool]:
-        return self._run(lambda: self._list_tools())
+        self._send_request(ListToolsRequest())
+        msg = self._recv_response()
+        return [MCPTool.model_validate(tool) for tool in msg.result]
 
     def call_tool(self, tool: MCPTool, arguments: dict[str, Any]) -> list[str]:
-        return self._run(lambda: self._call_tool(tool, arguments))
+        self._send_request(CallToolRequest(tool=tool, arguments=arguments))
+        msg = self._recv_response()
+        return msg.result
 
     def cleanup(self) -> None:
-        self._stop.set()
-        self._thread.join()
+        if self._proc.is_alive():
+            self._send_request(ShutdownRequest())
+            self._proc.join()

--- a/bindings/python/ailoy/mcp.py
+++ b/bindings/python/ailoy/mcp.py
@@ -50,7 +50,7 @@ class MCPServer:
     """
     MCPServer manages a subprocess that acts as a bridge between an MCP stdio server and the main process.
 
-    - The subprocess communicates with the MCP stdio server using the `ClientSession` provided by the MCP SDK.
+    - The subprocess communicates with the MCP stdio server using the official MCP Python SDK.
     - Communication between the main process and the subprocess is handled through a multiprocessing Pipe.
       Messages sent over this Pipe are serialized and deserialized using structured Pydantic models:
         - `RequestMessage` for requests from the main process to the subprocess.

--- a/bindings/python/tests/test_2_agent.py
+++ b/bindings/python/tests/test_2_agent.py
@@ -71,6 +71,7 @@ def test_mcp_tools_github(agent: Agent):
     agent._messages.clear()
     agent._tools.clear()
     agent.add_tools_from_mcp_server(
+        "github",
         mcp.StdioServerParameters(
             command="npx",
             args=["-y", "@modelcontextprotocol/server-github"],
@@ -81,8 +82,8 @@ def test_mcp_tools_github(agent: Agent):
         ],
     )
     tool_names = set([tool.desc.name for tool in agent._tools])
-    assert "search_repositories" in tool_names
-    assert "get_file_contents" in tool_names
+    assert "github/search_repositories" in tool_names
+    assert "github/get_file_contents" in tool_names
 
     # query = "Summarize README.md from repository brekkylab/ailoy."
     query = "Briefly explain about the repository brekkylab/ailoy."

--- a/examples/mcp_github_agent_py/mcp_github_agent.py
+++ b/examples/mcp_github_agent_py/mcp_github_agent.py
@@ -14,6 +14,7 @@ def main():
 
     with Agent(rt, model_name="Qwen/Qwen3-8B") as agent:
         agent.add_tools_from_mcp_server(
+            "github",
             StdioServerParameters(
                 command="npx",
                 args=["-y", "@modelcontextprotocol/server-github"],


### PR DESCRIPTION
Previously, MCP servers were launched and terminated on-demand each time the agent attempted to list or call tools. This PR introduces a persistent lifecycle for MCP servers, ensuring they remain active until explicitly removed or when the agent itself is deleted.

### Changes:

* **Python**

  * `MCPServer` now spawns a **dedicated subprocess** that acts as a bridge between the main process and the MCP stdio server.
  * Initially it was implemented in `threading`-based approach, but it was unreliable in certain environments (e.g., `pytest`).
  * Communication between processes is handled via `multiprocessing.Pipe` using structured, type-safe Pydantic messages (`RequestMessage` and `ResponseMessage`).
  * The `stdio_client` async context is maintained throughout the subprocess lifecycle and is properly cleaned up via `cleanup()`.

* **JavaScript**

  * `MCPServer` internally manages a single `Client` instance and maintains the connection using `StdioClientTransport`.
  * The connection persists until `cleanup()` is explicitly called, preventing repeated startup overhead.

* **Agent APIs**

  * Each MCP server instance is now given a **unique `name`**, which is used as a prefix for its tools.
  * The `Agent.add_tools_from_mcp_server()` method is still used as before, with the addition of a required `name` argument.
  * Agents can now cleanly remove tools from an MCP server using `remove_mcp_server()`.