### PR TITLE
change language model trait to mutable ref

### DIFF
--- a/v2/src/model/api/anthropic.rs
+++ b/v2/src/model/api/anthropic.rs
@@ -230,11 +230,11 @@ fn anthropic_stream_event_to_ailoy(
 }
 
 impl LanguageModel for AnthropicLanguageModel {
-    fn run(
-        self: std::sync::Arc<Self>,
+    fn run<'a>(
+        self: &'a mut Self,
         msgs: Vec<crate::value::Message>,
         tools: Vec<crate::value::ToolDesc>,
-    ) -> BoxStream<'static, Result<crate::value::MessageOutput, String>> {
+    ) -> BoxStream<'a, Result<crate::value::MessageOutput, String>> {
         let mut params = CreateMessageParams::new(RequiredMessageParams {
             model: self.model_name.clone(),
             messages: vec![],
@@ -442,23 +442,20 @@ impl LanguageModel for AnthropicLanguageModel {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use crate::value::{MessageAggregator, ToolDesc, ToolDescArg};
     use ailoy_macros::multi_platform_test;
 
-    const ANTHROPIC_API_KEY: &str = env!("ANTHROPIC_API_KEY");
+    const ANTHROPIC_API_KEY: Option<&str> = option_env!("ANTHROPIC_API_KEY");
 
     #[multi_platform_test]
     async fn anthropic_infer_with_thinking() {
         let mut config = AnthropicGenerationConfig::default();
         config.max_tokens = 2048;
         config.thinking = Some(AnthropicThinkingConfig::default());
-        let anthropic = Arc::new(
-            AnthropicLanguageModel::new("claude-sonnet-4-20250514", ANTHROPIC_API_KEY)
-                .with_config(config),
-        );
+        let mut anthropic =
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", ANTHROPIC_API_KEY.unwrap())
+                .with_config(config);
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -480,10 +477,8 @@ mod tests {
 
     #[multi_platform_test]
     async fn anthropic_infer_tool_call() {
-        let anthropic = Arc::new(AnthropicLanguageModel::new(
-            "claude-sonnet-4-20250514",
-            ANTHROPIC_API_KEY,
-        ));
+        let mut anthropic =
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", ANTHROPIC_API_KEY.unwrap());
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -511,13 +506,15 @@ mod tests {
             "How much hot currently in Dubai? Answer in Celcius.".to_owned(),
         )])];
         let mut agg = MessageAggregator::new();
-        let mut strm = anthropic.clone().run(msgs.clone(), tools.clone());
         let mut assistant_msg: Option<Message> = None;
-        while let Some(delta_opt) = strm.next().await {
-            let delta = delta_opt.unwrap();
-            if let Some(msg) = agg.update(delta) {
-                log::info(format!("{:?}", msg).as_str());
-                assistant_msg = Some(msg);
+        {
+            let mut strm = anthropic.run(msgs.clone(), tools.clone());
+            while let Some(delta_opt) = strm.next().await {
+                let delta = delta_opt.unwrap();
+                if let Some(msg) = agg.update(delta) {
+                    log::info(format!("{:?}", msg).as_str());
+                    assistant_msg = Some(msg);
+                }
             }
         }
         // This should be tool call message
@@ -554,10 +551,8 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let anthropic = Arc::new(AnthropicLanguageModel::new(
-            "claude-sonnet-4-20250514",
-            ANTHROPIC_API_KEY,
-        ));
+        let mut anthropic =
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", ANTHROPIC_API_KEY.unwrap());
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/openai.rs
+++ b/v2/src/model/api/openai.rs
@@ -56,11 +56,11 @@ mod tests {
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
 
-    const OPENAI_API_KEY: &str = env!("OPENAI_API_KEY");
+    const OPENAI_API_KEY: Option<&str> = option_env!("OPENAI_API_KEY");
 
     #[multi_platform_test]
     async fn openai_infer_with_thinking() {
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("o3-mini", OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("o3-mini", OPENAI_API_KEY.unwrap());
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -86,7 +86,7 @@ mod tests {
         use super::*;
         use crate::value::{MessageAggregator, ToolDescArg};
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY.unwrap());
         let tools = vec![ToolDesc::new(
             "temperature",
             "Get current temperature",
@@ -113,14 +113,16 @@ mod tests {
             "How much hot currently in Dubai? Answer in Celcius.".to_owned(),
         )])];
         let mut agg = MessageAggregator::new();
-        let mut strm = model.clone().run(msgs.clone(), tools.clone());
         let mut assistant_msg: Option<Message> = None;
-        while let Some(delta_opt) = strm.next().await {
-            let delta = delta_opt.unwrap();
-            log::debug(format!("{:?}", delta).as_str());
-            if let Some(msg) = agg.update(delta) {
-                log::info(format!("{:?}", msg).as_str());
-                assistant_msg = Some(msg);
+        {
+            let mut strm = model.run(msgs.clone(), tools.clone());
+            while let Some(delta_opt) = strm.next().await {
+                let delta = delta_opt.unwrap();
+                log::debug(format!("{:?}", delta).as_str());
+                if let Some(msg) = agg.update(delta) {
+                    log::info(format!("{:?}", msg).as_str());
+                    assistant_msg = Some(msg);
+                }
             }
         }
         // This should be tool call message
@@ -161,7 +163,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY.unwrap());
         let msgs = vec![
             Message::with_role(Role::User)
                 .with_contents(vec![Part::ImageData(image_base64, "image/jpeg".into())]),
@@ -210,9 +212,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let model = std::sync::Arc::new(
-            OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY).with_config(config),
-        );
+        let mut model =
+            OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY.unwrap()).with_config(config);
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/openai_chat_completion.rs
+++ b/v2/src/model/api/openai_chat_completion.rs
@@ -286,8 +286,8 @@ impl<T> LanguageModel for T
 where
     T: OpenAIChatCompletion + Clone,
 {
-    fn run(
-        self: std::sync::Arc<Self>,
+    fn run<'a>(
+        self: &'a mut Self,
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
     ) -> BoxStream<'static, Result<MessageOutput, String>> {

--- a/v2/src/model/api/xai.rs
+++ b/v2/src/model/api/xai.rs
@@ -65,11 +65,11 @@ mod tests {
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
 
-    const XAI_API_KEY: &str = env!("XAI_API_KEY");
+    const XAI_API_KEY: Option<&str> = option_env!("XAI_API_KEY");
 
     #[multi_platform_test]
     async fn xai_infer_with_thinking() {
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3-mini", XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-3-mini", XAI_API_KEY.unwrap());
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -94,7 +94,7 @@ mod tests {
     async fn xai_infer_tool_call() {
         use crate::value::ToolDescArg;
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3", XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-3", XAI_API_KEY.unwrap());
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -122,14 +122,16 @@ mod tests {
             "How much hot currently in Dubai? Answer in Celcius.".to_owned(),
         )])];
         let mut agg = MessageAggregator::new();
-        let mut strm = xai.clone().run(msgs.clone(), tools.clone());
         let mut assistant_msg: Option<Message> = None;
-        while let Some(delta_opt) = strm.next().await {
-            let delta = delta_opt.unwrap();
-            log::debug(format!("{:?}", delta).as_str());
-            if let Some(msg) = agg.update(delta) {
-                log::info(format!("{:?}", msg).as_str());
-                assistant_msg = Some(msg);
+        {
+            let mut strm = xai.run(msgs.clone(), tools.clone());
+            while let Some(delta_opt) = strm.next().await {
+                let delta = delta_opt.unwrap();
+                log::debug(format!("{:?}", delta).as_str());
+                if let Some(msg) = agg.update(delta) {
+                    log::info(format!("{:?}", msg).as_str());
+                    assistant_msg = Some(msg);
+                }
             }
         }
         // This should be tool call message
@@ -167,7 +169,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-4", XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-4", XAI_API_KEY.unwrap());
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/language_model.rs
+++ b/v2/src/model/language_model.rs
@@ -3,10 +3,8 @@ use crate::{
     value::{Message, MessageOutput, ToolDesc},
 };
 
-/// Runs the language model with the given tools and messages, returning a stream of `MessageOutput`s.
 pub trait LanguageModel: MaybeSend + MaybeSync {
-    // Runs the language model with the given tools and messages, returning a stream of `MessageOutput`s.
-    /// See [`LanguageModel`] trait document for the details.
+    /// Runs the language model with the given tools and messages, returning a stream of `MessageOutput`s.
     fn run<'a>(
         self: &'a mut Self,
         msg: Vec<Message>,


### PR DESCRIPTION
previous trait spec:
```
pub trait LanguageModel: MaybeSend + MaybeSync + 'static {
    fn run(
        self: Arc<Self>,
        msg: Vec<Message>,
        tools: Vec<ToolDesc>,
    ) -> BoxStream<'static, Result<MessageOutput, String>>;
}
```

to

```
pub trait LanguageModel: MaybeSend + MaybeSync {
    fn run<'a>(
        self: &'a mut Self,
        msg: Vec<Message>,
        tools: Vec<ToolDesc>,
    ) -> BoxStream<'a, Result<MessageOutput, String>>;
}
```

So that it is not necessary to force Arc<dyn LanguageModel> as a container type(+ do not force stream lifetime to static)