### PR TITLE
[WASM] add helper functions for multimodal user content conversion

### DIFF
--- a/bindings/js-web/src/agent.ts
+++ b/bindings/js-web/src/agent.ts
@@ -28,10 +28,30 @@ export class ImageContent {
     return new ImageContent("image_url", { url });
   }
 
+  static fromBytes(
+    data: Uint8Array<ArrayBufferLike>,
+    format: "png" | "jpg" | "jpeg" | "gif" | (string & {})
+  ) {
+    if (format === "jpg") format = "jpeg";
+    const base64 = uint8ArrayToBase64(data);
+    return this.fromUrl(`data:image/${format};base64,${base64}`);
+  }
+
+  static fromArrayBuffer(
+    buffer: ArrayBuffer,
+    format: Parameters<typeof this.fromBytes>[1]
+  ) {
+    return this.fromBytes(new Uint8Array(buffer), format);
+  }
+
+  static async fromFile(file: File) {
+    const arr = await file.arrayBuffer();
+    const format = file.type.replace(/^image\//, "");
+    return this.fromArrayBuffer(arr, format);
+  }
+
   static fromVips(image: Image) {
-    return new ImageContent("image_url", {
-      url: vipsImageToBase64(image),
-    });
+    return this.fromUrl(vipsImageToBase64(image));
   }
 }
 
@@ -44,14 +64,29 @@ export class AudioContent {
     }
   ) {}
 
