### PR TITLE
fix: add options to disable polyfills

### DIFF
--- a/vm/src/chat_manager.cpp
+++ b/vm/src/chat_manager.cpp
@@ -45,6 +45,10 @@ chat_manager_t::apply_chat_template(std::shared_ptr<const value_t> conversation,
   if (!enable_reasoning)
     inputs.extra_context = {{"enable_thinking", false}};
   minja::chat_template_options options;
+  // TODO: remove after minja issue fixed
+  options.polyfill_tools = false;
+  options.polyfill_tool_calls = false;
+  options.polyfill_tool_responses = false;
   return template_->apply(inputs, options);
 }
 


### PR DESCRIPTION
## Description
Due to an issue of current version of minja, the tool calls and tool responses are rendered through polyfills even though the Qwen3 chat template is capable to cover those.

After merging https://github.com/google/minja/pull/72, the template could be estimated properly(not to use polyfills) and using unnecessary polyfills can cause inconsistant behavior and performance of language models. so currently we's better to disable those polyfills before it is merged.


## Related PR
https://github.com/google/minja/pull/72
