### PR TITLE
fix: consider object disposal scopes

### DIFF
--- a/v2/shim_js/src/embedding_model.ts
+++ b/v2/shim_js/src/embedding_model.ts
@@ -12,8 +12,13 @@ export class EmbeddingModel {
   constructor(rt: TVMRuntime) {
     this.rt = rt;
     this.tvm = this.rt.tvm;
+
+    this.tvm.beginScope();
+
     this.contextWindowSize = this.rt.metadata.context_window_size || 8192;
     this.fPrefill = this.rt.get_function("prefill");
+
+    this.tvm.endScope();
   }
 
   async infer(tokens: Uint32Array): Promise<Float32Array | Uint16Array> {


### PR DESCRIPTION
## Description
In #179, `TVMRuntime` as the common part of LanguageModel and EmbeddingModel is added.
In the process of separating the content from the existing logic, there was a part that deviated from the TVM scope management logic. This PR includes fixes of this.

And additionally, there is another refactoring: constructor of `KVCache` now gets only TVMRuntime object instead of getting the separated tvm, vm, and metadata objects.