### PR TITLE
Remove `Self` type for Python3.10 compat

### DIFF
--- a/bindings/python/ailoy/models/api_model.py
+++ b/bindings/python/ailoy/models/api_model.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Self, get_args
+from typing import Literal, Optional, get_args
 
 from pydantic import model_validator
 from pydantic.dataclasses import dataclass
@@ -44,7 +44,7 @@ class APIModel:
     provider: Optional[APIModelProvider] = None
 
     @model_validator(mode="after")
-    def validate_provider(self) -> Self:
+    def validate_provider(self):
         if self.provider is None:
             if self.id in get_args(OpenAIModelId):
                 self.provider = "openai"


### PR DESCRIPTION
The latest ailoy-py package has import error on Python3.10 due to the usage of `Self` type which is not present in 3.10.
