### PR TITLE
Support `typing.Literal` as type hint of python function tools

### DIFF
--- a/bindings/python/ailoy/agent.py
+++ b/bindings/python/ailoy/agent.py
@@ -217,7 +217,7 @@ class ToolParameters(BaseModel):
 
 
 class ToolParametersProperty(BaseModel):
-    type: Literal["string", "number", "boolean", "object", "array", "null"]
+    type: Literal["string", "integer", "number", "boolean", "object", "array", "null"]
     description: Optional[str] = None
     model_config = ConfigDict(extra="allow")
 
@@ -506,7 +506,9 @@ class Agent:
                         raise RuntimeError("Tool not found")
                     tool_result = tool_.call(**tool_call.function.arguments)
                     return ToolMessage(
-                        content=[TextContent(text=json.dumps(tool_result))],
+                        content=[
+                            TextContent(text=tool_result if isinstance(tool_result, str) else json.dumps(tool_result))
+                        ],
                         tool_call_id=tool_call.id,
                     )
 


### PR DESCRIPTION
## Description
### Support `typing.Literal` as type of tool parameters
Details are described in https://github.com/huggingface/transformers/pull/39633.

### Bug fixes in 'python function tools'
1. pydantic validation error
  When a type hint of a parameter is `int`, its tool description is generated including `{"type": "integer"}` but, there was no `"integer"` in possible type. So added it.
2. When a python function tool returns a string as the result, that was wrapped by `""`, because all the results were processed with `json.dumps()`. Now omitting it when the result output is a string.