### PR TITLE
Add `rustfmt.toml` config for consistent formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     },
     "[rust]": {
         "editor.formatOnSave": true,
+        "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },
     "cmake.configureOnOpen": true,
     "cmake.configureArgs": [
@@ -142,5 +143,8 @@
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "debug"
-    }
+    },
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ],
 }

--- a/v2/macros/Cargo.toml
+++ b/v2/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ailoy-macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/v2/macros/src/lib.rs
+++ b/v2/macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Item, ItemFn};
+use syn::{Item, ItemFn, parse_macro_input};
 
 #[proc_macro_attribute]
 pub fn multi_platform_test(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/v2/rustfmt.toml
+++ b/v2/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2024"
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/v2/src/agent.rs
+++ b/v2/src/agent.rs
@@ -267,8 +267,7 @@ mod tests {
         use futures::StreamExt;
 
         use super::*;
-        use crate::model::LocalLanguageModel;
-        use crate::tool::MCPTransport;
+        use crate::{model::LocalLanguageModel, tool::MCPTransport};
 
         let cache = crate::cache::Cache::new();
         let key = "Qwen/Qwen3-0.6B";

--- a/v2/src/cache/cache.rs
+++ b/v2/src/cache/cache.rs
@@ -10,14 +10,13 @@ use futures::{Stream, StreamExt as _, stream::FuturesUnordered};
 use tokio::sync::RwLock;
 use url::Url;
 
-use crate::{
-    cache::{CacheContents, CacheEntry, TryFromCache},
-    utils::MaybeSend,
-};
-
 use super::{
     filesystem::{read, write},
     manifest::{Manifest, ManifestDirectory},
+};
+use crate::{
+    cache::{CacheContents, CacheEntry, TryFromCache},
+    utils::MaybeSend,
 };
 
 async fn download(url: Url) -> Result<Vec<u8>, String> {

--- a/v2/src/cache/filesystem.rs
+++ b/v2/src/cache/filesystem.rs
@@ -1,6 +1,7 @@
 #[cfg(any(target_family = "unix", target_family = "windows"))]
 mod native {
     use std::path::Path;
+
     use tokio::fs::{
         create_dir_all as tokio_create_dir_all, read as tokio_read,
         remove_dir_all as tokio_remove_dir, remove_file as tokio_remove_file, write as tokio_write,
@@ -207,6 +208,5 @@ mod opfs {
 
 #[cfg(any(target_family = "unix", target_family = "windows"))]
 pub use native::*;
-
 #[cfg(target_family = "wasm")]
 pub use opfs::*;

--- a/v2/src/ffi/dlpack_wrap.rs
+++ b/v2/src/ffi/dlpack_wrap.rs
@@ -1,6 +1,9 @@
-use crate::ffi::cxx_bridge::{DLDevice, DLPackTensor};
-use crate::utils::float16;
 use anyhow::{Result, bail};
+
+use crate::{
+    ffi::cxx_bridge::{DLDevice, DLPackTensor},
+    utils::float16,
+};
 
 unsafe impl Send for DLDevice {}
 

--- a/v2/src/ffi/faiss_wrap.rs
+++ b/v2/src/ffi/faiss_wrap.rs
@@ -1,8 +1,10 @@
-use std::fmt;
-use std::str::FromStr;
+use std::{
+    fmt,
+    str::FromStr,
+    sync::atomic::{AtomicI64, Ordering},
+};
 
 use anyhow::{Context, Result, bail};
-use std::sync::atomic::{AtomicI64, Ordering};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FaissMetricType {

--- a/v2/src/ffi/py/mod.rs
+++ b/v2/src/ffi/py/mod.rs
@@ -5,10 +5,9 @@ mod value;
 
 use cache_progress::*;
 use model::*;
-use value::*;
-
 use pyo3::prelude::*;
 use pyo3_stub_gen::{Result, generate::StubInfo};
+use value::*;
 
 #[pymodule(name = "_core")]
 fn ailoy_py(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {

--- a/v2/src/knowledge_base/api/chroma.rs
+++ b/v2/src/knowledge_base/api/chroma.rs
@@ -1,13 +1,13 @@
-use super::super::{AddInput, Embedding, GetResult, RetrieveResult, VectorStore};
-
 use ailoy_macros::multi_platform_async_trait;
 use anyhow::{Result, bail};
-use chromadb::client::{ChromaAuthMethod, ChromaClient, ChromaClientOptions};
-use chromadb::collection::{
-    ChromaCollection, CollectionEntries, GetOptions, QueryOptions, QueryResult,
+use chromadb::{
+    client::{ChromaAuthMethod, ChromaClient, ChromaClientOptions},
+    collection::{ChromaCollection, CollectionEntries, GetOptions, QueryOptions, QueryResult},
 };
 use serde_json::{Map, Value as Json};
 use uuid::Uuid;
+
+use super::super::{AddInput, Embedding, GetResult, RetrieveResult, VectorStore};
 
 pub struct ChromaStore {
     collection: ChromaCollection,
@@ -274,10 +274,10 @@ impl VectorStore for ChromaStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use ailoy_macros::multi_platform_test;
     use serde_json::json;
 
-    use ailoy_macros::multi_platform_test;
+    use super::*;
 
     async fn setup_test_store() -> Result<ChromaStore> {
         let client = ChromaClient::new(ChromaClientOptions::default()).await?;

--- a/v2/src/knowledge_base/local/faiss.rs
+++ b/v2/src/knowledge_base/local/faiss.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
-use super::super::{AddInput, Embedding, GetResult, Metadata, RetrieveResult, VectorStore};
-use crate::ffi;
 use ailoy_macros::multi_platform_async_trait;
 use anyhow::Result;
+
+use super::super::{AddInput, Embedding, GetResult, Metadata, RetrieveResult, VectorStore};
+use crate::ffi;
 
 pub struct DocEntry {
     pub document: String,
@@ -194,10 +195,11 @@ impl VectorStore for FaissStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ailoy_macros::multi_platform_test;
     use anyhow::Ok;
     use serde_json::json;
+
+    use super::*;
 
     async fn setup_test_store() -> Result<FaissStore> {
         Ok(FaissStore::new(3).await.unwrap())

--- a/v2/src/model/api/anthropic.rs
+++ b/v2/src/model/api/anthropic.rs
@@ -444,9 +444,10 @@ impl LanguageModel for AnthropicLanguageModel {
 mod tests {
     use std::sync::Arc;
 
+    use ailoy_macros::multi_platform_test;
+
     use super::*;
     use crate::value::{MessageAggregator, ToolDesc, ToolDescArg};
-    use ailoy_macros::multi_platform_test;
 
     const ANTHROPIC_API_KEY: &str = env!("ANTHROPIC_API_KEY");
 

--- a/v2/src/model/api/gemini.rs
+++ b/v2/src/model/api/gemini.rs
@@ -229,8 +229,9 @@ impl LanguageModel for GeminiLanguageModel {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::log;
     use ailoy_macros::multi_platform_test;
+
+    use crate::utils::log;
 
     const GEMINI_API_KEY: &str = env!("GEMINI_API_KEY");
 
@@ -331,10 +332,10 @@ mod tests {
 
     #[multi_platform_test]
     async fn gemini_infer_with_image() {
+        use base64::Engine;
+
         use super::*;
         use crate::value::MessageAggregator;
-
-        use base64::Engine;
 
         let client = reqwest::Client::new();
         let test_image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Jensen_Huang_%28cropped%29.jpg/250px-Jensen_Huang_%28cropped%29.jpg";

--- a/v2/src/model/api/openai.rs
+++ b/v2/src/model/api/openai.rs
@@ -49,12 +49,15 @@ impl OpenAIChatCompletion for OpenAILanguageModel {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::model::LanguageModel;
-    use crate::utils::log;
-    use crate::value::{Message, MessageAggregator, Part, Role, ToolDesc};
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
+
+    use super::*;
+    use crate::{
+        model::LanguageModel,
+        utils::log,
+        value::{Message, MessageAggregator, Part, Role, ToolDesc},
+    };
 
     const OPENAI_API_KEY: &str = env!("OPENAI_API_KEY");
 
@@ -150,10 +153,10 @@ mod tests {
 
     #[multi_platform_test]
     async fn openai_infer_with_image() {
+        use base64::Engine;
+
         use super::*;
         use crate::value::MessageAggregator;
-
-        use base64::Engine;
 
         let client = reqwest::Client::new();
         let test_image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Jensen_Huang_%28cropped%29.jpg/250px-Jensen_Huang_%28cropped%29.jpg";
@@ -181,12 +184,15 @@ mod tests {
 
     #[multi_platform_test]
     async fn openai_infer_structured_output() {
-        use super::OpenAIGenerationConfigBuilder;
-        use crate::model::api::openai_chat_completion::{
-            OpenAIResponseFormat, OpenAIResponseFormatJSONSchema,
-        };
-        use crate::value::MessageAggregator;
         use serde_json::json;
+
+        use super::OpenAIGenerationConfigBuilder;
+        use crate::{
+            model::api::openai_chat_completion::{
+                OpenAIResponseFormat, OpenAIResponseFormatJSONSchema,
+            },
+            value::MessageAggregator,
+        };
 
         let json_schema = serde_json::from_value::<OpenAIResponseFormatJSONSchema>(json!({
             "name": "summarize-content",

--- a/v2/src/model/api/xai.rs
+++ b/v2/src/model/api/xai.rs
@@ -1,8 +1,12 @@
 use openai_sdk_rs::OpenAI;
 
-use crate::model::api::openai_chat_completion::OpenAIChatCompletion;
-use crate::model::openai_chat_completion::{OpenAIGenerationConfig, OpenAIGenerationConfigBuilder};
-use crate::value::FinishReason;
+use crate::{
+    model::{
+        api::openai_chat_completion::OpenAIChatCompletion,
+        openai_chat_completion::{OpenAIGenerationConfig, OpenAIGenerationConfigBuilder},
+    },
+    value::FinishReason,
+};
 
 pub type XAIGenerationConfig = OpenAIGenerationConfig;
 pub type XAIGenerationConfigBuilder = OpenAIGenerationConfigBuilder;
@@ -58,12 +62,15 @@ impl OpenAIChatCompletion for XAILanguageModel {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::model::LanguageModel;
-    use crate::utils::log;
-    use crate::value::{Message, MessageAggregator, Part, Role, ToolDesc};
     use ailoy_macros::multi_platform_test;
     use futures::StreamExt;
+
+    use super::*;
+    use crate::{
+        model::LanguageModel,
+        utils::log,
+        value::{Message, MessageAggregator, Part, Role, ToolDesc},
+    };
 
     const XAI_API_KEY: &str = env!("XAI_API_KEY");
 

--- a/v2/src/model/local/inferencer.rs
+++ b/v2/src/model/local/inferencer.rs
@@ -1,6 +1,5 @@
 #[cfg(any(target_family = "unix", target_family = "windows"))]
 pub use tvm_runtime::Inferencer;
-
 #[cfg(any(target_family = "wasm"))]
 pub use tvmjs_runtime::Inferencer;
 
@@ -111,13 +110,12 @@ pub fn claim_files(
 mod tvm_runtime {
     use cxx::UniquePtr;
 
+    use super::*;
     use crate::{
         cache::{Cache, CacheContents, TryFromCache},
         ffi::cxx_bridge::{TVMLanguageModel, create_dldevice, create_tvm_language_model},
         utils::BoxFuture,
     };
-
-    use super::*;
 
     pub fn get_device_type(accelerator: &str) -> i32 {
         if accelerator == "metal" {
@@ -228,8 +226,9 @@ mod tvmjs_runtime {
         fn try_from_contents(
             mut contents: CacheContents,
         ) -> BoxFuture<'static, Result<Self, String>> {
-            use crate::ffi::js_bridge::init_language_model_js;
             use js_sys::{Object, Reflect, Uint8Array};
+
+            use crate::ffi::js_bridge::init_language_model_js;
 
             Box::pin(async move {
                 let cache_contents = {

--- a/v2/src/model/local/local_language_model.rs
+++ b/v2/src/model/local/local_language_model.rs
@@ -398,11 +398,11 @@ mod tests {
 #[cfg(all(test, target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
-    use crate::value::MessageAggregator;
-
-    use super::*;
     use futures::StreamExt as _;
     use wasm_bindgen_test::*;
+
+    use super::*;
+    use crate::value::MessageAggregator;
 
     wasm_bindgen_test_configure!(run_in_browser);
 

--- a/v2/src/tool/mcp/mod.rs
+++ b/v2/src/tool/mcp/mod.rs
@@ -5,8 +5,9 @@ mod wasm32;
 
 mod common;
 
-use crate::tool::Tool;
 use std::sync::Arc;
+
+use crate::tool::Tool;
 
 pub enum MCPTransport {
     Stdio(&'static str, Vec<&'static str>),

--- a/v2/src/tool/mcp/native.rs
+++ b/v2/src/tool/mcp/native.rs
@@ -126,10 +126,10 @@ mod tests {
     #[tokio::test]
     async fn run_stdio() -> anyhow::Result<()> {
         use indexmap::IndexMap;
-
-        use super::*;
         use onig::Regex;
         use rmcp::transport::ConfigureCommandExt;
+
+        use super::*;
 
         let command = tokio::process::Command::new("uvx").configure(|cmd| {
             cmd.arg("mcp-server-time");

--- a/v2/src/tool/mcp/wasm32.rs
+++ b/v2/src/tool/mcp/wasm32.rs
@@ -1,7 +1,8 @@
-use std::borrow::Cow;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::{
+    borrow::Cow,
+    rc::Rc,
+    sync::{Arc, atomic::AtomicU32},
+};
 
 use ailoy_macros::multi_platform_async_trait;
 use anyhow::anyhow;
@@ -377,9 +378,10 @@ pub async fn mcp_tools_from_streamable_http(
 
 #[cfg(test)]
 mod tests {
+    use wasm_bindgen_test::*;
+
     use super::*;
     use crate::utils::log;
-    use wasm_bindgen_test::*;
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/v2/src/tool/mod.rs
+++ b/v2/src/tool/mod.rs
@@ -4,11 +4,10 @@ mod mcp;
 use std::fmt::Debug;
 
 use ailoy_macros::multi_platform_async_trait;
-
-use crate::value::{Part, ToolCallArg, ToolDesc};
-
 pub use builtin::*;
 pub use mcp::*;
+
+use crate::value::{Part, ToolCallArg, ToolDesc};
 
 #[multi_platform_async_trait]
 pub trait Tool: Debug + 'static {

--- a/v2/src/utils/log.rs
+++ b/v2/src/utils/log.rs
@@ -1,6 +1,5 @@
 #[cfg(not(target_arch = "wasm32"))]
 use log;
-
 #[cfg(target_arch = "wasm32")]
 use web_sys;
 

--- a/v2/src/utils/maybe_sync.rs
+++ b/v2/src/utils/maybe_sync.rs
@@ -1,11 +1,10 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod sync {
+    /// Reexports of the actual marker traits from core.
+    pub use core::marker::{Send as MaybeSend, Sync as MaybeSync};
     use core::{future::Future, pin::Pin};
 
     use futures::stream::Stream;
-
-    /// Reexports of the actual marker traits from core.
-    pub use core::marker::{Send as MaybeSend, Sync as MaybeSync};
 
     pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -143,9 +142,11 @@ mod sync {
 
 #[cfg(target_arch = "wasm32")]
 mod unsync {
-    use core::cell::{RefCell, RefMut};
-
-    use core::{future::Future, pin::Pin};
+    use core::{
+        cell::{RefCell, RefMut},
+        future::Future,
+        pin::Pin,
+    };
 
     use futures::stream::Stream;
 
@@ -397,7 +398,6 @@ mod unsync {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use sync::*;
-
 #[cfg(target_arch = "wasm32")]
 pub use unsync::*;
 


### PR DESCRIPTION
This PR adds `rustfmt.toml` config to format the codes and sort the imports consistently.
Currently the config has [`group_imports = "StdExternalCrate"`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#group_imports) and [`imports_granularity = "Crate"`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#imports_granularity). They are still marked as unstable features, so we need to put `+nightly` in `rustfmt` command.
Any other config suggestions are welcomed.