### PR TITLE
tools: replace Arc<Self> with self

### DIFF
--- a/v2/src/knowledge_base/api/chroma.rs
+++ b/v2/src/knowledge_base/api/chroma.rs
@@ -276,7 +276,6 @@ impl VectorStore for ChromaStore {
 mod tests {
     use super::*;
     use serde_json::json;
-    use tokio;
 
     use ailoy_macros::multi_platform_test;
 

--- a/v2/src/tool/builtin.rs
+++ b/v2/src/tool/builtin.rs
@@ -3,9 +3,10 @@ use std::{
     sync::Arc,
 };
 
+use ailoy_macros::multi_platform_async_trait;
+
 use crate::{
     tool::Tool,
-    utils::BoxFuture,
     value::{Part, ToolCallArg, ToolDesc},
 };
 
@@ -44,13 +45,15 @@ impl BuiltinTool {
     }
 }
 
+#[multi_platform_async_trait]
 impl Tool for BuiltinTool {
     fn get_description(&self) -> ToolDesc {
         self.desc.clone()
     }
 
-    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>> {
-        Box::pin(async move { Ok(vec![(self.f)(args)]) })
+    async fn run(&self, args: ToolCallArg) -> Result<Vec<Part>, String> {
+        let tool_func = self.f.clone();
+        Ok(vec![tool_func(args)])
     }
 }
 

--- a/v2/src/tool/mcp/native.rs
+++ b/v2/src/tool/mcp/native.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ailoy_macros::multi_platform_async_trait;
 use rmcp::{
     model::CallToolRequestParam,
     service::{RoleClient, RunningService, ServiceExt},
@@ -11,7 +12,6 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::{
     tool::{Tool, mcp::common::*},
-    utils::BoxFuture,
     value::{Part, ToolCallArg, ToolDesc},
 };
 
@@ -58,34 +58,34 @@ struct MCPTool {
     pub desc: ToolDesc,
 }
 
+#[multi_platform_async_trait]
 impl Tool for MCPTool {
     fn get_description(&self) -> ToolDesc {
         self.desc.clone()
     }
 
-    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>> {
+    async fn run(&self, args: ToolCallArg) -> Result<Vec<Part>, String> {
+        let tool_name = self.name.clone();
         let peer = self.client.service.clone();
 
-        Box::pin(async move {
-            // Convert your ToolCall arguments → serde_json::Map (MCP expects JSON object)
-            let arguments: Option<JsonMap<String, JsonValue>> = serde_json::to_value(args)
-                .map_err(|e| format!("serialize ToolCall arguments failed: {e}"))?
-                .as_object()
-                .cloned();
+        // Convert your ToolCall arguments → serde_json::Map (MCP expects JSON object)
+        let arguments: Option<JsonMap<String, JsonValue>> = serde_json::to_value(args)
+            .map_err(|e| format!("serialize ToolCall arguments failed: {e}"))?
+            .as_object()
+            .cloned();
 
-            // Invoke the MCP tool
-            let result = peer
-                .call_tool(CallToolRequestParam {
-                    name: self.name.clone().into(),
-                    arguments,
-                })
-                .await
-                .map_err(|e| format!("mcp call_tool failed: {e}"))?;
+        // Invoke the MCP tool
+        let result = peer
+            .call_tool(CallToolRequestParam {
+                name: tool_name.into(),
+                arguments,
+            })
+            .await
+            .map_err(|e| format!("mcp call_tool failed: {e}"))?;
 
-            let parts = call_tool_result_to_parts(&result)
-                .map_err(|e| format!("call_tool_result_to_parts failed: {e}"))?;
-            Ok(parts)
-        })
+        let parts = call_tool_result_to_parts(&result)
+            .map_err(|e| format!("call_tool_result_to_parts failed: {e}"))?;
+        Ok(parts)
     }
 }
 
@@ -149,10 +149,7 @@ mod tests {
             Box::new(ToolCallArg::String("Asia/Seoul".into())),
         );
 
-        let parts = Arc::new(tool)
-            .run(ToolCallArg::Object(tool_call_args))
-            .await
-            .unwrap();
+        let parts = tool.run(ToolCallArg::Object(tool_call_args)).await.unwrap();
         assert_eq!(parts.len(), 1);
 
         let part = parts[0].clone();

--- a/v2/src/tool/mod.rs
+++ b/v2/src/tool/mod.rs
@@ -2,18 +2,17 @@ mod builtin;
 mod mcp;
 
 use std::fmt::Debug;
-use std::sync::Arc;
 
-use crate::{
-    utils::BoxFuture,
-    value::{Part, ToolCallArg, ToolDesc},
-};
+use ailoy_macros::multi_platform_async_trait;
+
+use crate::value::{Part, ToolCallArg, ToolDesc};
 
 pub use builtin::*;
 pub use mcp::*;
 
+#[multi_platform_async_trait]
 pub trait Tool: Debug + 'static {
     fn get_description(&self) -> ToolDesc;
 
-    fn run(self: Arc<Self>, args: ToolCallArg) -> BoxFuture<'static, Result<Vec<Part>, String>>;
+    async fn run(&self, args: ToolCallArg) -> Result<Vec<Part>, String>;
 }

--- a/v2/src/utils/maybe_sync.rs
+++ b/v2/src/utils/maybe_sync.rs
@@ -292,7 +292,7 @@ mod unsync {
         /// An RAII guard is returned to allow scoped unlock of the lock.\
         /// When the guard goes out of scope, the mutex will be unlocked.\
         /// Attempts to lock a mutex in the thread which already holds the lock will result in a deadlock.
-        pub fn lock(&self) -> RefMut<T> {
+        pub fn lock(&'_ self) -> RefMut<'_, T> {
             self.cell.borrow_mut()
         }
 
@@ -301,7 +301,7 @@ mod unsync {
         /// Otherwise, an RAII guard is returned.\
         /// The lock will be unlocked when the guard is dropped.\
         /// This function does not block.
-        pub fn try_lock(&self) -> Option<RefMut<T>> {
+        pub fn try_lock(&'_ self) -> Option<RefMut<'_, T>> {
             self.cell.try_borrow_mut().ok()
         }
 


### PR DESCRIPTION
Tool trait's `.run()` is now async and does not need to return `BoxFuture`.
But it still needs to be dyn compatible, so applied `multi_platform_async_trait`.