### PR TITLE
Fix node packaging: set sharp as external

### DIFF
--- a/bindings/js-node/rollup.config.js
+++ b/bindings/js-node/rollup.config.js
@@ -29,7 +29,10 @@ export default [
         exports: "named",
       },
     ],
-    external: [fileURLToPath(new URL("src/ailoy_addon.node", import.meta.url))],
+    external: [
+      fileURLToPath(new URL("src/ailoy_addon.node", import.meta.url)),
+      "sharp",
+    ],
     plugins: [
       resolve(),
       commonjs(),


### PR DESCRIPTION
`ailoy-node@0.0.3` has the following error when being imported.

```
Error: Could not load the "sharp" module using the darwin-arm64 runtime
undefined: Could not dynamically require "../src/build/Release/sharp-darwin-arm64.node". Please configure the dynamicRequireTargets or/and ignoreDynamicRequires option of @rollup/plugin-commonjs appropriately for this require call to work.
undefined: Could not dynamically require "../src/build/Release/sharp-wasm32.node". Please configure the dynamicRequireTargets or/and ignoreDynamicRequires option of @rollup/plugin-commonjs appropriately for this require call to work.
undefined: Could not dynamically require "@img/sharp-darwin-arm64/sharp.node". Please configure the dynamicRequireTargets or/and ignoreDynamicRequires option of @rollup/plugin-commonjs appropriately for this require call to work.
undefined: Could not dynamically require "@img/sharp-wasm32/sharp.node". Please configure the dynamicRequireTargets or/and ignoreDynamicRequires option of @rollup/plugin-commonjs appropriately for this require call to work.
Possible solutions:
- Ensure optional dependencies can be installed:
    npm install --include=optional sharp
- Ensure your package manager supports multi-platform installation:
    See https://sharp.pixelplumbing.com/install#cross-platform
- Add platform-specific dependencies:
    npm install --os=darwin --cpu=arm64 sharp
- Consult the installation documentation:
    See https://sharp.pixelplumbing.com/install
```

This PR fixes the problem by adding `sharp` in `external`.