### PR TITLE
add `skip_integrity_check` in `download_model`

### DIFF
--- a/bindings/js-web/src/models/localModel.ts
+++ b/bindings/js-web/src/models/localModel.ts
@@ -65,6 +65,7 @@ export class _LocalModel {
         model_id: this.id,
         quantization: this.quantization,
         device: "webgpu",
+        skip_integrity_check: true, // Skip integrity check due to poor performance on browser
       });
     }
 

--- a/docs/src/components/CodePreview/style.module.scss
+++ b/docs/src/components/CodePreview/style.module.scss
@@ -27,7 +27,7 @@
     }
 }
 
-.sandpack--file-explorer--wasm {
+.sandpack--file-explorer--web {
     button[title="styles.css"] {
         display: none;
     }

--- a/vm/src/model_cache.hpp
+++ b/vm/src/model_cache.hpp
@@ -54,7 +54,8 @@ model_cache_download_result_t
 download_model(const std::string &model_id, const std::string &quantization,
                const std::string &target_device,
                std::optional<model_cache_callback_t> callback = std::nullopt,
-               bool print_progress_bar = true);
+               bool print_progress_bar = true,
+               bool skip_integrity_check = false);
 
 model_cache_remove_result_t remove_model(const std::string &model_name,
                                          bool ask_prompt = false);


### PR DESCRIPTION
Added `skip_integrity_check` to disable sha1 integrity check during model download.
It's used in js-web since sha1 computation in browser shows poor performance.