### PR TITLE
Fix Rich Console output for Jupyter streaming by forcing ANSI terminal mode

### DIFF
--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -141,7 +141,11 @@ class ComponentState(BaseModel):
 
 ## Types for agent's responses
 
-_console = Console(highlight=False)
+_console = Console(
+    highlight=False,
+    force_jupyter=False,
+    force_terminal=True
+)
 
 
 class AgentResponseBase(BaseModel):


### PR DESCRIPTION
This PR updates the _consol initialization in agent.py to use force_jupyter=False and force_terminal=True for the Rich.Console.
This change disables the Rich HTML renderer in Jupyter and forces ANSI output, which resolves issues with broken or inconsistent streaming output when running in Jupyter notebooks.

Motivation
* Fixes garbled or unexpected LLM streaming output in Jupyter environments.
* Ensures consistent console rendering across both terminal and Jupyter.
