### PR TITLE
Fix tool name prefix for MCP tools

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -512,7 +512,7 @@ export class Agent {
         continue;
 
       const desc: ToolDescription = {
-        name: `${name}/${tool.name}`,
+        name: `${name}-${tool.name}`,
         description: tool.description || "",
         parameters: tool.inputSchema as ToolDescription["parameters"],
       };
@@ -538,7 +538,7 @@ export class Agent {
     this.mcpServers.splice(idx, 1);
 
     // Remove tools registered from the MCP server
-    this.tools = this.tools.filter((t) => !t.desc.name.startsWith(`${name}/`));
+    this.tools = this.tools.filter((t) => !t.desc.name.startsWith(`${name}-`));
   }
 
   getAvailableTools(): Array<ToolDescription> {

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -779,7 +779,7 @@ class Agent:
                 continue
 
             desc = ToolDescription(
-                name=f"{name}/{tool.name}", description=tool.description, parameters=tool.inputSchema
+                name=f"{name}-{tool.name}", description=tool.description, parameters=tool.inputSchema
             )
 
             def call(tool: MCPTool, **inputs: dict[str, Any]) -> list[str]:
@@ -803,4 +803,4 @@ class Agent:
         mcp_server.cleanup()
 
         # Remove tools registered from the MCP server
-        self._tools = list(filter(lambda t: not t.desc.name.startswith(f"{mcp_server.name}/"), self._tools))
+        self._tools = list(filter(lambda t: not t.desc.name.startswith(f"{mcp_server.name}-"), self._tools))


### PR DESCRIPTION
OpenAI accepts tool names with pattern `^[a-zA-Z0-9_-]+$` only. If violated, it returns the following error.
```json
{
  "error": {
    "message": "Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.",
    "type": "invalid_request_error",
    "param": "tools[0].function.name",
    "code": "invalid_value"
  }
}
```

But our MCP tool names are prefixed with `/` separator, which is not included in the pattern. Hence this PR replaces the separator with `-`.
Verified that it works with openai now.