### PR TITLE
fix: use `LazyLock` and `option_env!` instead of `env!` for the tests

### DIFF
--- a/v2/src/model/api/anthropic.rs
+++ b/v2/src/model/api/anthropic.rs
@@ -447,8 +447,12 @@ mod tests {
     use super::*;
     use crate::value::{MessageAggregator, ToolDesc, ToolDescArg};
     use ailoy_macros::multi_platform_test;
+    use std::sync::LazyLock;
 
-    const ANTHROPIC_API_KEY: &str = env!("ANTHROPIC_API_KEY");
+    static ANTHROPIC_API_KEY: LazyLock<&'static str> = LazyLock::new(|| {
+        option_env!("ANTHROPIC_API_KEY")
+            .expect("Environment variable 'ANTHROPIC_API_KEY' is required for the tests.")
+    });
 
     #[multi_platform_test]
     async fn anthropic_infer_with_thinking() {
@@ -456,7 +460,7 @@ mod tests {
         config.max_tokens = 2048;
         config.thinking = Some(AnthropicThinkingConfig::default());
         let anthropic = Arc::new(
-            AnthropicLanguageModel::new("claude-sonnet-4-20250514", ANTHROPIC_API_KEY)
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", *ANTHROPIC_API_KEY)
                 .with_config(config),
         );
 
@@ -482,7 +486,7 @@ mod tests {
     async fn anthropic_infer_tool_call() {
         let anthropic = Arc::new(AnthropicLanguageModel::new(
             "claude-sonnet-4-20250514",
-            ANTHROPIC_API_KEY,
+            *ANTHROPIC_API_KEY,
         ));
 
         let tools = vec![ToolDesc::new(
@@ -556,7 +560,7 @@ mod tests {
 
         let anthropic = Arc::new(AnthropicLanguageModel::new(
             "claude-sonnet-4-20250514",
-            ANTHROPIC_API_KEY,
+            *ANTHROPIC_API_KEY,
         ));
 
         let msgs = vec![

--- a/v2/src/model/api/gemini.rs
+++ b/v2/src/model/api/gemini.rs
@@ -231,8 +231,12 @@ impl LanguageModel for GeminiLanguageModel {
 mod tests {
     use crate::utils::log;
     use ailoy_macros::multi_platform_test;
+    use std::sync::LazyLock;
 
-    const GEMINI_API_KEY: &str = env!("GEMINI_API_KEY");
+    static GEMINI_API_KEY: LazyLock<&'static str> = LazyLock::new(|| {
+        option_env!("GEMINI_API_KEY")
+            .expect("Environment variable 'GEMINI_API_KEY' is required for the tests.")
+    });
 
     #[multi_platform_test]
     async fn gemini_infer_with_thinking() {
@@ -244,7 +248,8 @@ mod tests {
         gemini_config.thinking_config =
             Some(GeminiThinkingConfig::default().with_thoughts_included(true));
         let gemini = Arc::new(
-            GeminiLanguageModel::new("gemini-2.5-flash", GEMINI_API_KEY).with_config(gemini_config),
+            GeminiLanguageModel::new("gemini-2.5-flash", *GEMINI_API_KEY)
+                .with_config(gemini_config),
         );
 
         let msgs = vec![
@@ -271,7 +276,10 @@ mod tests {
         use super::*;
         use crate::value::{MessageAggregator, ToolDescArg};
 
-        let gemini = Arc::new(GeminiLanguageModel::new("gemini-2.5-flash", GEMINI_API_KEY));
+        let gemini = Arc::new(GeminiLanguageModel::new(
+            "gemini-2.5-flash",
+            *GEMINI_API_KEY,
+        ));
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -342,7 +350,10 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let gemini = Arc::new(GeminiLanguageModel::new("gemini-2.5-flash", GEMINI_API_KEY));
+        let gemini = Arc::new(GeminiLanguageModel::new(
+            "gemini-2.5-flash",
+            *GEMINI_API_KEY,
+        ));
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/openai.rs
+++ b/v2/src/model/api/openai.rs
@@ -55,12 +55,16 @@ mod tests {
     use crate::value::{Message, MessageAggregator, Part, Role, ToolDesc};
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
+    use std::sync::LazyLock;
 
-    const OPENAI_API_KEY: &str = env!("OPENAI_API_KEY");
+    static OPENAI_API_KEY: LazyLock<&'static str> = LazyLock::new(|| {
+        option_env!("OPENAI_API_KEY")
+            .expect("Environment variable 'OPENAI_API_KEY' is required for the tests.")
+    });
 
     #[multi_platform_test]
     async fn openai_infer_with_thinking() {
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("o3-mini", OPENAI_API_KEY));
+        let model = std::sync::Arc::new(OpenAILanguageModel::new("o3-mini", *OPENAI_API_KEY));
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -86,7 +90,7 @@ mod tests {
         use super::*;
         use crate::value::{MessageAggregator, ToolDescArg};
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY));
+        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY));
         let tools = vec![ToolDesc::new(
             "temperature",
             "Get current temperature",
@@ -161,7 +165,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY));
+        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY));
         let msgs = vec![
             Message::with_role(Role::User)
                 .with_contents(vec![Part::ImageData(image_base64, "image/jpeg".into())]),
@@ -211,7 +215,7 @@ mod tests {
             .unwrap();
 
         let model = std::sync::Arc::new(
-            OpenAILanguageModel::new("gpt-4.1", OPENAI_API_KEY).with_config(config),
+            OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY).with_config(config),
         );
 
         let msgs = vec![

--- a/v2/src/model/api/xai.rs
+++ b/v2/src/model/api/xai.rs
@@ -64,12 +64,16 @@ mod tests {
     use crate::value::{Message, MessageAggregator, Part, Role, ToolDesc};
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
+    use std::sync::LazyLock;
 
-    const XAI_API_KEY: &str = env!("XAI_API_KEY");
+    static XAI_API_KEY: LazyLock<&'static str> = LazyLock::new(|| {
+        option_env!("XAI_API_KEY")
+            .expect("Environment variable 'XAI_API_KEY' is required for the tests.")
+    });
 
     #[multi_platform_test]
     async fn xai_infer_with_thinking() {
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3-mini", XAI_API_KEY));
+        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3-mini", *XAI_API_KEY));
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -94,7 +98,7 @@ mod tests {
     async fn xai_infer_tool_call() {
         use crate::value::ToolDescArg;
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3", XAI_API_KEY));
+        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3", *XAI_API_KEY));
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -167,7 +171,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-4", XAI_API_KEY));
+        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-4", *XAI_API_KEY));
 
         let msgs = vec![
             Message::with_role(Role::User)


### PR DESCRIPTION
## Description
We're currently using the `env!` macro to provide an API key at compile time for use in tests.
`env!` causes a compile error if the corresponding environment variable doesn't exist at compile time. However, since the code is compiled when building with the test target, the corresponding environment variable must be present, even if empty, even when building tests unrelated to the environment variable. This negatively impacts the unit testability of modules.

Therefore, we're retrieving the environment variable at compile time, but using `std::sync::LazyLock` to generate an error when attempting to use it, and maintaining it static.