### PR TITLE
Enable Gemini

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -139,5 +139,8 @@
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.cargo.features": [],
     // "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
-    "rust-analyzer.procMacro.enable": true
+    "rust-analyzer.procMacro.enable": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "debug"
+    }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,8 +893,6 @@ dependencies = [
 [[package]]
 name = "gemini-rust"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4349322f0de046b481d1c29d9376498c0d35fde9e4cc4da7a748198dfe2f80e0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -904,7 +902,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
  "url",
 ]
 
@@ -2250,6 +2247,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -2861,7 +2859,6 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
 [[package]]
 name = "gemini-rust"
 version = "1.1.0"
+source = "git+https://github.com/brekkylab/gemini-rust.git?branch=main#f49284ee87a8fcee4c7d62bbb29c003b325e3a5d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,12 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-stream",
+ "base64 0.21.7",
  "cmake",
  "cxx",
+ "dotenv",
  "futures",
+ "gemini-rust",
  "getrandom 0.3.3",
  "indexmap",
  "js-sys",
@@ -145,6 +148,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +190,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -644,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dtor"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +888,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gemini-rust"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4349322f0de046b481d1c29d9376498c0d35fde9e4cc4da7a748198dfe2f80e0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -2817,6 +2861,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,8 @@ dependencies = [
  "base64 0.21.7",
  "cmake",
  "cxx",
- "dotenv",
+ "dotenvy",
+ "env_logger",
  "futures",
  "gemini-rust",
  "getrandom 0.3.3",
@@ -102,10 +103,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -375,6 +420,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -664,10 +715,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtor"
@@ -703,6 +754,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1295,6 +1369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1397,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1700,6 +1804,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "onig"
@@ -2247,7 +2357,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3112,6 +3221,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -15,7 +15,7 @@ async-channel = "2.5"
 async-stream = "0.3"
 base64 = "0.21"
 futures = "0.3.31"
-gemini-rust = "1.1.0"
+gemini-rust = { path = "../../gemini-rust" }
 indexmap = { version = "2", features = ["serde"] }
 log = "0.4.27"
 minijinja = { version = "2.11.0", features = ["loader", "custom_syntax", "json"] }

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -15,7 +15,7 @@ async-channel = "2.5"
 async-stream = "0.3"
 base64 = "0.21"
 futures = "0.3.31"
-gemini-rust = { path = "../../gemini-rust" }
+gemini-rust = { git = "https://github.com/brekkylab/gemini-rust.git", branch = "main" }
 indexmap = { version = "2", features = ["serde"] }
 minijinja = { version = "2.11.0", features = ["loader", "custom_syntax", "json"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -17,7 +17,6 @@ base64 = "0.21"
 futures = "0.3.31"
 gemini-rust = { path = "../../gemini-rust" }
 indexmap = { version = "2", features = ["serde"] }
-log = "0.4.27"
 minijinja = { version = "2.11.0", features = ["loader", "custom_syntax", "json"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }
 napi = { version = "3", features = ["tokio_rt"], optional = true }
@@ -58,14 +57,9 @@ web-sys = { version = "0.3", features = [
     "console"
 ] }
 
-[build-dependencies]
-napi-build = "2"
-
-[target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
-cmake = "0.1"
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cxx = "1.0"
+log = "0.4.27"
 onig = "6"
 parking_lot = "0.12.4"
 rmcp = { version = "0.5.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client"] }
@@ -76,7 +70,14 @@ tokio = { version = "1.0", default-features = false, features = ["macros", "rt-m
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-dotenv = "0.15"
+env_logger = "0.11.8"
+
+[build-dependencies]
+dotenvy = "0.15.7"
+napi-build = "2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
+cmake = "0.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -13,7 +13,9 @@ default = []
 anyhow = "1"
 async-channel = "2.5"
 async-stream = "0.3"
+base64 = "0.21"
 futures = "0.3.31"
+gemini-rust = "1.1.0"
 indexmap = { version = "2", features = ["serde"] }
 log = "0.4.27"
 minijinja = { version = "2.11.0", features = ["loader", "custom_syntax", "json"] }
@@ -72,6 +74,9 @@ tokio = { version = "1.0", default-features = false, features = ["macros", "rt-m
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+dotenv = "0.15"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/v2/bindings/python/ailoy/_core.pyi
+++ b/v2/bindings/python/ailoy/_core.pyi
@@ -78,14 +78,16 @@ class Part:
     def url(self) -> typing.Optional[builtins.str]: ...
     @property
     def data(self) -> typing.Optional[builtins.str]: ...
-    def __new__(cls, part_type:builtins.str, *, text:typing.Optional[builtins.str]=None, url:typing.Optional[builtins.str]=None, data:typing.Optional[builtins.str]=None, function:typing.Optional[builtins.str]=None, id:typing.Optional[builtins.str]=None, name:typing.Optional[builtins.str]=None, arguments:typing.Optional[builtins.str]=None) -> Part:
+    @property
+    def mime_type(self) -> typing.Optional[builtins.str]: ...
+    def __new__(cls, part_type:builtins.str, *, text:typing.Optional[builtins.str]=None, url:typing.Optional[builtins.str]=None, data:typing.Optional[builtins.str]=None, mime_type:typing.Optional[builtins.str]=None, function:typing.Optional[builtins.str]=None, id:typing.Optional[builtins.str]=None, name:typing.Optional[builtins.str]=None, arguments:typing.Optional[builtins.str]=None) -> Part:
         r"""
         Part(part_type, *, id=None, text=None, url=None, data=None, function=None)
         
         Examples:
         - Part(part_type="text", text="hello")
         - Part(part_type="image", url="https://example.com/cat.png")
-        - Part(part_type="image", data="<base64>")  # 'base64=' alias also accepted
+        - Part(part_type="image", data="<base64>", mime_type="image/jpeg")  # 'base64=' alias also accepted
         - Part(part_type="function", function='{"name":"foo","arguments":"{}"}')
         """
 

--- a/v2/build.rs
+++ b/v2/build.rs
@@ -3,6 +3,17 @@ fn main() {
     let target = std::env::var("TARGET").expect("TARGET not set");
     println!("cargo:rustc-env=BUILD_TARGET_TRIPLE={}", target);
 
+    // Load .env file at build time if exists
+    if let Ok(path) = std::env::var("CARGO_MANIFEST_DIR") {
+        let env_path = std::path::Path::new(&path).join(".env");
+        if env_path.exists() {
+            for item in dotenvy::dotenv_iter().expect("Failed to read .env file") {
+                let (key, value) = item.expect("Failed to parse .env line");
+                println!("cargo:rustc-env={}={}", key, value);
+            }
+        }
+    }
+
     if target.starts_with("wasm") {
         return;
     } else {

--- a/v2/src/agent.rs
+++ b/v2/src/agent.rs
@@ -122,9 +122,9 @@ impl Agent {
                         };
                         let tool = tools.iter().find(|v| v.get_description().get_name() == tc.name).unwrap().clone();
                         let resp = tool.run(tc.arguments).await?;
-                        let delta = Message::with_role(Role::Tool).with_contents(resp.clone());
+                        let delta = Message::with_role(Role::Tool(tc.name.clone())).with_contents(resp.clone());
                         yield MessageOutput::new().with_delta(delta);
-                        let tool_msg = Message::with_role(Role::Tool).with_contents(resp);
+                        let tool_msg = Message::with_role(Role::Tool(tc.name)).with_contents(resp);
                         msgs.lock().await.push(tool_msg);
                     }
                 }
@@ -135,7 +135,7 @@ impl Agent {
                         let tool = tools.iter().find(|v| v.get_description().name == tc.name).unwrap().clone();
                         let parts = tool.run(tc.arguments).await?;
                         for part in parts.into_iter() {
-                            let tool_msg = Message::with_role(Role::Tool).with_contents([part.clone()]);
+                            let tool_msg = Message::with_role(Role::Tool(tc.name.clone())).with_contents([part.clone()]);
                             yield MessageOutput{ delta: tool_msg.clone(), finish_reason: Some(FinishReason::Stop)};
                             self.messages.lock().await.push(tool_msg);
                         }

--- a/v2/src/model/api/gemini.rs
+++ b/v2/src/model/api/gemini.rs
@@ -1,0 +1,377 @@
+use std::sync::Arc;
+
+use futures::stream::StreamExt;
+use gemini_rust::{
+    Content as GeminiContent, FunctionCall as GeminiFunctionCall,
+    FunctionDeclaration as GeminiFunctionDeclaration,
+    FunctionParameters as GeminiFunctionParameters, Gemini,
+    GenerationResponse as GeminiGenerationResponse, Message as GeminiMessage, Role as GeminiRole,
+    Tool as GeminiTool,
+};
+pub use gemini_rust::{
+    GenerationConfig as GeminiGenerationConfig, ThinkingConfig as GeminiThinkingConfig,
+};
+
+use crate::{
+    model::LanguageModel,
+    utils::BoxStream,
+    value::{FinishReason, Message, MessageOutput, Part, Role, ToolDesc},
+};
+
+#[derive(Clone)]
+pub struct GeminiLanguageModel {
+    model_name: String,
+    inner: Gemini,
+    config: GeminiGenerationConfig,
+}
+
+impl GeminiLanguageModel {
+    pub fn new(model_name: impl Into<String>, api_key: impl Into<String>) -> Self {
+        let model_name: String = model_name.into();
+        let inner = Gemini::with_model(api_key.into(), format!("models/{}", model_name.clone()));
+        Self {
+            model_name,
+            inner,
+            config: GeminiGenerationConfig::default(),
+        }
+    }
+
+    pub fn with_config(&mut self, config: GeminiGenerationConfig) -> Self {
+        self.config = config;
+        self.clone()
+    }
+}
+
+fn gemini_response_to_ailoy(response: &GeminiGenerationResponse) -> Result<MessageOutput, String> {
+    let candidate = response.candidates[0].clone();
+
+    // https://ai.google.dev/api/generate-content#FinishReason
+    let finish_reason = match candidate.finish_reason {
+        Some(finish_reason) => match finish_reason.as_str() {
+            "STOP" => {
+                if candidate.content.parts.len() > 0 {
+                    // Gemini does not provide "ToolCalls" finish reason explicitly,
+                    // so we infer it by checking if there's FunctionCall part.
+                    let part = candidate.content.parts[0].clone();
+                    match part {
+                        gemini_rust::Part::FunctionCall { .. } => Some(FinishReason::ToolCalls),
+                        _ => Some(FinishReason::Stop),
+                    }
+                } else {
+                    Some(FinishReason::Stop)
+                }
+            }
+            "MAX_TOKENS" => {
+                if !response.thoughts().is_empty() {
+                    // Gemini can return MAX_TOKENS finish reason if it was thinking and it has been finished.
+                    // In this case, the finish reason should not be set, and the generation should be continued.
+                    None
+                } else {
+                    Some(FinishReason::Length)
+                }
+            }
+            "SAFETY" | "RECITATION" | "LANGUAGE" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII"
+            | "IMAGE_SAFETY" => Some(FinishReason::ContentFilter),
+            _ => Some(FinishReason::Stop),
+        },
+        None => None,
+    };
+
+    let mut message = Message::new();
+    message.role = Some(Role::Assistant);
+    for part in candidate.content.parts.iter() {
+        match part {
+            gemini_rust::Part::Text { text, thought } => {
+                if thought.is_some_and(|b| b) {
+                    message.reasoning = text.clone();
+                } else {
+                    message.contents.push(Part::Text(text.clone()));
+                }
+            }
+            gemini_rust::Part::FunctionCall { function_call } => {
+                message.tool_calls.push(Part::new_function(
+                    "",
+                    function_call.name.clone(),
+                    function_call.args.to_string(),
+                ));
+            }
+            gemini_rust::Part::InlineData { .. } => {
+                todo!("Gemini outputs other than text is not supported")
+            }
+            gemini_rust::Part::FunctionResponse { .. } => {
+                panic!("Function Response cannot be returned from model")
+            }
+        }
+    }
+
+    let output = MessageOutput {
+        delta: message,
+        finish_reason,
+    };
+
+    Ok(output)
+}
+
+impl LanguageModel for GeminiLanguageModel {
+    fn run(
+        self: Arc<Self>,
+        msgs: Vec<Message>,
+        tools: Vec<ToolDesc>,
+    ) -> BoxStream<'static, Result<MessageOutput, String>> {
+        let mut content = self.inner.generate_content();
+
+        // Parse messages
+        for msg in msgs.iter() {
+            match &msg.role {
+                Some(role) => match role {
+                    Role::System => {
+                        content = content.with_system_prompt(msg.contents[0].as_str().unwrap());
+                    }
+                    Role::User => {
+                        let part = msg.contents[0].clone();
+                        match part {
+                            Part::Text(text) => {
+                                content = content.with_user_message(text);
+                            }
+                            Part::ImageData(base64, mime_type) => {
+                                content = content.with_message(GeminiMessage {
+                                    role: GeminiRole::User,
+                                    content: GeminiContent::inline_data(mime_type, base64),
+                                });
+                            }
+                            Part::ImageURL(_) => {
+                                panic!("Gemini does not support public image URL input")
+                            }
+                            _ => panic!("This part cannot belong to user"),
+                        }
+                    }
+                    Role::Assistant => {
+                        if msg.contents.len() > 0 {
+                            let part = msg.contents[0].clone();
+                            match part {
+                                Part::Text(text) => {
+                                    content = content.with_model_message(text);
+                                }
+                                _ => panic!("This part cannot belong to assistant contents"),
+                            }
+                        } else if msg.tool_calls.len() > 0 {
+                            let tc = msg.tool_calls[0].clone();
+                            match tc {
+                                Part::Function {
+                                    name, arguments, ..
+                                } => {
+                                    let function_call =
+                                        GeminiContent::function_call(GeminiFunctionCall {
+                                            name: name,
+                                            args: serde_json::from_str(arguments.as_str()).unwrap(),
+                                        });
+                                    content = content.with_message(GeminiMessage {
+                                        content: function_call,
+                                        role: GeminiRole::Model,
+                                    });
+                                }
+                                Part::FunctionString(_) => {
+                                    panic!("Function call should be in a completed form")
+                                }
+                                _ => panic!("This part cannot belong to assistant tool_calls"),
+                            }
+                        } else {
+                            panic!("Assistant message does not have any content")
+                        }
+                    }
+                    Role::Tool(tool_name) => {
+                        content = content.with_function_response(
+                            tool_name,
+                            serde_json::from_str(&msg.contents[0].as_str().unwrap()).unwrap(),
+                        );
+                    }
+                },
+                None => {
+                    panic!("Message role should not be None");
+                }
+            }
+        }
+
+        // Parse tools
+        content = content.with_tool(GeminiTool::with_functions(
+            tools
+                .iter()
+                .map(|tool| {
+                    let tool_params = serde_json::to_value(&tool.parameters).unwrap();
+                    let function_params =
+                        serde_json::from_value::<GeminiFunctionParameters>(tool_params).unwrap();
+                    GeminiFunctionDeclaration::new(
+                        tool.name.clone(),
+                        tool.description.clone(),
+                        function_params,
+                    )
+                })
+                .collect(),
+        ));
+
+        // Set generation config
+        content = content.with_generation_config(self.config.clone());
+
+        let strm = async_stream::try_stream! {
+            let mut stream = content.execute_stream().await.unwrap();
+            while let Some(resp) = stream.next().await {
+                let resp = resp.map_err(|e| e.to_string()).unwrap();
+                let output = gemini_response_to_ailoy(&resp)?;
+                yield output;
+            }
+        };
+        Box::pin(strm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::sync::LazyLock;
+
+    use dotenv::dotenv;
+
+    static GEMINI_API_KEY: LazyLock<String> = LazyLock::new(|| {
+        dotenv().ok();
+        env::var("GEMINI_API_KEY").unwrap_or_else(|_| {
+            eprintln!("Warning: GEMINI_API_KEY is not set");
+            "".to_string()
+        })
+    });
+
+    #[tokio::test]
+    async fn gemini_infer_with_thinking() {
+        use super::*;
+        use crate::value::MessageAggregator;
+
+        let mut gemini_config = GeminiGenerationConfig::default();
+        gemini_config.max_output_tokens = Some(2048);
+        gemini_config.thinking_config =
+            Some(GeminiThinkingConfig::default().with_thoughts_included(true));
+        let gemini = Arc::new(
+            GeminiLanguageModel::new("gemini-2.5-flash", GEMINI_API_KEY.as_str())
+                .with_config(gemini_config),
+        );
+
+        let msgs = vec![
+            Message::with_role(Role::System).with_contents(vec![Part::Text(
+                "You are a helpful mathematics assistant.".to_owned(),
+            )]),
+            Message::with_role(Role::User).with_contents(vec![Part::Text(
+                "What is the sum of the first 50 prime numbers?".to_owned(),
+            )]),
+        ];
+        let mut agg = MessageAggregator::new();
+        let mut strm = gemini.run(msgs, Vec::new());
+        while let Some(delta_opt) = strm.next().await {
+            let delta = delta_opt.unwrap();
+            println!("{:?}", delta);
+            if let Some(msg) = agg.update(delta) {
+                println!("{:?}", msg);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn gemini_infer_tool_call() {
+        use super::*;
+        use crate::value::{MessageAggregator, ToolDescArg};
+
+        let gemini = Arc::new(GeminiLanguageModel::new(
+            "gemini-2.5-flash",
+            GEMINI_API_KEY.as_str(),
+        ));
+
+        let tools = vec![ToolDesc::new(
+            "temperature",
+            "Get current temperature",
+            ToolDescArg::new_object().with_properties(
+                [
+                    (
+                        "location",
+                        ToolDescArg::new_string().with_desc("The city name"),
+                    ),
+                    (
+                        "unit",
+                        ToolDescArg::new_string()
+                            .with_enum(["Celcius", "Fernheit"])
+                            .with_desc("The unit of temperature"),
+                    ),
+                ],
+                ["location", "unit"],
+            ),
+            Some(
+                ToolDescArg::new_number().with_desc("Null if the given city name is unavailable."),
+            ),
+        )];
+        let mut msgs = vec![Message::with_role(Role::User).with_contents([Part::Text(
+            "How much hot currently in Dubai? Answer in Celcius.".to_owned(),
+        )])];
+        let mut agg = MessageAggregator::new();
+        let mut strm = gemini.clone().run(msgs.clone(), tools.clone());
+        let mut assistant_msg: Option<Message> = None;
+        while let Some(delta_opt) = strm.next().await {
+            println!("{:?}", delta_opt);
+            let delta = delta_opt.unwrap();
+            if let Some(msg) = agg.update(delta) {
+                assistant_msg = Some(msg);
+            }
+        }
+        // This should be tool call message
+        let assistant_msg = assistant_msg.unwrap();
+        msgs.push(assistant_msg);
+
+        // Append a fake tool call result message
+        let tool_result_msg = Message::with_role(Role::Tool("temperature".into()))
+            .with_contents(vec![Part::Text("{\"temperature\": 38.5}".into())]);
+        msgs.push(tool_result_msg);
+
+        let mut strm = gemini.run(msgs, tools);
+        let mut assistant_msg: Option<Message> = None;
+        while let Some(delta_opt) = strm.next().await {
+            println!("{:?}", delta_opt);
+            let delta = delta_opt.unwrap();
+            if let Some(msg) = agg.update(delta) {
+                assistant_msg = Some(msg);
+            }
+        }
+        // Final message shuold say something like "Dubai is 38.5°C"
+        let assistant_msg = assistant_msg.unwrap();
+        println!("Final Answer: {:?}", assistant_msg);
+    }
+
+    #[tokio::test]
+    async fn gemini_infer_with_image() {
+        use super::*;
+        use crate::value::MessageAggregator;
+
+        use base64::Engine;
+
+        let test_image_url =
+            "https://cdn.britannica.com/60/257460-050-62FF74CB/NVIDIA-Jensen-Huang.jpg?w=385";
+        let response = reqwest::get(test_image_url).await.unwrap();
+        let image_bytes = response.bytes().await.unwrap();
+        let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
+
+        let gemini = Arc::new(GeminiLanguageModel::new(
+            "gemini-2.5-flash",
+            GEMINI_API_KEY.as_str(),
+        ));
+
+        let msgs = vec![
+            Message::with_role(Role::User)
+                .with_contents(vec![Part::ImageData(image_base64, "image/jpeg".into())]),
+            Message::with_role(Role::User)
+                .with_contents(vec![Part::Text("What is shown in this image?".to_owned())]),
+        ];
+        let mut agg = MessageAggregator::new();
+        let mut strm = gemini.run(msgs, Vec::new());
+        while let Some(delta_opt) = strm.next().await {
+            let delta = delta_opt.unwrap();
+            println!("{:?}", delta);
+            if let Some(msg) = agg.update(delta) {
+                println!("{:?}", msg);
+            }
+        }
+    }
+}

--- a/v2/src/model/api/mod.rs
+++ b/v2/src/model/api/mod.rs
@@ -1,3 +1,4 @@
+mod gemini;
 mod openai;
 
 use futures::StreamExt;
@@ -8,6 +9,7 @@ use crate::{
     utils::{BoxFuture, BoxStream},
     value::{Message, MessageOutput, MessageStyle, OPENAI_FMT, StyledMessage, ToolDesc},
 };
+pub use gemini::*;
 
 #[derive(Clone)]
 pub struct APILanguageModel {
@@ -154,7 +156,9 @@ mod tests {
                     ),
                     (
                         "unit",
-                        ToolDescArg::new_string().with_enum(["Celcius", "Fernheit"]),
+                        ToolDescArg::new_string()
+                            .with_enum(["Celcius", "Fernheit"])
+                            .with_desc("The unit of temperature"),
                     ),
                 ],
                 ["location", "unit"],

--- a/v2/src/model/local/local_language_model.rs
+++ b/v2/src/model/local/local_language_model.rs
@@ -304,7 +304,7 @@ mod tests {
             Message::with_role(Role::Assistant)
                 .with_contents([Part::new_text("\n\n")])
                 .with_tool_calls([Part::new_function_string("\n{\"name\": \"temperature\", \"arguments\": {\"location\": \"Dubai\", \"unit\": \"Celcius\"}}\n")]),
-            Message::with_role(Role::Tool).with_contents([Part::new_text("40")])
+            Message::with_role(Role::Tool("temperature".into())).with_contents([Part::new_text("40")])
         ];
         let mut agg = MessageAggregator::new();
         let mut strm = model.run(msgs, tools);

--- a/v2/src/tool/mcp/common.rs
+++ b/v2/src/tool/mcp/common.rs
@@ -114,7 +114,7 @@ pub fn call_tool_result_to_parts(result: &CallToolResult) -> anyhow::Result<Vec<
             .iter()
             .map(|c| match c.raw.clone() {
                 RawContent::Text(text) => Part::Text(text.text),
-                RawContent::Image(image) => Part::ImageData(image.data),
+                RawContent::Image(image) => Part::ImageData(image.data, image.mime_type),
                 // RawContent::Audio(audio) => Part::Audio {
                 //     data: audio.data.clone(),
                 //     format: audio.mime_type.replace(r"^audio\/", ""),

--- a/v2/src/tool/mcp/native.rs
+++ b/v2/src/tool/mcp/native.rs
@@ -158,7 +158,7 @@ mod tests {
         let part = parts[0].clone();
         assert_eq!(part.is_text(), true);
 
-        let parsed_part: serde_json::Value = serde_json::from_str(part.as_str().unwrap()).unwrap();
+        let parsed_part: serde_json::Value = serde_json::from_str(&part.as_str().unwrap()).unwrap();
         assert_eq!(parsed_part["timezone"].as_str(), Some("Asia/Seoul"));
         assert_eq!(parsed_part["is_dst"].as_bool(), Some(false));
         assert_eq!(

--- a/v2/src/tool/mcp/wasm32.rs
+++ b/v2/src/tool/mcp/wasm32.rs
@@ -191,13 +191,9 @@ impl StreamableHttpClient {
                 let message: ServerJsonRpcMessage = response.json().await?;
                 Ok(StreamableHttpPostResponse::Json(message, session_id))
             }
-            _ => {
-                // unexpected content type
-                log::error!("unexpected content type: {:?}", content_type);
-                Err(StreamableHttpError::UnexpectedContentType(
-                    content_type.map(|ct| String::from_utf8_lossy(ct.as_bytes()).to_string()),
-                ))
-            }
+            _ => Err(StreamableHttpError::UnexpectedContentType(
+                content_type.map(|ct| String::from_utf8_lossy(ct.as_bytes()).to_string()),
+            )),
         }
     }
 
@@ -382,6 +378,7 @@ pub async fn mcp_tools_from_streamable_http(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::log;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -392,7 +389,7 @@ mod tests {
         client.initialize().await?;
 
         let list_tools = client.list_tools().await?;
-        web_sys::console::log_1(&format!("list of tools: {:?}", list_tools).into());
+        log::debug(&format!("list of tools: {:?}", list_tools));
 
         let call_tool = client
             .call_tool(CallToolRequestParam {
@@ -406,7 +403,7 @@ mod tests {
             })
             .await
             .unwrap();
-        web_sys::console::log_1(&format!("call tool result: {:?}", call_tool).into());
+        log::debug(&format!("call tool result: {:?}", call_tool));
 
         Ok(())
     }
@@ -420,7 +417,7 @@ mod tests {
             serde_json::json!({"latitude": 32.7767, "longitude": -96.797}),
         )?;
         let parts = tool.run(args).await.unwrap();
-        web_sys::console::log_1(&format!("tool call result: {:?}", parts).into());
+        log::debug(&format!("tool call result: {:?}", parts));
 
         Ok(())
     }

--- a/v2/src/utils/log.rs
+++ b/v2/src/utils/log.rs
@@ -1,0 +1,37 @@
+#[cfg(not(target_arch = "wasm32"))]
+use log;
+
+#[cfg(target_arch = "wasm32")]
+use web_sys;
+
+pub fn debug(s: impl Into<String> + std::fmt::Display) {
+    #[cfg(not(target_arch = "wasm32"))]
+    log::debug!("{}", s);
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::debug_1(&s.to_string().into());
+}
+
+pub fn info(s: impl Into<String> + std::fmt::Display) {
+    #[cfg(not(target_arch = "wasm32"))]
+    log::info!("{}", s);
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::info_1(&s.to_string().into());
+}
+
+pub fn warn(s: impl Into<String> + std::fmt::Display) {
+    #[cfg(not(target_arch = "wasm32"))]
+    log::warn!("{}", s);
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::warn_1(&s.to_string().into());
+}
+
+pub fn error(s: impl Into<String> + std::fmt::Display) {
+    #[cfg(not(target_arch = "wasm32"))]
+    log::error!("{}", s);
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::error_1(&s.to_string().into());
+}

--- a/v2/src/utils/mod.rs
+++ b/v2/src/utils/mod.rs
@@ -1,3 +1,6 @@
-mod maybe_sync;
+pub mod log;
+pub mod maybe_sync;
+#[cfg(test)]
+mod test;
 
 pub use maybe_sync::*;

--- a/v2/src/utils/test.rs
+++ b/v2/src/utils/test.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! multi_platform_test {
+    ($(#[$meta:meta])* $vis:vis async fn $name:ident($($args:tt)*) $body:block) => {
+        $(#[$meta])*
+        #[tokio::test]
+        $vis async fn $name($($args)*) {
+            let _ = env_logger::builder().is_test(true).try_init();
+            $body
+        }
+    };
+}
+
+#[cfg(test)]
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! multi_platform_test {
+    ($(#[$meta:meta])* $vis:vis async fn $name:ident($($args:tt)*) $body:block) => {
+        $(#[$meta])*
+        #[wasm_bindgen_test::wasm_bindgen_test]
+        $vis async fn $name($($args)*) $body
+    };
+}

--- a/v2/src/value/formats.rs
+++ b/v2/src/value/formats.rs
@@ -41,7 +41,8 @@ mod tests {
                     "get_something",
                     "{\"WhatToGet\": \"name\"}",
                 )]),
-            StyledMessage::with_role(Role::Tool).with_contents([Part::Text(String::from("Jaden"))]),
+            StyledMessage::with_role(Role::Tool("get_something".into()))
+                .with_contents([Part::Text(String::from("Jaden"))]),
             StyledMessage::with_role(Role::Assistant)
                 .with_contents([Part::Text(String::from("You can call me Jaden."))]),
         ]

--- a/v2/src/value/message.rs
+++ b/v2/src/value/message.rs
@@ -22,7 +22,7 @@ pub enum Role {
     Assistant,
     /// Outputs produced by external tools/functions, typically in
     /// response to an assistant tool call (and often correlated via `tool_call_id`).
-    Tool,
+    Tool(String),
 }
 
 /// Represents a complete chat message composed of multiple parts (multi-modal).


### PR DESCRIPTION
This PR adds Gemini functionalities with the same coverage as in cpp.

In addition, some utilities are included to make multi-platform tests more simpler.
- To make a test runnable on both native and browser, just wrap it with `multi_platform_test!` macro.
- Use `crate::utils::log` to print logs in both native and browser.
- Reads `GEMINI_API_KEY` env var from `.env` at compile time, and forward it on both native and browser tests.

## Notes
It requires https://github.com/flachesis/gemini-rust/pull/7 to be merged in order to run on wasm. Until then, it's downloaded from our forked repo.