### PR TITLE
Windows: update openssl to 3.5.1

### DIFF
--- a/.github/workflows/build_node_windows.yaml
+++ b/.github/workflows/build_node_windows.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install OpenSSL
         shell: powershell
         run: |
-          $url = "https://slproweb.com/download/Win64OpenSSL-3_5_0.exe"
+          $url = "https://slproweb.com/download/Win64OpenSSL-3_5_1.exe"
           $output = "openssl-installer.exe"
           Invoke-WebRequest -Uri $url -OutFile $output
           Start-Process -FilePath ".\openssl-installer.exe" -ArgumentList "/silent", "/verysilent", "/sp-", "/SUPPRESSMSGBOXES" -Wait

--- a/.github/workflows/build_python_windows.yaml
+++ b/.github/workflows/build_python_windows.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install OpenSSL
         shell: powershell
         run: |
-          $url = "https://slproweb.com/download/Win64OpenSSL-3_5_0.exe"
+          $url = "https://slproweb.com/download/Win64OpenSSL-3_5_1.exe"
           $output = "openssl-installer.exe"
           Invoke-WebRequest -Uri $url -OutFile $output
           Start-Process -FilePath ".\openssl-installer.exe" -ArgumentList "/silent", "/verysilent", "/sp-", "/SUPPRESSMSGBOXES" -Wait


### PR DESCRIPTION
The link for OpenSSL 3.5.0 has been disappeared, so we need to update it.