### PR TITLE
Update TVM codes

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(nlohmann_json)
 
-FetchContent_Declare(dlpack URL https://github.com/dmlc/dlpack/archive/refs/tags/v1.0.tar.gz EXCLUDE_FROM_ALL)
+FetchContent_Declare(dlpack URL https://github.com/dmlc/dlpack/archive/refs/tags/v1.1.tar.gz EXCLUDE_FROM_ALL)
 set(BUILD_MOCK OFF CACHE BOOL "DLPack disable mock build" FORCE)  # skip building mock in dlpack
 FetchContent_MakeAvailable(dlpack)
 

--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(ailoy_vm_obj PRIVATE magic_enum)
 FetchContent_Declare(
     tokenizers-cpp
     GIT_REPOSITORY https://github.com/mlc-ai/tokenizers-cpp.git
-    GIT_TAG 4fbe996658ddd003b88e1650d799b351fe83b2d6
+    GIT_TAG aae12091f520ae2eababfa95e45436e9953992d4
     EXCLUDE_FROM_ALL
 )
 if(NODE)
@@ -90,7 +90,7 @@ if(AILOY_WITH_TVM)
         FetchContent_Declare(
             tvm
             GIT_REPOSITORY https://github.com/brekkylab/relax.git
-            GIT_TAG dcda2cfd38a8183990d27a0ec6fbeecbb74a46b4
+            GIT_TAG a02a2d4cc7f20770429ccbb99d7c9b989574e0d6
             EXCLUDE_FROM_ALL
         )
         if(APPLE)
@@ -113,6 +113,7 @@ if(AILOY_WITH_TVM)
     endif()
     target_include_directories(ailoy_vm_obj PUBLIC
         ${TVM_SOURCE_DIR}/3rdparty/dmlc-core/include
+        ${TVM_SOURCE_DIR}/ffi/include
         ${TVM_SOURCE_DIR}/include
     )
     target_link_libraries(tvm_runtime PRIVATE dlpack)

--- a/vm/src/tvm/embedding_model.hpp
+++ b/vm/src/tvm/embedding_model.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tvm/runtime/packed_func.h>
+#include <tvm/ffi/function.h>
 
 #include "module.hpp"
 #include "tvm_model.hpp"
@@ -23,7 +23,7 @@ public:
   }
 
 private:
-  tvm::runtime::PackedFunc fprefill_;
+  tvm::ffi::Function fprefill_;
   std::shared_ptr<tvm_model_t> engine_ = nullptr;
 };
 

--- a/vm/src/tvm/language_model.hpp
+++ b/vm/src/tvm/language_model.hpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
+#include <tvm/ffi/function.h>
 #include <tvm/runtime/ndarray.h>
-#include <tvm/runtime/packed_func.h>
 
 #include "exception.hpp"
 #include "module.hpp"
@@ -202,15 +202,15 @@ private:
 
   std::unordered_map<std::string, stream_mode_t> stream_modes_;
 
-  tvm::runtime::PackedFunc fembed_;
+  tvm::ffi::Function fembed_;
 
-  tvm::runtime::PackedFunc fprefill_;
+  tvm::ffi::Function fprefill_;
 
-  tvm::runtime::PackedFunc fdecode_;
+  tvm::ffi::Function fdecode_;
 
-  tvm::runtime::PackedFunc fapply_bitmask_inplace_;
+  tvm::ffi::Function fapply_bitmask_inplace_;
 
-  tvm::runtime::PackedFunc fsample_top_p_from_logits_;
+  tvm::ffi::Function fsample_top_p_from_logits_;
 };
 
 component_or_error_t

--- a/vm/src/tvm/tvm_model.hpp
+++ b/vm/src/tvm/tvm_model.hpp
@@ -3,9 +3,10 @@
 #include <optional>
 
 #include <nlohmann/json.hpp>
+#include <tvm/ffi/function.h>
 #include <tvm/runtime/device_api.h>
-#include <tvm/runtime/packed_func.h>
-#include <tvm/runtime/relax_vm/ndarray_cache_support.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/vm/ndarray_cache_support.h>
 
 #include "logging.hpp"
 #include "module.hpp"
@@ -34,12 +35,12 @@ public:
 
   const nlohmann::json &get_mlc_chat_config() const { return mlc_chat_config_; }
 
-  tvm::runtime::PackedFunc get_function(const std::string_view fname) {
-    return *tvm::runtime::Registry::Get(std::string(fname));
+  tvm::ffi::Function get_function(const std::string_view fname) {
+    return *tvm::ffi::Function::GetGlobal(std::string(fname));
   }
 
-  tvm::runtime::PackedFunc get_vm_function(const std::string_view fname,
-                                           bool query_imports = false) {
+  tvm::ffi::Function get_vm_function(const std::string_view fname,
+                                     bool query_imports = false) {
     return get_module().GetFunction(std::string(fname), query_imports);
   }
 
@@ -65,8 +66,8 @@ private:
   tvm::runtime::Module mod_;
   nlohmann::json metadata_ = {};
   nlohmann::json mlc_chat_config_ = {};
-  tvm::runtime::relax_vm::NDArrayCacheMetadata ndarray_cache_metadata_;
-  tvm::runtime::ObjectRef params_;
+  tvm::runtime::vm::NDArrayCacheMetadata ndarray_cache_metadata_;
+  tvm::Array<tvm::runtime::NDArray> params_;
 
   std::string err_;
 };


### PR DESCRIPTION
TVM has recently updated its FFI-related APIs, so this PR updates the corresponding code to align with the latest changes.

## Breaking Changes

After this PR is merged, previously built model libraries will no longer be compatible.
To support older model libraries, we would need to implement model versioning as discussed in #114. However, this requires a more robust architecture and will take time to design and implement.

Therefore, we've decided to drop backward compatibility with versions `<= 0.0.2` for now and encourage users to upgrade Ailoy to the latest version.
We plan to merge this PR just before releasing version `0.0.3`.