### PR TITLE
update build system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,6 @@ dependencies = [
  "async-stream",
  "cmake",
  "cxx",
- "cxx-build",
  "futures",
  "getrandom 0.3.3",
  "indexmap",
@@ -472,21 +471,6 @@ dependencies = [
  "cxxbridge-macro",
  "foldhash",
  "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.168"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d3cbb84fb003242941c231b45ca9417e786e66e94baa39584bd99df3a270b6"
-dependencies = [
- "cc",
- "codespan-reporting",
- "indexmap",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
 ]
 
 [[package]]
@@ -2331,12 +2315,6 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
-
-[[package]]
-name = "scratch"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -56,7 +56,6 @@ napi-build = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
 cmake = "0.1"
-cxx-build = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cxx = "1.0"
@@ -72,3 +71,4 @@ path = "src/lib.rs"
 [[bin]]
 name = "py_stub_gen"
 doc = false
+required-features = ["python"]

--- a/v2/build.rs
+++ b/v2/build.rs
@@ -12,147 +12,20 @@ fn main() {
 }
 
 fn build_native() {
-    use std::{
-        env,
-        fs::read_dir,
-        path::{Path, PathBuf},
-        process::Command,
-    };
+    use std::{env, path::PathBuf};
 
     use cmake::Config;
-
-    fn find_cargo_target_dir() -> PathBuf {
-        if let Ok(dir) = env::var("CARGO_TARGET_DIR") {
-            PathBuf::from(dir)
-        } else {
-            let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-            for ancestor in out_dir.ancestors() {
-                if ancestor.ends_with("build") {
-                    return ancestor
-                        .parent() // debug or release
-                        .and_then(|p| p.parent()) // target or custom root
-                        .expect("Invalid OUT_DIR structure")
-                        .to_path_buf();
-                }
-            }
-            panic!("Failed to determine target dir from OUT_DIR");
-        }
-    }
-
-    fn clone(name: &str, url: &str, dir: &Path) {
-        use std::fs;
-        use std::process::Command;
-
-        if dir.exists() {
-            println!("cargo:warning={} already exists. Skipping clone.", name);
-            return;
-        }
-
-        fs::create_dir_all(dir.parent().unwrap()).unwrap();
-
-        let status = Command::new("git")
-            .args([
-                "clone",
-                "--depth",
-                "1",
-                "--recursive",
-                url,
-                dir.to_str().unwrap(),
-            ])
-            .status()
-            .expect(&format!("Failed to run git clone for {}", name));
-
-        if !status.success() {
-            panic!("Git clone of {} failed", name);
-        }
-    }
-
-    fn copy_into_python_package(
-        lib_name: &str,
-        cmake_install_dir: &Path,
-        cargo_manifest_dir: &Path,
-    ) {
-        let src = cmake_install_dir.join(lib_name);
-        let dst_dir = cargo_manifest_dir.join("bindings/python/ailoy");
-        std::fs::copy(&src, dst_dir.join(lib_name)).expect("copy tvm_runtime");
-    }
 
     // Setup directories
     let cargo_manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let cmake_source_dir = cargo_manifest_dir.join("shim");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let cargo_target_dir = find_cargo_target_dir();
-    let cmake_binary_dir = out_dir.join("build");
-    let cmake_install_dir = out_dir
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("deps");
-    let cpp_include_files = read_dir(&cmake_source_dir.join("include"))
-        .expect("Failed to read cpp/include")
-        .filter_map(Result::ok)
-        .into_iter()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().map(|ext| ext == "hpp").unwrap_or(false))
-        .collect::<Vec<_>>();
-    let cpp_source_files = read_dir(&cmake_source_dir.join("src"))
-        .expect("Failed to read cpp/src")
-        .filter_map(Result::ok)
-        .into_iter()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().map(|ext| ext == "hpp").unwrap_or(false))
-        .collect::<Vec<_>>();
-    let cpp_files = cpp_include_files
-        .clone()
-        .into_iter()
-        .chain(cpp_source_files.clone().into_iter())
-        .collect::<Vec<_>>();
-
-    // Download if not exists
-    let tvm_dir = cmake_source_dir.join("3rdparty").join("tvm");
-    clone("tvm", "https://github.com/brekkylab/relax", &tvm_dir);
-
-    // Run cxx bridge
-    let mut cxx = cxx_build::bridge("src/ffi/cxx_bridge.rs");
-    for f in &cpp_source_files {
-        cxx.file(f);
-    }
-    cxx.flag_if_supported("-std=c++20")
-        .include(&cmake_source_dir.join("include"))
-        .include(&tvm_dir.join("include"))
-        .include(&tvm_dir.join("ffi").join("include"))
-        .include(&tvm_dir.join("3rdparty").join("picojson"))
-        .include(&tvm_dir.join("3rdparty").join("dlpack").join("include"))
-        .include(&tvm_dir.join("3rdparty").join("dmlc-core").join("include"))
-        .include(cargo_target_dir.join("cxxbridge"))
-        .compile("rust_bridge");
+    let cmake_install_dir = out_dir.parent().unwrap().join("deps");
 
     // Run CMake
     Config::new(&cmake_source_dir)
-        .env("CARGO_TARGET_DIR", &cargo_target_dir)
-        .define("TVM_ROOT", &tvm_dir)
         .define("CMAKE_INSTALL_PREFIX", &cmake_install_dir)
         .build();
-    Command::new("cmake")
-        .arg("--install")
-        .arg(&cmake_binary_dir)
-        .status()
-        .expect("failed to run cmake install");
-
-    // Copy to python package
-    if env::var("CARGO_FEATURE_PYTHON").is_ok() {
-        #[cfg(target_os = "macos")]
-        let tvm_lib_name = "libtvm_runtime.dylib";
-        #[cfg(target_os = "linux")]
-        let tvm_lib_name = "libtvm_runtime.so";
-        #[cfg(target_os = "windows")]
-        let tvm_lib_name = "tvm_runtime.dll";
-
-        copy_into_python_package(tvm_lib_name, &cmake_install_dir, &cargo_manifest_dir);
-    }
 
     // Link to this project
     println!("cargo:rustc-link-lib=c++");
@@ -161,17 +34,38 @@ fn build_native() {
         cmake_install_dir.display()
     );
     println!("cargo:rustc-link-lib=static=ailoy_cpp_shim");
-    println!("cargo:rustc-link-lib=dylib=tvm_runtime");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+
+    #[cfg(target_os = "linux")]
+    {
+        // Linux/ELF: ... -Wl,--whole-archive -l:libtvm_runtime.a -Wl,--no-whole-archive
+        println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+        println!("cargo:rustc-link-arg=-Wl,-l:libtvm_runtime.a");
+        println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // macOS: ... -Wl,-force_load,/abs/path/to/libtvm_runtime.a
+        println!(
+            "cargo:rustc-link-arg=-Wl,-force_load,{}",
+            (cmake_install_dir.join("libtvm_runtime.a")).display()
+        );
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // Windows (MSVC): ... tvm_runtime.lib /WHOLEARCHIVE:tvm_runtime.lib
+        println!("cargo:rustc-link-lib=static=tvm_runtime.lib");
+        println!(
+            "cargo:rustc-link-arg=/WHOLEARCHIVE:{}",
+            (cmake_install_dir.join("tvm_runtime.lib")).display()
+        );
+    }
 
     if std::env::var_os("CARGO_FEATURE_NODE").is_some() {
         napi_build::setup();
     }
 
-    // Add rerun targets
-    for f in &cpp_files {
-        println!("cargo:rerun-if-changed={}", f.display());
-    }
     println!(
         "cargo:rerun-if-changed={}",
         cmake_source_dir.join("CMakeLists.txt").display()

--- a/v2/shim/CMakeLists.txt
+++ b/v2/shim/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 # Avoid FetchContent warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 cmake_policy(SET CMP0135 NEW)
 
+include(FetchContent)
+
 ##################
 # Global options #
 ##################
@@ -45,11 +47,6 @@ project(ailoy CXX)
 
 set(AILOY_WITH_TEST ON CACHE BOOL "Build test")
 
-include(FetchContent)
-
-FetchContent_Declare(magic_enum URL https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.7.tar.gz EXCLUDE_FROM_ALL)
-FetchContent_MakeAvailable(magic_enum)
-
 if(AILOY_WITH_TEST)
     FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.tar.gz)
     set(INSTALL_GTEST OFF)
@@ -63,114 +60,157 @@ endif()
 ######################
 # ailoy (cxx bridge) #
 ######################
-# @jhlee: Can we remove hard-coded paths?
-set(CARGO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
-set(AILOY_CXXBRIDGE_RS ${CARGO_SOURCE_DIR}/src/ffi/cxx_bridge.rs)
-set(AILOY_CXXBRIDGE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cxx_bridge)
-set(AILOY_CXXBRIDGE_CC ${AILOY_CXXBRIDGE_DIR}/cxx_bridge.rs.cc)
-set(AILOY_CXXBRIDGE_H ${AILOY_CXXBRIDGE_DIR}/cxx_bridge.rs.h)
-set(AILOY_CXXBRIDGE_BASE_DIR ${AILOY_CXXBRIDGE_DIR}/rust)
-set(AILOY_CXXBRIDGE_BASE_H ${AILOY_CXXBRIDGE_BASE_DIR}/cxx.h)
-file(MAKE_DIRECTORY ${AILOY_CXXBRIDGE_DIR})
-file(MAKE_DIRECTORY ${AILOY_CXXBRIDGE_BASE_DIR})
+set(AILOY_CXXBRIDGE_RS ${PROJECT_SOURCE_DIR}/../src/ffi/cxx_bridge.rs CACHE FILEPATH "Path to the cxx_bridge.rs")
+set(AILOY_CXXBRIDGE_OUTDIR ${PROJECT_BINARY_DIR}/cxxbridge CACHE PATH "Output dir for cxxbridge generated files")
+set(AILOY_CXXBRIDGE_CC ${AILOY_CXXBRIDGE_OUTDIR}/cxx_bridge.rs.cc)
+set(AILOY_CXXBRIDGE_H ${AILOY_CXXBRIDGE_OUTDIR}/cxx_bridge.rs.h)
+set(AILOY_CXXBRIDGE_BASE_H ${AILOY_CXXBRIDGE_OUTDIR}/rust/cxx.h)
 
-# Create header file
-execute_process(
-    COMMAND cxxbridge ${AILOY_CXXBRIDGE_RS} --header
-    OUTPUT_FILE ${AILOY_CXXBRIDGE_H}
-    WORKING_DIRECTORY ${CARGO_SOURCE_DIR}
-    RESULT_VARIABLE ret
-)
-if(NOT ret EQUAL 0)
-    message(FATAL_ERROR "cxxbridge header generation failed ${AILOY_CXXBRIDGE_RS}")
-endif()
+# Ensure the cxxbridge CLI is available (cargo install cxxbridge-cmd)
+find_program(CXXBRIDGE_EXE NAMES cxxbridge REQUIRED)
 
-# Create source file
-execute_process(
-    COMMAND cxxbridge ${AILOY_CXXBRIDGE_RS}
-    OUTPUT_FILE ${AILOY_CXXBRIDGE_CC}
-    WORKING_DIRECTORY ${CARGO_SOURCE_DIR}
-    RESULT_VARIABLE ret
-)
-if(NOT ret EQUAL 0)
-    message(FATAL_ERROR "cxxbridge cpp generation failed")
-endif()
+# Create output directories at configure time
+file(MAKE_DIRECTORY ${AILOY_CXXBRIDGE_OUTDIR})
+file(MAKE_DIRECTORY ${AILOY_CXXBRIDGE_OUTDIR}/rust)
 
-# Get base header dir
-execute_process(
-    COMMAND cxxbridge --header
-    OUTPUT_FILE ${AILOY_CXXBRIDGE_BASE_H}
-    WORKING_DIRECTORY ${CARGO_SOURCE_DIR}
-    RESULT_VARIABLE ret
+# ---- Helper script to capture stdout -> file (portable) ----
+# cxxbridge prints to stdout; CMake COMMAND has no portable redirection.
+# We call a small CMake script that uses execute_process(OUTPUT_FILE ...).
+set(_CXXBRIDGE_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/_cxxbridge.cmake)
+file(WRITE "${_CXXBRIDGE_SCRIPT}" [=[
+  if(NOT DEFINED MODE)
+    message(FATAL_ERROR "MODE not set (header|cc|base_header)")
+  endif()
+  if(NOT DEFINED CXXBRIDGE_EXE)
+    message(FATAL_ERROR "cxxbridge-cmd not cound. Please install with `cargo install cxxbridge-cmd`.")
+  endif()
+  if("${MODE}" STREQUAL "header")
+    execute_process(COMMAND ${CXXBRIDGE_EXE} ${INPUT} --header OUTPUT_FILE ${OUTPUT} RESULT_VARIABLE rv COMMAND_ECHO STDOUT)
+  elseif("${MODE}" STREQUAL "cc")
+    execute_process(COMMAND ${CXXBRIDGE_EXE} ${INPUT} OUTPUT_FILE ${OUTPUT} RESULT_VARIABLE rv COMMAND_ECHO STDOUT)
+  elseif("${MODE}" STREQUAL "base_header")
+    execute_process(COMMAND ${CXXBRIDGE_EXE} --header OUTPUT_FILE ${OUTPUT} RESULT_VARIABLE rv COMMAND_ECHO STDOUT)
+  else()
+    message(FATAL_ERROR "Unknown MODE='${MODE}'")
+  endif()
+  if(NOT rv EQUAL 0)
+    message(FATAL_ERROR "cxxbridge failed: ${rv}")
+  endif()
+]=])
+
+# ---- Per-artifact custom commands (rebuilds only when inputs change) ----
+# Generate the C++ header from the Rust bridge
+add_custom_command(
+    OUTPUT ${AILOY_CXXBRIDGE_H}
+    COMMAND ${CMAKE_COMMAND}
+        -DCXXBRIDGE_EXE=${CXXBRIDGE_EXE}
+        -DINPUT=${AILOY_CXXBRIDGE_RS}
+        -DOUTPUT=${AILOY_CXXBRIDGE_H}
+        -DMODE=header
+        -P ${_CXXBRIDGE_SCRIPT}
+    DEPENDS ${AILOY_CXXBRIDGE_RS}
+    COMMENT "cxxbridge: generating ${AILOY_CXXBRIDGE_H}"
+    VERBATIM
 )
-if(NOT ret EQUAL 0)
-    message(FATAL_ERROR "cxxbridge cpp generation failed")
-endif()
+
+# Generate the C++ source from the Rust bridge
+add_custom_command(
+    OUTPUT "${AILOY_CXXBRIDGE_CC}"
+    COMMAND ${CMAKE_COMMAND}
+        -DCXXBRIDGE_EXE=${CXXBRIDGE_EXE}
+        -DINPUT=${AILOY_CXXBRIDGE_RS}
+        -DOUTPUT=${AILOY_CXXBRIDGE_CC}
+        -DMODE=cc
+        -P ${_CXXBRIDGE_SCRIPT}
+    DEPENDS ${AILOY_CXXBRIDGE_RS}
+    COMMENT "cxxbridge: generating ${AILOY_CXXBRIDGE_CC}"
+    VERBATIM
+)
+
+# Generate the base support header (cxx.h)
+add_custom_command(
+    OUTPUT ${AILOY_CXXBRIDGE_BASE_H}
+    COMMAND ${CMAKE_COMMAND}
+        -DCXXBRIDGE_EXE=${CXXBRIDGE_EXE}
+        -DOUTPUT=${AILOY_CXXBRIDGE_BASE_H}
+        -DMODE=base_header
+        -P ${_CXXBRIDGE_SCRIPT}
+    COMMENT "cxxbridge: generating ${AILOY_CXXBRIDGE_BASE_H}"
+    VERBATIM
+)
+
+# Aggregate target so others can depend on "generation done"
+add_custom_target(ailoy_cxxbridge_gen
+  DEPENDS "${AILOY_CXXBRIDGE_H}" "${AILOY_CXXBRIDGE_CC}" "${AILOY_CXXBRIDGE_BASE_H}"
+)
+
+# Mark generated for IDEs
+set_source_files_properties(${AILOY_CXXBRIDGE_H} PROPERTIES GENERATED TRUE)
+set_source_files_properties(${AILOY_CXXBRIDGE_CC} PROPERTIES GENERATED TRUE)
+set_source_files_properties(${AILOY_CXXBRIDGE_BASE_H} PROPERTIES GENERATED TRUE)
 
 ##################
 # ailoy_cpp_shim #
 ##################
-file(GLOB_RECURSE AILOY_CPP_SHIM_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp ${AILOY_CXXBRIDGE_CC})
+file(GLOB_RECURSE AILOY_CPP_SHIM_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_library(ailoy_cpp_shim STATIC ${AILOY_CPP_SHIM_SRCS})
-target_include_directories(ailoy_cpp_shim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(ailoy_cpp_shim PUBLIC ${AILOY_CXXBRIDGE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_dependencies(ailoy_cpp_shim ailoy_cxxbridge_gen)
+target_sources(ailoy_cpp_shim PRIVATE ${AILOY_CXXBRIDGE_CC})
+target_include_directories(ailoy_cpp_shim PUBLIC ${AILOY_CXXBRIDGE_OUTDIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 #######
 # tvm #
 #######
+FetchContent_Declare(
+    tvm
+    GIT_REPOSITORY https://github.com/brekkylab/relax.git
+    GIT_TAG e2aa6d0ebf9bd82632a510c00f3966eeee89e68a
+    EXCLUDE_FROM_ALL
+)
+set(CONDA_BUILD ON) # Actually it is not related to conda, but this is only way to disable python build
+set(BUILD_DUMMY_LIBTVM ON)
+set(BUILD_STATIC_RUNTIME ON)
+set(USE_LIBBACTRACE OFF)
+set(TVM_FFI_USE_LIBBACKTRACE OFF)
 if(APPLE)
     set(USE_METAL ON)
-    set(USE_VULKAN OFF)
     target_compile_definitions(ailoy_cpp_shim PUBLIC USE_METAL=1)
 elseif(WIN32)
-    set(USE_METAL OFF)
     set(USE_VULKAN ON)
     target_compile_definitions(ailoy_cpp_shim PUBLIC USE_VULKAN=1)
 elseif(LINUX)
-    set(USE_METAL OFF)
     set(USE_VULKAN ON)
     target_compile_definitions(ailoy_cpp_shim PUBLIC USE_VULKAN=1)
+elseif(EMSCRIPTEN)
 else()
     message(FATAL_ERROR "Not implemented")
 endif()
+FetchContent_MakeAvailable(tvm)
 
-# Define TVM root if not already defined
-include(ExternalProject)
-ExternalProject_Add(tvm_build
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target tvm_runtime --parallel 8
-    INSTALL_COMMAND ""
-    CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-        -DUSE_METAL=${USE_METAL}
-        -DUSE_VULKAN=${USE_VULKAN}
-        -DUSE_LIBBACKTRACE=OFF
-        -DBUILD_DUMMY_LIBTVM=ON
+# Hollow wrapper for TVM runtime.
+# The static TVM runtime must be linked with --whole-archive at the final link step.
+# Since `ailoy_cpp_shim` is an intermediate static library, we must NOT pull TVM symbols
+# into it. This INTERFACE target mirrors TVM’s usage requirements (include dirs,
+# compile definitions/options) without adding `tvm_runtime` to the link line.
+# Consumers (final executables/shared libs) should link `tvm_runtime` themselves, e.g.:
+#   target_link_libraries(my_exe PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,tvm_runtime>")
+add_library(tvm_runtime_hollow INTERFACE)
+target_include_directories(tvm_runtime_hollow INTERFACE
+    $<TARGET_PROPERTY:tvm_runtime,INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:tvm_runtime,INTERFACE_INCLUDE_DIRECTORIES>
 )
-
-# Include and link TVM headers/libraries manually
-ExternalProject_Get_Property(tvm_build BINARY_DIR)
-set(TVM_BINARY_DIR ${BINARY_DIR})
-
-target_include_directories(ailoy_cpp_shim PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/ffi/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/picojson
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dlpack/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dmlc-core/include
+target_compile_definitions(tvm_runtime_hollow INTERFACE
+    $<TARGET_PROPERTY:tvm_runtime,COMPILE_DEFINITIONS>
+    $<TARGET_PROPERTY:tvm_runtime,INTERFACE_COMPILE_DEFINITIONS>
 )
-
-add_library(tvm_runtime SHARED IMPORTED GLOBAL)
-set_target_properties(tvm_runtime PROPERTIES
-    IMPORTED_LOCATION ${TVM_BINARY_DIR}/libtvm_runtime.dylib
+target_compile_options(tvm_runtime_hollow INTERFACE
+    $<TARGET_PROPERTY:tvm_runtime,COMPILE_OPTIONS>
+    $<TARGET_PROPERTY:tvm_runtime,INTERFACE_COMPILE_OPTIONS>
 )
-add_dependencies(tvm_runtime tvm_build)
-target_link_libraries(ailoy_cpp_shim PUBLIC tvm_runtime)
-target_compile_definitions(ailoy_cpp_shim PUBLIC
-    DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>
-    AILOY_USE_TVM=1
-)
+add_dependencies(tvm_runtime_hollow tvm_runtime)
 
+# User of ailoy_cpp_shim should import tvm_runtime with whole-archive options
+target_link_libraries(ailoy_cpp_shim PRIVATE tvm_runtime_hollow)
 
 if(AILOY_WITH_TEST)
     add_executable(test_tvm ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tvm.cpp)
@@ -185,4 +225,4 @@ endif()
 ###########
 
 install(TARGETS ailoy_cpp_shim ARCHIVE DESTINATION .)
-install(FILES ${TVM_BINARY_DIR}/libtvm_runtime.dylib DESTINATION .)
+install(FILES ${tvm_BINARY_DIR}/libtvm_runtime.a DESTINATION .)


### PR DESCRIPTION
This PR aims to simplify the previous complex build system:

1. Removed the use of cxx-build on the Rust side. Instead, all CXX code generation is unified under CMake using `cxxbridge-cmd`.
2. Configured the build to produce `tvm_runtime.a`, so that Rust, Python, and Node no longer need to link against `tvm_runtime.so` explicitly.