-  static async fromBytes(
+  static fromBytes(
     data: Uint8Array<ArrayBufferLike>,
-    format: "mp3" | "wav"
+    format: AudioContent["input_audio"]["format"]
   ) {
     return new AudioContent("input_audio", {
       data: uint8ArrayToBase64(data),
       format,
     });
+  }
+
+  static fromArrayBuffer(
+    buffer: ArrayBuffer,
+    format: AudioContent["input_audio"]["format"]
+  ) {
+    return this.fromBytes(new Uint8Array(buffer), format);
+  }
+
+  static async fromFile(file: File) {
+    const arr = await file.arrayBuffer();
+    const format = file.type.replace(/^audio\//, "");
+    if (format !== "mp3" && format !== "wav")
+      throw new Error(`Unsupported audio format: ${format}`);
+    return this.fromBytes(new Uint8Array(arr), format);
   }
 }
 

--- a/bindings/js-web/tests/agent-claude.test.ts
+++ b/bindings/js-web/tests/agent-claude.test.ts
@@ -9,8 +9,8 @@ import {
 import Vips from "wasm-vips";
 
 import { defineAgent } from "../src/agent";
-import { Runtime } from "../src/runtime";
 import { APIModel } from "../src/models";
+import { Runtime } from "../src/runtime";
 
 describe.skipIf(process.env.CLAUDE_API_KEY === "undefined")(
   "Claude Agent",
@@ -64,24 +64,24 @@ describe.skipIf(process.env.CLAUDE_API_KEY === "undefined")(
 
       const toolCallResp = await iter.next();
       /**
-         * Example toolCallResp
-          {
-            "content": {
-              "function": {
-                "arguments": {
-                  "base": "USD",
-                  "symbols": "KRW",
-                },
-                "name": "frankfurter",
+       * Example toolCallResp
+        {
+          "content": {
+            "function": {
+              "arguments": {
+                "base": "USD",
+                "symbols": "KRW",
               },
-              "id": "call_GHiqPOWq2KGMlntor4zkJtb6",
-              "type": "function",
+              "name": "frankfurter",
             },
-            "isTypeSwitched": true,
-            "role": "assistant",
-            "type": "tool_call",
-          }
-        */
+            "id": "call_GHiqPOWq2KGMlntor4zkJtb6",
+            "type": "function",
+          },
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "tool_call",
+        }
+      */
       expect(toolCallResp.value).to.have.property("content");
       expect(toolCallResp.value.content).to.have.property("type", "function");
       expect(toolCallResp.value.content).to.have.property("function");
@@ -100,23 +100,23 @@ describe.skipIf(process.env.CLAUDE_API_KEY === "undefined")(
 
       const toolCallResultResp = await iter.next();
       /**
-         * Example toolCallResultResp
-          {
-            "content": {
-              "content": [
-                {
-                  "text": "{"KRW":1404.62}",
-                  "type": "text",
-                },
-              ],
-              "role": "tool",
-              "tool_call_id": "call_GHiqPOWq2KGMlntor4zkJtb6",
-            },
-            "isTypeSwitched": true,
+       * Example toolCallResultResp
+        {
+          "content": {
+            "content": [
+              {
+                "text": "{"KRW":1404.62}",
+                "type": "text",
+              },
+            ],
             "role": "tool",
-            "type": "tool_call_result",
-          }
-        */
+            "tool_call_id": "call_GHiqPOWq2KGMlntor4zkJtb6",
+          },
+          "isTypeSwitched": true,
+          "role": "tool",
+          "type": "tool_call_result",
+        }
+      */
       expect(toolCallResultResp.value).to.have.property("content");
       expect(toolCallResultResp.value).to.have.property("role", "tool");
       expect(toolCallResultResp.value.content).to.have.property("content");

--- a/bindings/js-web/tests/agent-gemini.test.ts
+++ b/bindings/js-web/tests/agent-gemini.test.ts
@@ -9,8 +9,8 @@ import {
 import Vips from "wasm-vips";
 
 import { defineAgent, AudioContent } from "../src/agent";
-import { Runtime } from "../src/runtime";
 import { APIModel } from "../src/models";
+import { Runtime } from "../src/runtime";
 
 describe.skipIf(process.env.GEMINI_API_KEY === "undefined")(
   "Gemini Agent",
@@ -168,8 +168,7 @@ describe.skipIf(process.env.GEMINI_API_KEY === "undefined")(
       );
 
       const arrayBuffer = await audioResp.arrayBuffer();
-      const buffer = new Uint8Array(arrayBuffer);
-      const audioContent = await AudioContent.fromBytes(buffer, "wav");
+      const audioContent = AudioContent.fromArrayBuffer(arrayBuffer, "wav");
 
       const iter = agent.query(["What's in these recording?", audioContent]);
       const resp = await iter.next();

--- a/bindings/js-web/tests/agent-grok.test.ts
+++ b/bindings/js-web/tests/agent-grok.test.ts
@@ -9,8 +9,8 @@ import {
 import Vips from "wasm-vips";
 
 import { defineAgent, AudioContent } from "../src/agent";
-import { Runtime } from "../src/runtime";
 import { APIModel } from "../src/models";
+import { Runtime } from "../src/runtime";
 
 describe.skipIf(process.env.XAI_API_KEY === "undefined")(
   "Grok Agent",
@@ -34,14 +34,14 @@ describe.skipIf(process.env.XAI_API_KEY === "undefined")(
       const iter = agent.query("Hello World!");
       const resp = await iter.next();
       /**
-     * Example response
-      {
-        "content": "Hi there! How can I assist you today?",
-        "isTypeSwitched": true,
-        "role": "assistant",
-        "type": "output_text",
-      }
-    */
+       * Example response
+        {
+          "content": "Hi there! How can I assist you today?",
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "output_text",
+        }
+      */
       expect(resp.value).to.have.property("type", "output_text");
       expect(resp.value).to.have.property("role", "assistant");
       expect(resp.value).to.have.property("content");
@@ -146,14 +146,14 @@ describe.skipIf(process.env.XAI_API_KEY === "undefined")(
       const iter = agent.query([image, "What is in this image?"]);
       const resp = await iter.next();
       /**
-     * Example response
-      {
-        "content": "The image shows a person wearing glasses and a leather jacket, smiling at the camera.",
-        "isTypeSwitched": true,
-        "role": "assistant",
-        "type": "output_text",
-      }
-    */
+       * Example response
+        {
+          "content": "The image shows a person wearing glasses and a leather jacket, smiling at the camera.",
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "output_text",
+        }
+      */
       expect(resp.value).to.have.property("type", "output_text");
       expect(resp.value).to.have.property("role", "assistant");
       expect(resp.value).to.have.property("content");

--- a/bindings/js-web/tests/agent-openai.test.ts
+++ b/bindings/js-web/tests/agent-openai.test.ts
@@ -9,8 +9,8 @@ import {
 import Vips from "wasm-vips";
 
 import { defineAgent, AudioContent } from "../src/agent";
-import { Runtime } from "../src/runtime";
 import { APIModel } from "../src/models";
+import { Runtime } from "../src/runtime";
 
 describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
   "OpenAI Agent",
@@ -34,14 +34,14 @@ describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
       const iter = agent.query("Hello World!");
       const resp = await iter.next();
       /**
-     * Example response
-      {
-        "content": "Hi there! How can I assist you today?",
-        "isTypeSwitched": true,
-        "role": "assistant",
-        "type": "output_text",
-      }
-    */
+       * Example response
+        {
+          "content": "Hi there! How can I assist you today?",
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "output_text",
+        }
+      */
       expect(resp.value).to.have.property("type", "output_text");
       expect(resp.value).to.have.property("role", "assistant");
       expect(resp.value).to.have.property("content");
@@ -59,24 +59,24 @@ describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
       );
       const toolCallResp = await iter.next();
       /**
-     * Example toolCallResp
-      {
-        "content": {
-          "function": {
-            "arguments": {
-              "base": "USD",
-              "symbols": "KRW",
+       * Example toolCallResp
+        {
+          "content": {
+            "function": {
+              "arguments": {
+                "base": "USD",
+                "symbols": "KRW",
+              },
+              "name": "frankfurter",
             },
-            "name": "frankfurter",
+            "id": "call_GHiqPOWq2KGMlntor4zkJtb6",
+            "type": "function",
           },
-          "id": "call_GHiqPOWq2KGMlntor4zkJtb6",
-          "type": "function",
-        },
-        "isTypeSwitched": true,
-        "role": "assistant",
-        "type": "tool_call",
-      }
-    */
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "tool_call",
+        }
+      */
       expect(toolCallResp.value).to.have.property("content");
       expect(toolCallResp.value.content).to.have.property("type", "function");
       expect(toolCallResp.value.content).to.have.property("function");
@@ -95,23 +95,23 @@ describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
 
       const toolCallResultResp = await iter.next();
       /**
-     * Example toolCallResultResp
-      {
-        "content": {
-          "content": [
-            {
-              "text": "{"KRW":1404.62}",
-              "type": "text",
-            },
-          ],
+       * Example toolCallResultResp
+        {
+          "content": {
+            "content": [
+              {
+                "text": "{"KRW":1404.62}",
+                "type": "text",
+              },
+            ],
+            "role": "tool",
+            "tool_call_id": "call_GHiqPOWq2KGMlntor4zkJtb6",
+          },
+          "isTypeSwitched": true,
           "role": "tool",
-          "tool_call_id": "call_GHiqPOWq2KGMlntor4zkJtb6",
-        },
-        "isTypeSwitched": true,
-        "role": "tool",
-        "type": "tool_call_result",
-      }
-    */
+          "type": "tool_call_result",
+        }
+      */
       expect(toolCallResultResp.value).to.have.property("content");
       expect(toolCallResultResp.value).to.have.property("role", "tool");
       expect(toolCallResultResp.value.content).to.have.property("content");
@@ -146,14 +146,14 @@ describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
       const iter = agent.query([image, "What is in this image?"]);
       const resp = await iter.next();
       /**
-     * Example response
-      {
-        "content": "The image shows a person wearing glasses and a leather jacket, smiling at the camera.",
-        "isTypeSwitched": true,
-        "role": "assistant",
-        "type": "output_text",
-      }
-    */
+       * Example response
+        {
+          "content": "The image shows a person wearing glasses and a leather jacket, smiling at the camera.",
+          "isTypeSwitched": true,
+          "role": "assistant",
+          "type": "output_text",
+        }
+      */
       expect(resp.value).to.have.property("type", "output_text");
       expect(resp.value).to.have.property("role", "assistant");
       expect(resp.value).to.have.property("content");
@@ -177,21 +177,19 @@ describe.skipIf(process.env.OPENAI_API_KEY === "undefined")(
       );
 
       const arrayBuffer = await audioResp.arrayBuffer();
-      const buffer = new Uint8Array(arrayBuffer);
-      const audioContent = await AudioContent.fromBytes(buffer, "wav");
+      const audioContent = AudioContent.fromArrayBuffer(arrayBuffer, "wav");
 
       const iter = agent.query(["What's in these recording?", audioContent]);
       const resp = await iter.next();
       /**
-   * Example response
-    {
-      "content": "The recording contains a statement about the fact that the sun rises in the east and sets in the west, and mentions that this observation has been made by humans for thousands of years.",
-      "isTypeSwitched": true,
-      "role": "assistant",
-      "type": "output_text",
-    }
-   */
-
+       * Example response
+       {
+         "content": "The recording contains a statement about the fact that the sun rises in the east and sets in the west, and mentions that this observation has been made by humans for thousands of years.",
+         "isTypeSwitched": true,
+         "role": "assistant",
+         "type": "output_text",
+       }
+      */
       expect(resp.value).to.have.property("type", "output_text");
       expect(resp.value).to.have.property("role", "assistant");
       expect(resp.value).to.have.property("content");


### PR DESCRIPTION
While creating example apps, I found that it would be more convenient to support multimodal input conversion from `File`, `ArrayBuffer` or `Uint8Array<ArrayBufferLike>` which are often used in javascript frontends.