### PR TITLE
Fix linux node build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # Compiled Dynamic libraries
 *.so
+*.so.[0-9]*
 *.dylib
 *.dll
 

--- a/bindings/js-node/CMakeLists.txt
+++ b/bindings/js-node/CMakeLists.txt
@@ -15,6 +15,11 @@ if (DEFINED NODE)
   find_package(OpenSSL REQUIRED)
   target_link_libraries(ailoy_addon PUBLIC ailoy_core_obj ailoy_broker_client_obj ailoy_broker_obj ailoy_vm_obj OpenSSL::Crypto OpenSSL::SSL ${CMAKE_JS_LIB})
 
+  # On Linux, do not expose static libstdc++ symbols globally
+  if(UNIX AND NOT APPLE)
+    target_link_options(ailoy_addon PRIVATE -Wl,--exclude-libs,ALL)
+  endif()
+
   if(MSVC AND CMAKE_JS_NODELIB_DEF AND CMAKE_JS_NODELIB_TARGET)
     execute_process(COMMAND ${CMAKE_AR} /def:${CMAKE_JS_NODELIB_DEF} /out:${CMAKE_JS_NODELIB_TARGET} ${CMAKE_STATIC_LINKER_FLAGS})
   endif()

--- a/bindings/js-node/build.js
+++ b/bindings/js-node/build.js
@@ -61,7 +61,8 @@ function listDir(dir) {
       buildDir,
       "--CDNODE:BOOL=ON",
       "--CDAILOY_WITH_TEST:BOOL=OFF",
-      `--parallel ${require("os").cpus().length}`,
+      "--parallel",
+      `${require("os").cpus().length}`,
     ];
     await runCommand("npx", buildArgs, { cwd: __dirname });
 


### PR DESCRIPTION
This PR fixes the Node.js build error on Linux due to the link with `libstdc++-nonshared.a`, by adding `--exclude-libs` link option. See the below ChatGPT answer for the detailed explanation.

---

## ❓ What does `-Wl,--exclude-libs,ALL` mean?
This linker flag tells `ld` (the GNU linker) to **exclude all symbols** from **all static libraries** from being exported to the final shared object (in your case, `ailoy_addon.node`).

More precisely, it tells the linker:

> “When you copy object files from a static `.a` archive into this shared object, don't make the symbols in those object files globally visible — treat them as local/internal only.”

## 🧨 What problem were you facing?
You saw errors like:
```cpp
undefined reference to `std::_Sp_counted_ptr<decltype(nullptr), (__gnu_cxx::_Lock_policy)2>::_M_dispose()'
```
This symbol is part of **libstdc++** and especially relevant when using `std::shared_ptr` and C++17 filesystem. The error pointed to `libstdc++_nonshared.a`, which is a *special static archive* provided by GCC to patch certain ABI-specific behaviors **without fully linking in the shared libstdc++.so**.

But here's the catch:

You statically linked other `.a` libraries (like `libssl.a`, `libcrypto.a`, `libfaiss.a`, etc.).

Those `.a` files, especially `libstdc++_nonshared.a`, were being linked *statically* into your `.node` shared library.

The result: your `.node` file **exported some libstdc++ internals**, causing symbol mismatches or undefined references at link time or load time.

## ✅ Why `--exclude-libs,ALL` fixes it
By adding `--exclude-libs,ALL`, you're telling the linker:

> “Even though I’m linking static `.a` libraries, don’t expose their symbols globally. Keep them local to this `.so`.”

This **prevents collisions or unresolved references** that happen when the dynamic linker (`ld.so`) sees multiple conflicting definitions across shared objects.

## 🔄 Without `--exclude-libs`
Without it, the linker **exports internal symbols from `.a` archives**, which pollutes the global symbol table of your `.node` file. When Node.js (or another `.so`) loads, the dynamic linker gets confused or mismatches symbols — especially in libstdc++ which is sensitive to compiler versions and ABI.