### PR TITLE
Add ailoy-web packaging workflow

### DIFF
--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Create package
         run: |
           npm install
+          npm run build:configure
           npm run build:wasm
           npm run build:ts
           npm pack

--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -1,8 +1,7 @@
 name: Build ailoy-web
 
 on:
-  # workflow_dispatch:
-  push:
+  workflow_dispatch:
 
 env:
   NODE_VERSION: "20.19.4"

--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -33,9 +33,7 @@ jobs:
       - name: Create package
         run: |
           npm install
-          npm run build:configure
-          npm run build:wasm
-          npm run build:ts
+          npm run build
           npm pack
           PACKAGE_NAME=$(ls -1t ailoy-web-*.tgz | head -n 1)
           echo "PACKAGE_NAME=$PACKAGE_NAME"

--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -14,7 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: Setup Rust Nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rust-src
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -1,0 +1,42 @@
+name: Build ailoy-web
+
+on:
+  # workflow_dispatch:
+  push:
+
+env:
+  NODE_VERSION: "20.19.4"
+
+jobs:
+  build-macos:
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+    
+      - name: Setup Emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.11
+
+      - name: Create package
+        run: |
+          npm install
+          npm build:wasm
+          npm build:ts
+          npm pack
+          PACKAGE_NAME=$(ls -1t ailoy-web-*.tgz | head -n 1)
+          echo "PACKAGE_NAME=$PACKAGE_NAME"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+        working-directory: ${{ github.workspace }}/bindings/js-web
+
+      - name: Upload npm package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}
+          path: ${{ github.workspace }}/bindings/js-web/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/build_js_web.yaml
+++ b/.github/workflows/build_js_web.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Create package
         run: |
           npm install
-          npm build:wasm
-          npm build:ts
+          npm run build:wasm
+          npm run build:ts
           npm pack
           PACKAGE_NAME=$(ls -1t ailoy-web-*.tgz | head -n 1)
           echo "PACKAGE_NAME=$PACKAGE_NAME"

--- a/bindings/js-web/package.json
+++ b/bindings/js-web/package.json
@@ -20,7 +20,7 @@
     "build:wasm": "cd ../.. && cmake --build ./build/emscripten-release -t ailoy_js_web --parallel 10",
     "build:tvm": "make -C ../../build/emscripten-release/_deps/tvm-src/web && cp ../../build/emscripten-release/_deps/tvm-src/web/src/*.js ./src/tvmjs",
     "build:ts": "NODE_ENV=production vite build",
-    "build": "npm run build:configure && npm run build:wasm && npm run build:ts",
+    "build": "npm run build:configure && npm run build:wasm && npm run build:tvm && npm run build:ts",
     "dev": "NODE_ENV=development vite dev",
     "test": "vitest",
     "prepack": "clean-package",


### PR DESCRIPTION
This PR adds the build workflow of ailoy-web on macos-14 runner.
The build requires Node.js, Emsdk, and Rust nightly toolchain.
