### PR TITLE
Enable Claude Models

### DIFF
--- a/bindings/js-node/src/agent.ts
+++ b/bindings/js-node/src/agent.ts
@@ -67,7 +67,21 @@ export type GeminiModelName =
   | "gemini-1.5-flash"
   | "gemini-1.5-pro";
 
-export type ModelName = TVMModelName | OpenAIModelName | GeminiModelName;
+export type ClaudeModelName =
+  | "claude-sonnet-4-20250514"
+  | "claude-3-7-sonnet-20250219"
+  | "claude-3-5-sonnet-20241022"
+  | "claude-3-5-sonnet-20240620"
+  | "claude-opus-4-20250514"
+  | "claude-3-opus-20240229"
+  | "claude-3-5-haiku-20241022"
+  | "claude-3-haiku-20240307";
+
+export type ModelName =
+  | TVMModelName
+  | OpenAIModelName
+  | GeminiModelName
+  | ClaudeModelName;
 
 interface ModelDescription {
   modelId: string;
@@ -123,6 +137,38 @@ const modelDescriptions: Record<ModelName, ModelDescription> = {
   "gemini-1.5-pro": {
     modelId: "gemini-1.5-pro",
     componentType: "gemini",
+  },
+  "claude-sonnet-4-20250514": {
+    modelId: "claude-sonnet-4-20250514",
+    componentType: "claude",
+  },
+  "claude-3-7-sonnet-20250219": {
+    modelId: "claude-3-7-sonnet-20250219",
+    componentType: "claude",
+  },
+  "claude-3-5-sonnet-20241022": {
+    modelId: "claude-3-5-sonnet-20241022",
+    componentType: "claude",
+  },
+  "claude-3-5-sonnet-20240620": {
+    modelId: "claude-3-5-sonnet-20240620",
+    componentType: "claude",
+  },
+  "claude-opus-4-20250514": {
+    modelId: "claude-opus-4-20250514",
+    componentType: "claude",
+  },
+  "claude-3-opus-20240229": {
+    modelId: "claude-3-opus-20240229",
+    componentType: "claude",
+  },
+  "claude-3-5-haiku-20241022": {
+    modelId: "claude-3-5-haiku-20241022",
+    componentType: "claude",
+  },
+  "claude-3-haiku-20240307": {
+    modelId: "claude-3-haiku-20240307",
+    componentType: "claude",
   },
 };
 

--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -96,7 +96,17 @@ GeminiModelName = Literal[
     "gemini-1.5-flash",
     "gemini-1.5-pro",
 ]
-ModelName = Union[TVMModelName, OpenAIModelName, GeminiModelName]
+ClaudeModelName = Literal[
+    "claude-sonnet-4-20250514",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-sonnet-20240620",
+    "claude-opus-4-20250514",
+    "claude-3-opus-20240229",
+    "claude-3-5-haiku-20241022",
+    "claude-3-haiku-20240307",
+]
+ModelName = Union[TVMModelName, OpenAIModelName, GeminiModelName, ClaudeModelName]
 
 
 class TVMModel(BaseModel):
@@ -160,6 +170,38 @@ model_descriptions: dict[ModelName, ModelDescription] = {
     "gemini-1.5-pro": ModelDescription(
         model_id="gemini-1.5-pro",
         component_type="gemini",
+    ),
+    "claude-sonnet-4-20250514": ModelDescription(
+        model_id="claude-sonnet-4-20250514",
+        component_type="claude",
+    ),
+    "claude-3-7-sonnet-20250219": ModelDescription(
+        model_id="claude-3-7-sonnet-20250219",
+        component_type="claude",
+    ),
+    "claude-3-5-sonnet-20241022": ModelDescription(
+        model_id="claude-3-5-sonnet-20241022",
+        component_type="claude",
+    ),
+    "claude-3-5-sonnet-20240620": ModelDescription(
+        model_id="claude-3-5-sonnet-20240620",
+        component_type="claude",
+    ),
+    "claude-opus-4-20250514": ModelDescription(
+        model_id="claude-opus-4-20250514",
+        component_type="claude",
+    ),
+    "claude-3-opus-20240229": ModelDescription(
+        model_id="claude-3-opus-20240229",
+        component_type="claude",
+    ),
+    "claude-3-5-haiku-20241022": ModelDescription(
+        model_id="claude-3-5-haiku-20241022",
+        component_type="claude",
+    ),
+    "claude-3-haiku-20240307": ModelDescription(
+        model_id="claude-3-haiku-20240307",
+        component_type="claude",
     ),
 }
 

--- a/vm/src/language_module.cpp
+++ b/vm/src/language_module.cpp
@@ -82,6 +82,12 @@ std::shared_ptr<const module_t> get_language_module() {
         "gemini", create_openai_component<gemini_llm_engine_t>);
   }
 
+  // Add Component: Claude
+  if (!language_module->factories.contains("claude")) {
+    language_module->factories.insert_or_assign(
+        "claude", create_openai_component<claude_llm_engine_t>);
+  }
+
   return language_module;
 }
 

--- a/vm/src/openai.cpp
+++ b/vm/src/openai.cpp
@@ -14,21 +14,16 @@ openai_llm_engine_t::openai_llm_engine_t(const std::string &api_key,
                                          const std::string &model)
     : api_key_(api_key), model_(model) {}
 
