### PR TITLE
Use picojson instead of nlohmann json

### DIFF
--- a/v2/build.rs
+++ b/v2/build.rs
@@ -114,8 +114,6 @@ fn build_native() {
     // Download if not exists
     let tvm_dir = cmake_source_dir.join("3rdparty").join("tvm");
     clone("tvm", "https://github.com/brekkylab/relax", &tvm_dir);
-    let json_dir = cmake_source_dir.join("3rdparty").join("json");
-    clone("json", "https://github.com/nlohmann/json.git", &json_dir);
 
     // Run cxx bridge
     let mut cxx = cxx_build::bridge("src/ffi/cxx_bridge.rs");
@@ -126,9 +124,9 @@ fn build_native() {
         .include(&cmake_source_dir.join("include"))
         .include(&tvm_dir.join("include"))
         .include(&tvm_dir.join("ffi").join("include"))
+        .include(&tvm_dir.join("3rdparty").join("picojson"))
         .include(&tvm_dir.join("3rdparty").join("dlpack").join("include"))
         .include(&tvm_dir.join("3rdparty").join("dmlc-core").join("include"))
-        .include(&json_dir.join("include"))
         .include(cargo_target_dir.join("cxxbridge"))
         .compile("rust_bridge");
 

--- a/v2/shim/CMakeLists.txt
+++ b/v2/shim/CMakeLists.txt
@@ -115,18 +115,6 @@ add_library(ailoy_cpp_shim STATIC ${AILOY_CPP_SHIM_SRCS})
 target_include_directories(ailoy_cpp_shim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(ailoy_cpp_shim PUBLIC ${AILOY_CXXBRIDGE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-########
-# json #
-########
-FetchContent_Declare(
-    nlohmann_json
-    URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/json
-    EXCLUDE_FROM_ALL
-)
-FetchContent_MakeAvailable(nlohmann_json)
-target_link_libraries(ailoy_cpp_shim PRIVATE nlohmann_json)
-
 #######
 # tvm #
 #######
@@ -167,6 +155,7 @@ set(TVM_BINARY_DIR ${BINARY_DIR})
 target_include_directories(ailoy_cpp_shim PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/include
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/ffi/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/picojson
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dlpack/include
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dmlc-core/include
 )

--- a/v2/shim/include/language_model.hpp
+++ b/v2/shim/include/language_model.hpp
@@ -7,7 +7,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include <rust/cxx.h>
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/ndarray.h>

--- a/v2/shim/include/tvm_runtime.hpp
+++ b/v2/shim/include/tvm_runtime.hpp
@@ -3,7 +3,7 @@
 #include <cstddef>
 
 #include <dlpack/dlpack.h>
-#include <nlohmann/json.hpp>
+#include <picojson.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
 
@@ -21,7 +21,7 @@ public:
     return vm_;
   }
 
-  const nlohmann::json &get_metadata() const { return metadata_; }
+  const picojson::object &get_metadata() const { return metadata_; }
 
   tvm::ffi::Function get_function(const std::string_view fname) {
     return *tvm::ffi::Function::GetGlobal(std::string(fname));
@@ -39,7 +39,7 @@ public:
 private:
   DLDevice device_;
   tvm::runtime::Module vm_;
-  nlohmann::json metadata_;
+  picojson::object metadata_;
   tvm::Array<tvm::runtime::NDArray> params_;
 };
 


### PR DESCRIPTION
## Description
This PR suggests to use `picojson` included in `tvm/3rdparty` already instead of nlohmann json added particularly.
In v2 C++, there are a few cases where JSON operations are used, but there are no cases where they are used externally.
Those cases all get only some attribute values from metadata, so can be replaced.