### PR TITLE
Add test for tokenizers

### DIFF
--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(ailoy_vm_obj PRIVATE magic_enum)
 FetchContent_Declare(
     tokenizers-cpp
     GIT_REPOSITORY https://github.com/mlc-ai/tokenizers-cpp.git
-    GIT_TAG 8fd3b64057db4ddb5a49691cf02009f0373900d5
+    GIT_TAG f77710965a3bcae85b7a00bdddbfc1adadef0e32
     EXCLUDE_FROM_ALL
 )
 if(NODE)
@@ -61,6 +61,11 @@ if(NODE)
 endif()
 FetchContent_MakeAvailable(tokenizers-cpp)
 target_link_libraries(ailoy_vm_obj PUBLIC tokenizers_c tokenizers_cpp)
+if(EMSCRIPTEN)
+    # Need to disable TOKENIZERS_PARALLELISM on WASM
+    # https://github.com/mlc-ai/tokenizers-cpp/pull/42
+    target_compile_definitions(tokenizers_cpp PRIVATE COMPILE_WASM_RUNTIME)
+endif()
 
 
 # tvm
@@ -185,11 +190,12 @@ if(AILOY_WITH_TEST)
     add_executable(test_model_cache ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_model_cache.cpp)
     add_test(NAME TestModelCache COMMAND test_model_cache)
     target_include_directories(test_model_cache PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-    target_link_libraries(test_model_cache PRIVATE ailoy_vm_obj ailoy_broker_obj ailoy_broker_client_obj ailoy_core_obj)
-    target_link_options(test_model_cache PRIVATE -fsanitize=undefined -fsanitize=address)
+    target_link_libraries(test_model_cache PRIVATE ailoy_vm_obj ailoy_core_obj)
     if(EMSCRIPTEN)
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tests/test_model_cache.html" "${CMAKE_CURRENT_BINARY_DIR}/test_model_cache.html" COPYONLY)
     else()
+        # NOTE: Do not add sanitizer options on Emscripten. It leads to poor performance!
+        target_link_options(test_model_cache PRIVATE -fsanitize=undefined -fsanitize=address)
         target_link_libraries(test_model_cache PRIVATE GTest::gtest)
     endif()
 
@@ -228,4 +234,15 @@ if(AILOY_WITH_TEST)
     target_include_directories(test_api_models PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_link_libraries(test_api_models PRIVATE ailoy_vm_obj ailoy_broker_obj ailoy_broker_client_obj ailoy_core_obj nlohmann_json::nlohmann_json GTest::gtest GTest::gmock)
     target_link_options(test_api_models PRIVATE -fsanitize=undefined -fsanitize=address)
+
+    add_executable(test_tokenizers ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tokenizers.cpp)
+    target_include_directories(test_tokenizers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(test_tokenizers PRIVATE ailoy_vm_obj ailoy_core_obj)
+    if(EMSCRIPTEN)
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tokenizers.html" "${CMAKE_CURRENT_BINARY_DIR}/test_tokenizers.html" COPYONLY)
+    else()
+        # NOTE: Do not add sanitizer options on Emscripten. It leads to poor performance!
+        target_link_options(test_tokenizers PRIVATE -fsanitize=undefined -fsanitize=address)
+        target_link_libraries(test_tokenizers PRIVATE GTest::gtest)
+    endif()
 endif()

--- a/vm/tests/test_tokenizers.cpp
+++ b/vm/tests/test_tokenizers.cpp
@@ -1,0 +1,86 @@
+#ifdef EMSCRIPTEN
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#else
+#include <gtest/gtest.h>
+#endif
+
+#include <format>
+#include <iostream>
+
+#include "model_cache.hpp"
+#include "tokenizer.hpp"
+
+static std::string expected_text = "What is your name?";
+static std::vector<uint32_t> expected_tokens{3838, 374, 697, 829, 30};
+
+#ifdef EMSCRIPTEN
+
+int main() {
+  auto cache_root = ailoy::get_cache_root();
+  auto tokenizer_path = cache_root / "tvm-models" / "Qwen--Qwen3-0.6B" /
+                        "q4f16_1" / "tokenizer.json";
+  if (!ailoy::fs::file_exists(tokenizer_path).unwrap()) {
+    std::cout << "tokenizer.json for Qwen/Qwen3-0.6B is not present. Download "
+                 "the model first."
+              << std::endl;
+    return;
+  }
+
+  ailoy::tokenizer_t tokenizer(tokenizer_path);
+
+  std::cout << std::format("Encode text: \"{}\"", expected_text) << std::endl;
+  auto tokens = tokenizer.encode(expected_text);
+  if (tokens.size() != expected_tokens.size()) {
+    throw std::runtime_error("The number of tokens is not same as expected");
+  }
+
+  for (int i = 0; i < tokens.size(); i++) {
+    std::cout << std::format("{}th token: {}", i, tokens[i]) << std::endl;
+    if (tokens[i] != expected_tokens[i]) {
+      throw std::runtime_error(
+          std::format("The {}th token({}) is not same as expected({})", i,
+                      tokens[i], expected_tokens[i]));
+    }
+  }
+
+  auto decoded_text = tokenizer.decode(tokens);
+  std::cout << std::format("Decoded text: {}", decoded_text) << std::endl;
+  if (decoded_text != expected_text) {
+    throw std::runtime_error(std::format(
+        "The decoded text is not same as expected: \"{}\"", expected_text));
+  }
+
+  return 0;
+}
+
+#else
+
+TEST(TokenizersTest, EncodeDecode) {
+  auto cache_root = ailoy::get_cache_root();
+  auto tokenizer_path = cache_root / "tvm-models" / "Qwen--Qwen3-0.6B" /
+                        "q4f16_1" / "tokenizer.json";
+  if (!ailoy::fs::file_exists(tokenizer_path).unwrap()) {
+    GTEST_SKIP() << "tokenizer.json for Qwen/Qwen3-0.6B is not present. "
+                    "Download the model first.";
+    return;
+  }
+
+  ailoy::tokenizer_t tokenizer(tokenizer_path);
+
+  auto encoded_tokens = tokenizer.encode(expected_text);
+  ASSERT_EQ(encoded_tokens.size(), expected_tokens.size());
+  for (int i = 0; i < encoded_tokens.size(); i++) {
+    ASSERT_EQ(encoded_tokens[i], expected_tokens[i]);
+  }
+
+  auto decoded_text = tokenizer.decode(encoded_tokens);
+  ASSERT_EQ(decoded_text, expected_text);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+#endif

--- a/vm/tests/test_tokenizers.html
+++ b/vm/tests/test_tokenizers.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ailoy Model Cache Test</title>
+    <title>Ailoy Tokenizers Test</title>
     <style>
         body { font-family: sans-serif; background-color: #f4f4f4; color: #333; }
         #output { width: 95%; height: 500px; border: 1px solid #ccc; padding: 10px; font-family: monospace; white-space: pre-wrap; background-color: #fff; }
     </style>
 </head>
 <body>
-    <h1>Ailoy Model Cache Test</h1>
+    <h1>Ailoy Tokenizers Test</h1>
     <p>The output from the WebAssembly module will appear below. Check the browser's developer console (F12) for any additional errors.</p>
     <textarea id="output" readonly></textarea>
 
@@ -33,6 +33,6 @@
         };
     </script>
 
-    <script async src="test_model_cache.js"></script>
+    <script async src="test_tokenizers.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- We suffered from slow initialization of tokenizer class in browser environment, and the reason was sanitizer link options (`-fsanitize=undefined -fsanitize=address`) added in test executables. We fixed it by removing these options on Emscripten build time.
- We found that there's `-DCOMPILE_WASM_RUNTIME` compile definition in official mlc-ai/web-tokenizers build script (https://github.com/mlc-ai/tokenizers-cpp/blob/main/web/build.sh#L8). This is for preventing thread parallelism which leads to error on WASM runtime (see https://github.com/mlc-ai/tokenizers-cpp/pull/42). So we provide the same compile definition on Emscripten build time.
- Added the test executable (and html) for testing tokenizers only.