-openai_response_delta_t openai_llm_engine_t::infer(
-    std::unique_ptr<openai_chat_completion_request_t> request) {
+openai_response_delta_t
+openai_llm_engine_t::infer(std::shared_ptr<const value_t> input) {
   httplib::Client client(api_url());
-  std::unordered_map<std::string, std::string> headers = {
-      {"Authorization", "Bearer " + api_key_},
-      {"Content-Type", "application/json"},
-      {"Cache-Control", "no-cache"},
-  };
   httplib::Headers httplib_headers;
-  for (const auto &[key, value] : headers) {
+  for (const auto &[key, value] : headers()) {
     httplib_headers.emplace(key, value);
   }
 
-  request->model = model_;
-  nlohmann::json body = request->to_json(true);
+  nlohmann::json body = convert_request_body(input);
+  debug("[{}] Request body: {}", name(), body.dump());
 
   httplib::Request http_req;
   std::stringstream response_body;
@@ -58,13 +53,12 @@ openai_response_delta_t openai_llm_engine_t::infer(
   return delta;
 }
 
-std::unique_ptr<openai_chat_completion_request_t>
-openai_llm_engine_t::convert_request_input(
+nlohmann::json openai_llm_engine_t::convert_request_body(
     std::shared_ptr<const value_t> inputs) {
   if (!inputs->is_type_of<map_t>())
     throw ailoy::exception(std::format("[{}] input should be a map", name()));
 
-  auto request = std::make_unique<openai_chat_completion_request_t>();
+  openai_chat_completion_request_t request;
 
   auto input_map = inputs->as<map_t>();
   if (!input_map->contains("messages") ||
@@ -78,22 +72,49 @@ openai_llm_engine_t::convert_request_input(
   messages = melt_content_text(messages)->as<array_t>();
 
   for (const auto &msg_val : *messages) {
-    request->messages.push_back(msg_val->to_nlohmann_json());
+    request.messages.push_back(msg_val->to_nlohmann_json());
   }
 
+  // Convert tools
   if (input_map->contains("tools")) {
     auto tools = input_map->at("tools");
     if (!tools->is_type_of<array_t>()) {
       throw ailoy::exception(
           std::format("[{}] tools should be an array type", name()));
     }
-    request->tools = std::vector<openai_chat_tool_t>{};
+    request.tools = std::vector<openai_chat_tool_t>{};
     for (const auto &tool_val : *tools->as<array_t>()) {
-      request->tools.value().push_back(tool_val->to_nlohmann_json());
+      request.tools.value().push_back(tool_val->to_nlohmann_json());
     }
   }
 
-  return request;
+  // Dump with function call arguments as string
+  nlohmann::json body = request.to_json(true);
+  // Add model
+  body["model"] = model_;
+
+  return body;
+}
+
+nlohmann::json claude_llm_engine_t::convert_request_body(
+    std::shared_ptr<const value_t> inputs) {
+  auto body = openai_llm_engine_t::convert_request_body(inputs);
+
+  // Claude takes the tool result content as a string,
+  // not an array of {"type": "text", "text": "..."}
+  for (auto &message : body["messages"]) {
+    if (message["role"] == "tool") {
+      if (message["content"].is_string())
+        continue;
+      if (message["content"].size() == 0)
+        continue;
+      if (message["content"][0]["type"] != "text")
+        continue;
+      message["content"] = message["content"][0]["text"];
+    }
+  }
+
+  return body;
 }
 
 // TODO: enable iterative infer

--- a/vm/tests/test_api_models.cpp
+++ b/vm/tests/test_api_models.cpp
@@ -46,6 +46,21 @@ protected:
 };
 std::shared_ptr<ailoy::component_t> GeminiTest::comp_ = nullptr;
 
+class ClaudeTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    char const *api_key = std::getenv("CLAUDE_API_KEY");
+    if (api_key == NULL) {
+      GTEST_SKIP() << "API key not configured. Skip the test.";
+      return;
+    }
+    comp_ =
+        create_api_model_comp("claude", api_key, "claude-sonnet-4-20250514");
+  }
+  static std::shared_ptr<ailoy::component_t> comp_;
+};
+std::shared_ptr<ailoy::component_t> ClaudeTest::comp_ = nullptr;
+
 void test_simple_chat(std::shared_ptr<ailoy::component_t> comp) {
   auto infer = comp->get_operator("infer");
 
@@ -229,6 +244,10 @@ TEST_F(OpenAITest, ToolCall) { test_tool_calling(comp_); }
 TEST_F(GeminiTest, SimpleChat) { test_simple_chat(comp_); }
 
 TEST_F(GeminiTest, ToolCall) { test_tool_calling(comp_); }
+
+TEST_F(ClaudeTest, SimpleChat) { test_simple_chat(comp_); }
+
+TEST_F(ClaudeTest, ToolCall) { test_tool_calling(comp_); }
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This PR adds support for Claude models listed at [https://docs.anthropic.com/en/api/models-list](https://docs.anthropic.com/en/api/models-list).

* Claude requires different headers compared to OpenAI, so a virtual `headers()` method was added and overridden accordingly.
* Since Claude expects the "tool result" content as a plain string instead of an array of `{"type": "text", "text": "..."}` objects, we need to handle tool results separately. The overridden `convert_request_body()` method does such processing based on the result of base method.
* Anthropic states that their OpenAI-compatible APIs are not intended for long-term or production use in most cases, and they recommend using their native API to access the full feature set. The same applies to Gemini. However, due to limited resources, we’re currently unable to implement support for each provider's native API individually. Long term, we should consider integrating native APIs into our components.