### PR TITLE
Reduce duplicates using maybe-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "napi-derive",
  "onig",
  "ordered-float",
+ "parking_lot",
  "pyo3",
  "pyo3-async-runtimes",
  "pyo3-stub-gen",
@@ -1324,6 +1325,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1745,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2412,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -65,6 +65,7 @@ cmake = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cxx = "1.0"
 onig = "6"
+parking_lot = "0.12.4"
 rmcp = { version = "0.5.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client"] }
 tokenizers = { version = "0.21.4", default-features = false, features = ["onig"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }

--- a/v2/src/agent.rs
+++ b/v2/src/agent.rs
@@ -288,7 +288,6 @@ mod tests {
             .await?;
 
         let agent_tools = agent.get_tools();
-        println!("{:?}", agent_tools);
         assert_eq!(agent_tools.len(), 2);
         assert_eq!(
             agent_tools[0].get_description().name,

--- a/v2/src/cache/from_cache.rs
+++ b/v2/src/cache/from_cache.rs
@@ -1,8 +1,9 @@
 use std::pin::Pin;
 
-use futures::future::BoxFuture;
-
-use crate::cache::{Cache, CacheContents, CacheEntry};
+use crate::{
+    cache::{Cache, CacheContents, CacheEntry},
+    utils::{BoxFuture, MaybeSend},
+};
 
 /// Build a value by fetching the files it needs from the Ailoy [`Cache`].
 ///
@@ -60,7 +61,7 @@ use crate::cache::{Cache, CacheContents, CacheEntry};
 /// ```
 ///
 /// See also: [`Cache::try_create`], [`CacheEntry`], [`CacheContents`].
-pub trait TryFromCache: Sized + Send + 'static {
+pub trait TryFromCache: Sized + MaybeSend + 'static {
     /// Declare the set of files needed to construct `Self`.
     ///
     /// The returned future resolves to a list of logical entries (`dirname`/`filename`)

--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -1,6 +1,9 @@
+extern crate alloc;
+
 pub mod agent;
 pub mod cache;
 pub mod ffi;
 pub mod model;
 pub mod tool;
+pub mod utils;
 pub mod value;

--- a/v2/src/model/api/mod.rs
+++ b/v2/src/model/api/mod.rs
@@ -5,10 +5,10 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::{
     model::LanguageModel,
+    utils::{BoxFuture, BoxStream},
     value::{Message, MessageOutput, MessageStyle, OPENAI_FMT, StyledMessage, ToolDesc},
 };
 
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct APILanguageModel {
     model: String,
@@ -17,30 +17,11 @@ pub struct APILanguageModel {
         dyn Fn(
                 Vec<StyledMessage>,
                 Vec<ToolDesc>,
-            )
-                -> futures::future::BoxFuture<'static, Result<reqwest::Response, reqwest::Error>>
+            ) -> BoxFuture<'static, Result<reqwest::Response, reqwest::Error>>
             + Send
             + Sync,
     >,
     handle_response: Arc<dyn Fn(&mut Vec<u8>) -> Result<Vec<MessageOutput>, String> + Send + Sync>,
-}
-
-#[cfg(target_arch = "wasm32")]
-#[derive(Clone)]
-pub struct APILanguageModel {
-    model: String,
-    style: MessageStyle,
-    make_request: Arc<
-        dyn Fn(
-                Vec<StyledMessage>,
-                Vec<ToolDesc>,
-            ) -> futures::future::LocalBoxFuture<
-                'static,
-                Result<reqwest::Response, reqwest::Error>,
-            > + Send
-            + Sync,
-    >,
-    handle_response: Arc<dyn Fn(&mut Vec<u8>) -> Result<Vec<MessageOutput>, String>>,
 }
 
 impl APILanguageModel {
@@ -78,51 +59,12 @@ impl APILanguageModel {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl LanguageModel for APILanguageModel {
     fn run(
         self: Arc<Self>,
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
-    ) -> futures::stream::BoxStream<'static, Result<MessageOutput, String>> {
-        let msgs = msgs
-            .iter()
-            .map(|v| StyledMessage {
-                data: v.clone(),
-                style: self.style.clone(),
-            })
-            .collect::<Vec<_>>();
-        let req = (self.make_request)(msgs, tools);
-        let strm = async_stream::try_stream! {
-            let mut buf: Vec<u8> = Vec::with_capacity(8192);
-            let resp = req.await.map_err(|e| e.to_string())?;
-            if resp.status().is_success() {
-                let mut strm = resp.bytes_stream();
-                while let Some(chunk_res) = strm.next().await {
-                    let chunk = chunk_res.map_err(|e| e.to_string())?;
-                    buf.extend_from_slice(&chunk);
-                    let outs = (self.handle_response)(&mut buf)?;
-                    for v in outs {
-                        yield v;
-                    }
-                }
-            } else {
-                let status = resp.status();
-                let text = resp.text().await.unwrap_or_default();
-                Err(format!("Request failed: {} - {}", status, text))?;
-            }
-        };
-        Box::pin(strm)
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl LanguageModel for APILanguageModel {
-    fn run(
-        self: Arc<Self>,
-        msgs: Vec<Message>,
-        tools: Vec<ToolDesc>,
-    ) -> futures::stream::LocalBoxStream<'static, Result<MessageOutput, String>> {
+    ) -> BoxStream<'static, Result<MessageOutput, String>> {
         let msgs = msgs
             .iter()
             .map(|v| StyledMessage {

--- a/v2/src/model/api/openai.rs
+++ b/v2/src/model/api/openai.rs
@@ -1,43 +1,14 @@
-use crate::value::{MessageOutput, StyledMessage, StyledMessageOutput, ToolDesc};
+use crate::{
+    utils::BoxFuture,
+    value::{MessageOutput, StyledMessage, StyledMessageOutput, ToolDesc},
+};
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn make_request(
     model_name: &str,
     api_key: &str,
     msgs: Vec<StyledMessage>,
     tools: Vec<ToolDesc>,
-) -> futures::future::BoxFuture<'static, Result<reqwest::Response, reqwest::Error>> {
-    let mut body = serde_json::json!({
-        "model": model_name,
-        "messages": msgs,
-        "stream": true
-    });
-    if !tools.is_empty() {
-        body["tool_choice"] = serde_json::json!("auto");
-        body["tools"] = serde_json::to_value(tools).unwrap();
-    }
-
-    let req = reqwest::Client::new()
-        .request(
-            reqwest::Method::POST,
-            "https://api.openai.com/v1/chat/completions",
-        )
-        .bearer_auth(api_key)
-        .header("Content-Type", "application/json")
-        .header(reqwest::header::ACCEPT, "text/event-stream")
-        .body(body.to_string())
-        .send();
-
-    Box::pin(req)
-}
-
-#[cfg(target_arch = "wasm32")]
-pub fn make_request(
-    model_name: &str,
-    api_key: &str,
-    msgs: Vec<StyledMessage>,
-    tools: Vec<ToolDesc>,
-) -> futures::future::LocalBoxFuture<'static, Result<reqwest::Response, reqwest::Error>> {
+) -> BoxFuture<'static, Result<reqwest::Response, reqwest::Error>> {
     let mut body = serde_json::json!({
         "model": model_name,
         "messages": msgs,

--- a/v2/src/model/local/chat_template.rs
+++ b/v2/src/model/local/chat_template.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
-use futures::future::BoxFuture;
 use minijinja::{Environment, context};
 use minijinja_contrib::{add_to_environment, pycompat::unknown_method_callback};
 
 use crate::{
     cache::{Cache, CacheContents, CacheEntry, TryFromCache},
+    utils::BoxFuture,
     value::{Message, MessageStyle, QWEN3_FMT, StyledMessage, ToolDesc},
 };
 

--- a/v2/src/model/local/inferencer.rs
+++ b/v2/src/model/local/inferencer.rs
@@ -1,11 +1,11 @@
 #[cfg(any(target_family = "unix", target_family = "windows"))]
 mod tvm_runtime {
     use cxx::UniquePtr;
-    use futures::future::BoxFuture;
 
     use crate::{
         cache::{Cache, CacheContents, CacheEntry, TryFromCache},
         ffi::{TVMLanguageModel, create_dldevice, create_tvm_language_model},
+        utils::BoxFuture,
     };
 
     pub fn get_lib_extension() -> &'static str {
@@ -137,9 +137,10 @@ mod tvm_runtime {
 
 #[cfg(any(target_family = "wasm"))]
 mod tvmjs_runtime {
-    use futures::future::BoxFuture;
-
-    use crate::cache::{Cache, CacheContents, CacheEntry, TryFromCache};
+    use crate::{
+        cache::{Cache, CacheContents, CacheEntry, TryFromCache},
+        utils::BoxFuture,
+    };
 
     #[derive(Debug)]
     pub struct Inferencer {}

--- a/v2/src/model/local/tokenizer.rs
+++ b/v2/src/model/local/tokenizer.rs
@@ -1,9 +1,11 @@
 use std::str::FromStr;
 
-use futures::future::BoxFuture;
 use tokenizers::tokenizer::Tokenizer as HFTokenizer;
 
-use crate::cache::{Cache, CacheContents, CacheEntry, TryFromCache};
+use crate::{
+    cache::{Cache, CacheContents, CacheEntry, TryFromCache},
+    utils::BoxFuture,
+};
 
 #[derive(Debug, Clone)]
 pub struct Tokenizer {

--- a/v2/src/tool/builtin.rs
+++ b/v2/src/tool/builtin.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     tool::Tool,
+    utils::BoxFuture,
     value::{Part, ToolCallArg, ToolDesc},
 };
 
@@ -48,19 +49,7 @@ impl Tool for BuiltinTool {
         self.desc.clone()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    fn run(
-        self: Arc<Self>,
-        args: ToolCallArg,
-    ) -> futures::future::BoxFuture<'static, Result<Vec<Part>, String>> {
-        Box::pin(async move { Ok(vec![(self.f)(args)]) })
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn run(
-        self: Arc<Self>,
-        args: ToolCallArg,
-    ) -> futures::future::LocalBoxFuture<'static, Result<Vec<Part>, String>> {
+    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>> {
         Box::pin(async move { Ok(vec![(self.f)(args)]) })
     }
 }

--- a/v2/src/tool/mcp/native.rs
+++ b/v2/src/tool/mcp/native.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use rmcp::{
     model::CallToolRequestParam,
     service::{RoleClient, RunningService, ServiceExt},
@@ -12,6 +11,7 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::{
     tool::{Tool, mcp::common::*},
+    utils::BoxFuture,
     value::{Part, ToolCallArg, ToolDesc},
 };
 

--- a/v2/src/tool/mcp/wasm32.rs
+++ b/v2/src/tool/mcp/wasm32.rs
@@ -20,6 +20,7 @@ use crate::{
         Tool,
         mcp::common::{call_tool_result_to_parts, map_mcp_tool_to_tool_description},
     },
+    utils::BoxFuture,
     value::{Part, ToolCallArg, ToolDesc},
 };
 
@@ -331,10 +332,7 @@ impl Tool for MCPTool {
         self.desc.clone()
     }
 
-    fn run(
-        self: Arc<Self>,
-        args: ToolCallArg,
-    ) -> futures::future::LocalBoxFuture<'static, Result<Vec<Part>, String>> {
+    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>> {
         let client = self.client.clone();
 
         Box::pin(async move {

--- a/v2/src/tool/mod.rs
+++ b/v2/src/tool/mod.rs
@@ -4,27 +4,16 @@ mod mcp;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::value::{Part, ToolCallArg, ToolDesc};
+use crate::{
+    utils::BoxFuture,
+    value::{Part, ToolCallArg, ToolDesc},
+};
 
 pub use builtin::*;
 pub use mcp::*;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub trait Tool: Send + Sync + Debug + 'static {
-    fn get_description(&self) -> ToolDesc;
-
-    fn run(
-        self: Arc<Self>,
-        args: ToolCallArg,
-    ) -> futures::future::BoxFuture<'static, Result<Vec<Part>, String>>;
-}
-
-#[cfg(target_arch = "wasm32")]
 pub trait Tool: Debug + 'static {
     fn get_description(&self) -> ToolDesc;
 
-    fn run(
-        self: Arc<Self>,
-        args: ToolCallArg,
-    ) -> futures::future::LocalBoxFuture<'static, Result<Vec<Part>, String>>;
+    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>>;
 }

--- a/v2/src/utils/maybe_sync.rs
+++ b/v2/src/utils/maybe_sync.rs
@@ -1,0 +1,535 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod sync {
+    use core::{future::Future, pin::Pin};
+
+    use futures::stream::Stream;
+
+    /// Reexports of the actual marker traits from core.
+    pub use core::marker::{Send as MaybeSend, Sync as MaybeSync};
+
+    pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
+
+    pub type BoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + Send + 'a>>;
+
+    /// A pointer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A pointer type which can be shared, but only within single thread
+    /// where it was created when "sync" feature is not enabled.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use {maybe_sync::{MaybeSend, Rc}, std::fmt::Debug};
+    ///
+    /// fn maybe_sends<T: MaybeSend + Debug + 'static>(val: T) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSend` is alias to `std::marker::Send`.
+    ///     std::thread::spawn(move || { println!("{:?}", val) });
+    ///   }
+    /// }
+    ///
+    /// // Unlike `std::rc::Rc` this `maybe_sync::Rc` always satisfies `MaybeSend` bound.
+    /// maybe_sends(Rc::new(42));
+    /// ```
+    pub type Rc<T> = alloc::sync::Arc<T>;
+
+    /// Mutex implementation to use in conjunction with `MaybeSync` bound.
+    ///
+    /// A type alias to `parking_lot::Mutex` when "sync" feature is enabled.\
+    /// A wrapper type around `std::cell::RefCell` when "sync" feature is not enabled.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use {maybe_sync::{MaybeSend, Mutex}, std::{fmt::Debug, sync::Arc}};
+    ///
+    /// fn maybe_sends<T: MaybeSend + Debug + 'static>(val: Arc<Mutex<T>>) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSend` is alias to `std::marker::Send`,
+    ///     // and `Mutex` is `parking_lot::Mutex`.
+    ///     std::thread::spawn(move || { println!("{:?}", *val.lock()) });
+    ///   }
+    /// }
+    ///
+    /// // `maybe_sync::Mutex<T>` would always satisfy `MaybeSync` and `MaybeSend`
+    /// // bounds when `T: MaybeSend`,
+    /// // even if feature "sync" is enabeld.
+    /// maybe_sends(Arc::new(Mutex::new(42)));
+    /// ```
+    pub type Mutex<T> = parking_lot::Mutex<T>;
+
+    /// A boolean type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A boolean type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a bool.
+    pub type AtomicBool = core::sync::atomic::AtomicBool;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i8.
+    pub type AtomicI8 = core::sync::atomic::AtomicI8;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i16.
+    pub type AtomicI16 = core::sync::atomic::AtomicI16;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i32.
+    pub type AtomicI32 = core::sync::atomic::AtomicI32;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicIsize = core::sync::atomic::AtomicIsize;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i8.
+    pub type AtomicU8 = core::sync::atomic::AtomicU8;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i16.
+    pub type AtomicU16 = core::sync::atomic::AtomicU16;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i32.
+    pub type AtomicU32 = core::sync::atomic::AtomicU32;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicUsize = core::sync::atomic::AtomicUsize;
+
+    /// A raw pointer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A raw pointer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicPtr<T> = core::sync::atomic::AtomicPtr<T>;
+}
+
+#[cfg(target_arch = "wasm32")]
+mod unsync {
+    use core::cell::{RefCell, RefMut};
+
+    use core::{future::Future, pin::Pin};
+
+    use futures::stream::Stream;
+
+    /// Marker trait that can represent nothing if feature "sync" is not enabled.
+    /// Or be reexport of `std::marker::Send` if "sync" feature is enabled.
+    ///
+    /// It is intended to be used as trait bound where `std::marker::Send` bound
+    /// is required only when application is compiled for multithreaded environment.\
+    /// If "sync" feature is not enabled then this trait bound will *NOT* allow
+    /// value to cross thread boundary or be used where sendable value is expected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use {maybe_sync::MaybeSend, std::{fmt::Debug, rc::Rc}};
+    ///
+    /// fn maybe_sends<T: MaybeSend + Debug + 'static>(val: T) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSend` is alias to `std::marker::Send`.
+    ///     std::thread::spawn(move || { println!("{:?}", val) });
+    ///   }
+    /// }
+    ///
+    /// #[cfg(not(feature = "sync"))]
+    /// {
+    ///   // If this code is compiled then `MaybeSend` dummy markerd implemented for all types.
+    ///   maybe_sends(Rc::new(42));
+    /// }
+    /// ```
+    pub trait MaybeSend {}
+
+    /// All values are maybe sendable.
+    impl<T> MaybeSend for T where T: ?Sized {}
+
+    /// Marker trait that can represent nothing if feature "sync" is not enabled.
+    /// Or be reexport of `std::marker::Sync` if "sync" feature is enabled.
+    ///
+    /// It is intended to be used as trait bound where `std::marker::Sync` bound
+    /// is required only when application is compiled for multithreaded environment.\
+    /// If "sync" feature is not enabled then this trait bound will *NOT* allow
+    /// reference to the value to cross thread boundary or be used where sync
+    /// value is expected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use {maybe_sync::MaybeSync, std::{sync::Arc, fmt::Debug, cell::Cell}};
+    ///
+    /// fn maybe_shares<T: MaybeSync + Debug + 'static>(val: Arc<T>) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSync` is alias to `std::marker::Sync`.
+    ///     std::thread::spawn(move || { println!("{:?}", val) });
+    ///   }
+    /// }
+    ///
+    /// #[cfg(not(feature = "sync"))]
+    /// {
+    ///   // If this code is compiled then `MaybeSync` dummy markerd implemented for all types.
+    ///   maybe_shares(Arc::new(Cell::new(42)));
+    /// }
+    /// ```
+    pub trait MaybeSync {}
+
+    /// All values are maybe sync.
+    impl<T> MaybeSync for T where T: ?Sized {}
+
+    pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
+
+    pub type BoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + 'a>>;
+
+    /// A pointer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A pointer type which can be shared, but only within single thread
+    /// where it was created when "sync" feature is not enabled.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use {maybe_sync::{MaybeSend, Rc}, std::fmt::Debug};
+    ///
+    /// fn maybe_sends<T: MaybeSend + Debug + 'static>(val: T) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSend` is alias to `std::marker::Send`.
+    ///     std::thread::spawn(move || { println!("{:?}", val) });
+    ///   }
+    /// }
+    ///
+    /// // Unlike `std::rc::Rc` this `maybe_sync::Rc<T>` would always
+    /// // satisfy `MaybeSend` bound when `T: MaybeSend + MaybeSync`,
+    /// // even if feature "sync" is enabeld.
+    /// maybe_sends(Rc::new(42));
+    /// ```
+    pub type Rc<T> = alloc::rc::Rc<T>;
+
+    /// Mutex implementation to use in conjunction with `MaybeSync` bound.
+    ///
+    /// A type alias to `parking_lot::Mutex` when "sync" feature is enabled.\
+    /// A wrapper type around `std::cell::RefCell` when "sync" feature is not enabled.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use {maybe_sync::{MaybeSend, Mutex}, std::{fmt::Debug, sync::Arc}};
+    ///
+    /// fn maybe_sends<T: MaybeSend + Debug + 'static>(val: Arc<Mutex<T>>) {
+    ///   #[cfg(feature = "sync")]
+    ///   {
+    ///     // If this code is compiled then `MaybeSend` is alias to `std::marker::Send`,
+    ///     // and `Mutex` is `parking_lot::Mutex`.
+    ///     std::thread::spawn(move || { println!("{:?}", *val.lock()) });
+    ///   }
+    /// }
+    ///
+    /// // `maybe_sync::Mutex<T>` would always satisfy `MaybeSync` and `MaybeSend`
+    /// // bounds when `T: MaybeSend`,
+    /// // even if feature "sync" is enabeld.
+    /// maybe_sends(Arc::new(Mutex::new(42)));
+    /// ```
+    #[repr(transparent)]
+    #[derive(Debug, Default)]
+    pub struct Mutex<T: ?Sized> {
+        cell: RefCell<T>,
+    }
+
+    impl<T> Mutex<T> {
+        /// Creates a new mutex in an unlocked state ready for use.
+        pub fn new(value: T) -> Self {
+            Mutex {
+                cell: RefCell::new(value),
+            }
+        }
+    }
+
+    impl<T> Mutex<T>
+    where
+        T: ?Sized,
+    {
+        /// Acquires a mutex, blocking the current thread until it is able to do so.\
+        /// This function will block the local thread until it is available to acquire the mutex.\
+        /// Upon returning, the thread is the only thread with the mutex held.\
+        /// An RAII guard is returned to allow scoped unlock of the lock.\
+        /// When the guard goes out of scope, the mutex will be unlocked.\
+        /// Attempts to lock a mutex in the thread which already holds the lock will result in a deadlock.
+        pub fn lock(&self) -> RefMut<T> {
+            self.cell.borrow_mut()
+        }
+
+        /// Attempts to acquire this lock.\
+        /// If the lock could not be acquired at this time, then `None` is returned.\
+        /// Otherwise, an RAII guard is returned.\
+        /// The lock will be unlocked when the guard is dropped.\
+        /// This function does not block.
+        pub fn try_lock(&self) -> Option<RefMut<T>> {
+            self.cell.try_borrow_mut().ok()
+        }
+
+        /// Returns a mutable reference to the underlying data.\
+        /// Since this call borrows the `Mutex` mutably,\
+        /// no actual locking needs to take place -
+        /// the mutable borrow statically guarantees no locks exist.
+        pub fn get_mut(&mut self) -> &mut T {
+            self.cell.get_mut()
+        }
+    }
+
+    /// A boolean type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A boolean type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a bool.
+    pub type AtomicBool = core::cell::Cell<bool>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i8.
+    pub type AtomicI8 = core::cell::Cell<i8>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i16.
+    pub type AtomicI16 = core::cell::Cell<i16>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i32.
+    pub type AtomicI32 = core::cell::Cell<i32>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicIsize = core::cell::Cell<isize>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i8.
+    pub type AtomicU8 = core::cell::Cell<u8>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i16.
+    pub type AtomicU16 = core::cell::Cell<u16>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a i32.
+    pub type AtomicU32 = core::cell::Cell<u32>;
+
+    /// A integer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A integer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicUsize = core::cell::Cell<usize>;
+
+    /// A raw pointer type which can be safely shared between threads
+    /// when "sync" feature is enabled.\
+    /// A raw pointer type with non-threadsafe interior mutability
+    /// when "sync" feature is not enabled.
+    ///
+    /// This type has the same in-memory representation as a isize.
+    pub type AtomicPtr<T> = core::cell::Cell<*mut T>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use sync::*;
+
+#[cfg(target_arch = "wasm32")]
+pub use unsync::*;
+
+/// Expands to `dyn $traits` with `Send` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Send` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSend, dyn_maybe_send};
+/// fn foo<T: MaybeSend>(_: T) {}
+/// // `x` will implement `MaybeSend` whether "sync" feature is enabled or not.
+/// let x: Box<dyn_maybe_send!(std::future::Future<Output = u32>)> = Box::new(async move { 42 });
+/// foo(x);
+/// ```
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! dyn_maybe_send {
+    ($($traits:tt)+) => {
+        dyn $($traits)+ + Send
+    };
+}
+
+/// Expands to `dyn $traits` with `Send` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Send` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSend, dyn_maybe_send};
+/// fn foo<T: MaybeSend>(_: T) {}
+/// // `x` will implement `MaybeSend` whether "sync" feature is enabled or not.
+/// let x: Box<dyn_maybe_send!(std::future::Future<Output = u32>)> = Box::new(async move { 42 });
+/// foo(x);
+/// ```
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! dyn_maybe_send {
+    ($($traits:tt)+) => {
+        dyn $($traits)+
+    };
+}
+
+/// Expands to `dyn $traits` with `Sync` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Sync` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSync, dyn_maybe_sync};
+/// fn foo<T: MaybeSync + ?Sized>(_: &T) {}
+///
+/// let x: &dyn_maybe_sync!(AsRef<str>) = &"qwerty";
+/// // `x` will implement `MaybeSync` whether "sync" feature is enabled or not.
+/// foo(x);
+/// ```
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! dyn_maybe_sync {
+    ($($traits:tt)+) => {
+        dyn $($traits)+ + Sync
+    };
+}
+
+/// Expands to `dyn $traits` with `Sync` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Sync` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSync, dyn_maybe_sync};
+/// fn foo<T: MaybeSync + ?Sized>(_: &T) {}
+/// // `x` will implement `MaybeSync` whether "sync" feature is enabled or not.
+/// let x: &dyn_maybe_sync!(AsRef<str>) = &"qwerty";
+/// foo(x);
+/// ```
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! dyn_maybe_sync {
+    ($($traits:tt)+) => {
+        dyn $($traits)+
+    };
+}
+
+/// Expands to `dyn $traits` with `Send` and `Sync` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Send` and `Sync` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSend, MaybeSync, dyn_maybe_send_sync};
+/// fn foo<T: MaybeSend + MaybeSync + ?Sized>(_: &T) {}
+/// // `x` will implement `MaybeSend` and `MaybeSync` whether "sync" feature is enabled or not.
+/// let x: &dyn_maybe_send_sync!(AsRef<str>) = &"qwerty";
+/// foo(x);
+/// ```
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! dyn_maybe_send_sync {
+    ($($traits:tt)+) => {
+        dyn $($traits)+ + Send + Sync
+    };
+}
+
+/// Expands to `dyn $traits` with `Sync` marker trait
+/// added when "sync" feature is enabled.
+///
+/// Expands to `dyn $traits` without `Sync` marker trait
+/// added "sync" feature is not enabled.
+///
+/// # Example
+/// ```
+/// # use maybe_sync::{MaybeSend, MaybeSync, dyn_maybe_send_sync};
+/// fn foo<T: MaybeSend + MaybeSync + ?Sized>(_: &T) {}
+/// // `x` will implement `MaybeSend` and `MaybeSync` whether "sync" feature is enabled or not.
+/// let x: &dyn_maybe_send_sync!(AsRef<str>) = &"qwerty";
+/// foo(x);
+/// ```
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! dyn_maybe_send_sync {
+    ($($traits:tt)+) => {
+        dyn $($traits)+
+    };
+}

--- a/v2/src/utils/mod.rs
+++ b/v2/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod maybe_sync;
+
+pub use maybe_sync::*;


### PR DESCRIPTION
This PR applies a patched version of [maybe-sync](https://docs.rs/maybe-sync/latest/maybe_sync/) to remove duplicated codes originiated from `Send` and `Sync`.