### PR TITLE
Formatted log

### DIFF
--- a/v2/src/utils/log.rs
+++ b/v2/src/utils/log.rs
@@ -12,12 +12,26 @@ pub fn debug(s: impl Into<String> + std::fmt::Display) {
     web_sys::console::debug_1(&s.to_string().into());
 }
 
+#[macro_export]
+macro_rules! debug_fmt {
+    ($($args:tt)*) => {
+        $crate::utils::log::debug(format!($($args)*))
+    };
+}
+
 pub fn info(s: impl Into<String> + std::fmt::Display) {
     #[cfg(not(target_arch = "wasm32"))]
     log::info!("{}", s);
 
     #[cfg(target_arch = "wasm32")]
     web_sys::console::info_1(&s.to_string().into());
+}
+
+#[macro_export]
+macro_rules! info_fmt {
+    ($($args:tt)*) => {
+        $crate::utils::log::info(format!($($args)*))
+    };
 }
 
 pub fn warn(s: impl Into<String> + std::fmt::Display) {
@@ -28,10 +42,24 @@ pub fn warn(s: impl Into<String> + std::fmt::Display) {
     web_sys::console::warn_1(&s.to_string().into());
 }
 
+#[macro_export]
+macro_rules! warn_fmt {
+    ($($args:tt)*) => {
+        $crate::utils::log::warn(format!($($args)*))
+    };
+}
+
 pub fn error(s: impl Into<String> + std::fmt::Display) {
     #[cfg(not(target_arch = "wasm32"))]
     log::error!("{}", s);
 
     #[cfg(target_arch = "wasm32")]
     web_sys::console::error_1(&s.to_string().into());
+}
+
+#[macro_export]
+macro_rules! error_fmt {
+    ($($args:tt)*) => {
+        $crate::utils::log::error(format!($($args)*))
+    };
 }

--- a/v2/src/utils/log.rs
+++ b/v2/src/utils/log.rs
@@ -13,7 +13,7 @@ pub fn debug(s: impl Into<String> + std::fmt::Display) {
 }
 
 #[macro_export]
-macro_rules! debug_fmt {
+macro_rules! debug {
     ($($args:tt)*) => {
         $crate::utils::log::debug(format!($($args)*))
     };
@@ -28,7 +28,7 @@ pub fn info(s: impl Into<String> + std::fmt::Display) {
 }
 
 #[macro_export]
-macro_rules! info_fmt {
+macro_rules! info {
     ($($args:tt)*) => {
         $crate::utils::log::info(format!($($args)*))
     };
@@ -43,7 +43,7 @@ pub fn warn(s: impl Into<String> + std::fmt::Display) {
 }
 
 #[macro_export]
-macro_rules! warn_fmt {
+macro_rules! warn {
     ($($args:tt)*) => {
         $crate::utils::log::warn(format!($($args)*))
     };
@@ -58,7 +58,7 @@ pub fn error(s: impl Into<String> + std::fmt::Display) {
 }
 
 #[macro_export]
-macro_rules! error_fmt {
+macro_rules! error {
     ($($args:tt)*) => {
         $crate::utils::log::error(format!($($args)*))
     };


### PR DESCRIPTION
## Description
Add macros wrapping log functions can be used like `print!()`.
macro names could be changed.