### PR TITLE
fix: bug on post-processing of local embedding model result

### DIFF
--- a/v2/shim/include/embedding_model.hpp
+++ b/v2/shim/include/embedding_model.hpp
@@ -21,8 +21,8 @@ class tvm_embedding_model_t {
 public:
   tvm_embedding_model_t(CacheContents &contents, DLDevice device);
 
-  void postprocess_embedding_ndarray(const tvm::runtime::NDArray &from,
-                                     tvm::runtime::NDArray &to);
+  void extract_ndarray_part(const tvm::runtime::NDArray &from,
+                            tvm::runtime::NDArray &to);
 
   const tvm::runtime::NDArray infer(std::vector<int> tokens);
 


### PR DESCRIPTION
## Description
During the post-processing of the local embedding model results in C++, an error occurred that caused the f16 value to be interpreted as f32, resulting in a malformed f16 value returned in the C++ stage. Therefore, because the incorrect f16 value was being used, the actual value was problematic.

This PR checks the DataType of the model result and returns a result in the appropriate format, allowing Rust to use valid f16 or f32 values. The conversion process for actually using the f16 values ​​is performed in Rust.