### PR TITLE
remove Arc in tests

### DIFF
--- a/v2/src/model/api/anthropic.rs
+++ b/v2/src/model/api/anthropic.rs
@@ -457,10 +457,9 @@ mod tests {
         let mut config = AnthropicGenerationConfig::default();
         config.max_tokens = 2048;
         config.thinking = Some(AnthropicThinkingConfig::default());
-        let anthropic = Arc::new(
+        let mut anthropic =
             AnthropicLanguageModel::new("claude-sonnet-4-20250514", *ANTHROPIC_API_KEY)
-                .with_config(config),
-        );
+                .with_config(config);
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -482,10 +481,8 @@ mod tests {
 
     #[multi_platform_test]
     async fn anthropic_infer_tool_call() {
-        let anthropic = Arc::new(AnthropicLanguageModel::new(
-            "claude-sonnet-4-20250514",
-            *ANTHROPIC_API_KEY,
-        ));
+        let mut anthropic =
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", *ANTHROPIC_API_KEY);
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -558,10 +555,8 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let anthropic = Arc::new(AnthropicLanguageModel::new(
-            "claude-sonnet-4-20250514",
-            *ANTHROPIC_API_KEY,
-        ));
+        let mut anthropic =
+            AnthropicLanguageModel::new("claude-sonnet-4-20250514", *ANTHROPIC_API_KEY);
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/gemini.rs
+++ b/v2/src/model/api/gemini.rs
@@ -245,10 +245,8 @@ mod tests {
         gemini_config.max_output_tokens = Some(2048);
         gemini_config.thinking_config =
             Some(GeminiThinkingConfig::default().with_thoughts_included(true));
-        let gemini = Arc::new(
-            GeminiLanguageModel::new("gemini-2.5-flash", *GEMINI_API_KEY)
-                .with_config(gemini_config),
-        );
+        let mut gemini = GeminiLanguageModel::new("gemini-2.5-flash", *GEMINI_API_KEY)
+            .with_config(gemini_config);
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -274,10 +272,7 @@ mod tests {
         use super::*;
         use crate::value::{MessageAggregator, ToolDescArg};
 
-        let gemini = Arc::new(GeminiLanguageModel::new(
-            "gemini-2.5-flash",
-            *GEMINI_API_KEY,
-        ));
+        let mut gemini = GeminiLanguageModel::new("gemini-2.5-flash", *GEMINI_API_KEY);
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -350,10 +345,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let gemini = Arc::new(GeminiLanguageModel::new(
-            "gemini-2.5-flash",
-            *GEMINI_API_KEY,
-        ));
+        let mut gemini = GeminiLanguageModel::new("gemini-2.5-flash", *GEMINI_API_KEY);
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/openai.rs
+++ b/v2/src/model/api/openai.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[multi_platform_test]
     async fn openai_infer_with_thinking() {
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("o3-mini", *OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("o3-mini", *OPENAI_API_KEY);
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -90,7 +90,7 @@ mod tests {
         use super::*;
         use crate::value::{MessageAggregator, ToolDescArg};
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY);
         let tools = vec![ToolDesc::new(
             "temperature",
             "Get current temperature",
@@ -167,7 +167,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let model = std::sync::Arc::new(OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY));
+        let mut model = OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY);
         let msgs = vec![
             Message::with_role(Role::User)
                 .with_contents(vec![Part::ImageData(image_base64, "image/jpeg".into())]),
@@ -216,9 +216,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let model = std::sync::Arc::new(
-            OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY).with_config(config),
-        );
+        let mut model = OpenAILanguageModel::new("gpt-4.1", *OPENAI_API_KEY).with_config(config);
 
         let msgs = vec![
             Message::with_role(Role::User)

--- a/v2/src/model/api/xai.rs
+++ b/v2/src/model/api/xai.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[multi_platform_test]
     async fn xai_infer_with_thinking() {
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3-mini", *XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-3-mini", *XAI_API_KEY);
 
         let msgs = vec![
             Message::with_role(Role::System).with_contents(vec![Part::Text(
@@ -98,7 +98,7 @@ mod tests {
     async fn xai_infer_tool_call() {
         use crate::value::ToolDescArg;
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-3", *XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-3", *XAI_API_KEY);
 
         let tools = vec![ToolDesc::new(
             "temperature",
@@ -173,7 +173,7 @@ mod tests {
         let image_bytes = response.bytes().await.unwrap();
         let image_base64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
-        let xai = std::sync::Arc::new(XAILanguageModel::new("grok-4", *XAI_API_KEY));
+        let mut xai = XAILanguageModel::new("grok-4", *XAI_API_KEY);
 
         let msgs = vec![
             Message::with_role(Role::User)


### PR DESCRIPTION
Use of `Arc` in `LanguageModel` is deprecated in #180, but the test still uses `Arc`

This PR fixes bug in tests