### PR TITLE
Value node binding

### DIFF
--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -26,7 +26,7 @@ jsonschema = { version = "0.33.0", default-features = false }
 mime-infer = "4.0.0"
 minijinja = { version = "2.11.0", features = ["loader", "custom_syntax", "json"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }
-napi = { version = "3", features = ["tokio_rt", "napi5", "serde-json"], optional = true }
+napi = { version = "3", features = ["tokio_rt", "napi8", "serde-json"], optional = true }
 napi-derive = { version = "3", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 pyo3 = { version = "0.26", features = ["experimental-async", "macros"], optional = true }

--- a/v2/bindings/nodejs/package-lock.json
+++ b/v2/bindings/nodejs/package-lock.json
@@ -14,6 +14,7 @@
                 "@vitest/coverage-v8": "^3.2.4",
                 "dotenv": "^17.2.2",
                 "prettier": "^3.6.2",
+                "typescript": "^5.8.2",
                 "vite": "^7.1.5",
                 "vite-plugin-dts": "^4.5.4",
                 "vite-plugin-static-copy": "^3.1.2",
@@ -1212,20 +1213,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@microsoft/tsdoc": {
@@ -5155,12 +5142,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/v2/bindings/nodejs/package.json
+++ b/v2/bindings/nodejs/package.json
@@ -26,6 +26,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "dotenv": "^17.2.2",
         "prettier": "^3.6.2",
+        "typescript": "^5.8.2",
         "vite": "^7.1.5",
         "vite-plugin-dts": "^4.5.4",
         "vite-plugin-static-copy": "^3.1.2",

--- a/v2/bindings/nodejs/src/ailoy_core.d.ts
+++ b/v2/bindings/nodejs/src/ailoy_core.d.ts
@@ -7,247 +7,70 @@ export type EmbeddingModel = LocalEmbeddingModel;
 export type VectorStore = FaissVectorStore | ChromaVectorStore;
 /* @ts-ignore */
 export type Tool = BuiltinTool | MCPTool | JsFunctionTool;
-export declare class Agent {
-  constructor(lm: LanguageModel, tools?: Array<Tool>);
-  run(message: Array<JsPart | string> | JsPart | string): AgentRunIterator;
-  addTool(tool: Tool): void;
-  addTools(tools: Array<Tool>): void;
-  removeTool(toolName: string): void;
-  removeTools(toolNames: Array<string>): void;
-}
-export type JsAgent = Agent;
+export type FinishReason =
+  | { type: "Stop" }
+  | { type: "Length" }
+  | { type: "ToolCall" }
+  | { type: "Refusal"; field0: string };
 
-export declare class AgentRunIterator {
-  [Symbol.asyncIterator](): this;
-  next(): Promise<AgentRunIteratorResult>;
-}
-
-export declare class AnthropicLanguageModel {
-  constructor(modelName: string, apiKey: string);
-  run(
-    messages: Array<JsMessage>,
-    tools?: Array<ToolDesc> | undefined | null
-  ): LanguageModelRunIterator;
-}
-export type JsAnthropicLanguageModel = AnthropicLanguageModel;
-
-export declare class BuiltinTool {
-  static terminal(): BuiltinTool;
-  get description(): ToolDesc;
-  call(kwargs?: Record<string, any> | undefined | null): Promise<Array<JsPart>>;
-}
-export type JsBuiltinTool = BuiltinTool;
-
-export declare class ChromaVectorStore {
-  static create(
-    chromaUrl: string,
-    collectionName: string
-  ): Promise<ChromaVectorStore>;
-  addVector(input: VectorStoreAddInput): Promise<string>;
-  addVectors(inputs: Array<VectorStoreAddInput>): Promise<Array<string>>;
-  getById(id: string): Promise<VectorStoreGetResult | null>;
-  getByIds(ids: Array<string>): Promise<Array<VectorStoreGetResult>>;
-  retrieve(
-    queryEmbedding: Embedding,
-    topK: number
-  ): Promise<Array<VectorStoreRetrieveResult>>;
-  batchRetrieve(
-    queryEmbeddings: Array<Embedding>,
-    topK: number
-  ): Promise<Array<Array<VectorStoreRetrieveResult>>>;
-  removeVector(id: string): Promise<void>;
-  removeVectors(ids: Array<string>): Promise<void>;
-  clear(): Promise<void>;
-  count(): Promise<number>;
-}
-export type JsChromaVectorStore = ChromaVectorStore;
-
-export declare class FaissVectorStore {
-  static create(dim: number): Promise<FaissVectorStore>;
-  addVector(input: VectorStoreAddInput): Promise<string>;
-  addVectors(inputs: Array<VectorStoreAddInput>): Promise<Array<string>>;
-  getById(id: string): Promise<VectorStoreGetResult | null>;
-  getByIds(ids: Array<string>): Promise<Array<VectorStoreGetResult>>;
-  retrieve(
-    queryEmbedding: Embedding,
-    topK: number
-  ): Promise<Array<VectorStoreRetrieveResult>>;
-  batchRetrieve(
-    queryEmbeddings: Array<Embedding>,
-    topK: number
-  ): Promise<Array<Array<VectorStoreRetrieveResult>>>;
-  removeVector(id: string): Promise<void>;
-  removeVectors(ids: Array<string>): Promise<void>;
-  clear(): Promise<void>;
-  count(): Promise<number>;
-}
-export type JsFaissVectorStore = FaissVectorStore;
-
-export declare class GeminiLanguageModel {
-  constructor(modelName: string, apiKey: string);
-  run(
-    messages: Array<JsMessage>,
-    tools?: Array<ToolDesc> | undefined | null
-  ): LanguageModelRunIterator;
-}
-export type JsGeminiLanguageModel = GeminiLanguageModel;
-
-export declare class JsFunctionTool {
-  constructor(desc: ToolDesc, func: (arg: any) => Promise<any>);
-  get description(): ToolDesc;
-  call(kwargs?: Record<string, any> | undefined | null): Promise<Array<JsPart>>;
+export interface Message {
+  role: Role;
+  id?: string;
+  thinking: string;
+  contents: Array<Part>;
+  toolCalls: Array<Part>;
+  signature?: string;
 }
 
-export declare class LanguageModelRunIterator {
-  [Symbol.asyncIterator](): this;
-  next(): Promise<LanguageModelIteratorResult>;
+export interface MessageDelta {
+  role?: Role;
+  id?: string;
+  thinking: string;
+  contents: Array<PartDelta>;
+  toolCalls: Array<PartDelta>;
+  signature?: string;
 }
 
-export declare class LocalEmbeddingModel {
-  static create(
-    modelName: string,
-    progressCallback?: ((arg: CacheProgress) => void) | undefined | null
-  ): Promise<LocalEmbeddingModel>;
-  run(message: string): Promise<Embedding>;
-}
-export type JsLocalEmbeddingModel = LocalEmbeddingModel;
-
-export declare class LocalLanguageModel {
-  static create(
-    modelName: string,
-    progressCallback?: ((arg: CacheProgress) => void) | undefined | null
-  ): Promise<LocalLanguageModel>;
-  run(
-    messages: Array<JsMessage>,
-    tools?: Array<ToolDesc> | undefined | null
-  ): LanguageModelRunIterator;
-  enableReasoning(): void;
-  disableReasoning(): void;
-}
-export type JsLocalLanguageModel = LocalLanguageModel;
-
-export declare class MCPTool {
-  get description(): ToolDesc;
-  call(kwargs?: Record<string, any> | undefined | null): Promise<Array<JsPart>>;
-}
-export type JsMCPTool = MCPTool;
-
-export declare class MCPTransport {
-  static newStdio(command: string, args: Array<string>): MCPTransport;
-  static newStreamableHttp(url: string): MCPTransport;
-  get type(): string;
-  get stdio(): { command: string; args: Array<string> };
-  get streamableHttp(): { url: string };
-  tools(toolNamePrefix: string): Promise<Array<MCPTool>>;
-}
-export type JsMCPTransport = MCPTransport;
-
-/** Message /// */
-export declare class Message {
-  constructor();
-  get role(): Role | null;
-  set role(role: Role);
-  get contents(): Array<Part>;
-  set contents(contents: Array<Part>);
-  get reasoning(): string;
-  set reasoning(reasoning: string);
-  get toolCalls(): Array<Part>;
-  set toolCalls(toolCalls: Array<Part>);
-  get toolCallId(): string | null;
-  set toolCallId(toolCallId: string);
-  toJSON(): object;
-  toString(): string;
-}
-export type JsMessage = Message;
-
-/** MessageAggregator /// */
-export declare class MessageAggregator {
-  constructor();
-  update(msg: MessageOutput): Message | null;
-}
-export type JsMessageAggregator = MessageAggregator;
-
-/** MessageOutput /// */
-export declare class MessageOutput {
-  get delta(): Message;
-  get finishReason(): FinishReason | null;
-  toJSON(): object;
-  toString(): string;
-}
-export type JsMessageOutput = MessageOutput;
-
-export declare class OpenAILanguageModel {
-  constructor(modelName: string, apiKey: string);
-  run(
-    messages: Array<JsMessage>,
-    tools?: Array<ToolDesc> | undefined | null
-  ): LanguageModelRunIterator;
-}
-export type JsOpenAILanguageModel = OpenAILanguageModel;
-
-/** Part /// */
-export declare class Part {
-  static newText(text: string): Part;
-  static newFunction(id: string, name: string, arguments: object): Part;
-  static newImageUrl(url: string): Part;
-  static newImageData(data: string, mimeType: string): Part;
-  get partType(): string;
-  get text(): string | null;
-  set text(text: string);
-  get id(): string | null;
-  set id(id: string);
-  get name(): string | null;
-  set name(name: string);
-  get arguments(): string | null;
-  set arguments(arguments: object);
-  get function(): string | null;
-  set function(func: string);
-  get url(): string | null;
-  set url(url: string);
-  get data(): string | null;
-  set data(data: string);
-  get mimeType(): string | null;
-  set mimeType(mimeType: string);
-  toJSON(): object;
-  toString(): string;
-}
-export type JsPart = Part;
-
-export declare class XAILanguageModel {
-  constructor(modelName: string, apiKey: string);
-  run(
-    messages: Array<JsMessage>,
-    tools?: Array<ToolDesc> | undefined | null
-  ): LanguageModelRunIterator;
-}
-export type JsXAILanguageModel = XAILanguageModel;
-
-export interface AgentRunIteratorResult {
-  value: JsMessageOutput;
-  done: boolean;
+export interface MessageOutput {
+  delta: MessageDelta;
+  finishReason?: FinishReason;
 }
 
-export interface CacheProgress {
-  comment: string;
-  current: number;
-  total: number;
+export type Part =
+  | { type: "Text"; text: string }
+  | { type: "Function"; id?: string; f: PartFunction }
+  | { type: "Value"; value: any }
+  | { type: "Image"; image: PartImage };
+
+export type PartDelta =
+  | { type: "Text"; text: string }
+  | { type: "Function"; id?: string; f: PartDeltaFunction }
+  | { type: "Value"; value: any }
+  | { type: "Null" };
+
+export type PartDeltaFunction =
+  | { type: "Verbatim"; field0: string }
+  | { type: "WithStringArgs"; name: string; args: string }
+  | { type: "WithParsedArgs"; name: string; args: any };
+
+export interface PartFunction {
+  name: string;
+  args: any;
 }
 
-export type Embedding = Array<number>;
+export type PartImage = {
+  type: "Binary";
+  h: number;
+  w: number;
+  c: PartImageColorspace;
+  data: Buffer;
+};
 
-export declare const enum FinishReason {
-  Stop = "Stop",
-  Length = "Length",
-  ContentFilter = "ContentFilter",
-  ToolCalls = "ToolCalls",
+export declare const enum PartImageColorspace {
+  Grayscale = "Grayscale",
+  RGB = "RGB",
+  RGBA = "RGBA",
 }
-
-export interface LanguageModelIteratorResult {
-  value: JsMessageOutput;
-  done: boolean;
-}
-
-export type Metadata = Record<string, any>;
 
 /** The author of a message (or streaming delta) in a chat. */
 export declare const enum Role {
@@ -257,36 +80,13 @@ export declare const enum Role {
   User = "User",
   /** Content authored by the assistant/model. */
   Assistant = "Assistant",
-  /**
-   * Outputs produced by external tools/functions, typically in
-   * response to an assistant tool call (and often correlated via `tool_call_id`).
-   */
+  /** Outputs produced by external tools/functions */
   Tool = "Tool",
 }
 
 export interface ToolDesc {
   name: string;
-  description: string;
+  description?: string;
   parameters: any;
   returns?: any;
-}
-
-export interface VectorStoreAddInput {
-  embedding: Embedding;
-  document: string;
-  metadata?: Metadata;
-}
-
-export interface VectorStoreGetResult {
-  id: string;
-  document: string;
-  embedding: Embedding;
-  metadata?: Metadata;
-}
-
-export interface VectorStoreRetrieveResult {
-  id: string;
-  document: string;
-  metadata?: Metadata;
-  distance: number;
 }

--- a/v2/bindings/nodejs/src/index.ts
+++ b/v2/bindings/nodejs/src/index.ts
@@ -1,63 +1,66 @@
-import util from "node:util";
+// import util from "node:util";
 
-import { Message, MessageOutput, Part, Role } from "./ailoy_core";
+// import { Message, MessageOutput, Part, Role } from "./ailoy_core";
 
-// Add custom inspect symbol to Part
-if (typeof Part !== "undefined" && Part.prototype) {
-  (Part.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] = function (
-    _depth: number,
-    _opts: any
-  ) {
-    return `Part ${util.inspect(this.toJSON())}`;
-  };
-}
+// // Add custom inspect symbol to Part
+// if (typeof Part !== "undefined" && Part.prototype) {
+//   (Part.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] = function (
+//     _depth: number,
+//     _opts: any
+//   ) {
+//     return `Part ${util.inspect(this.toJSON())}`;
+//   };
+// }
 
-// Add custom inspect symbol to Message
-if (typeof Message !== "undefined" && Message.prototype) {
-  (Message.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] =
-    function (_depth: number, _opts: any) {
-      return `Message ${util.inspect(this.toJSON())}`;
-    };
-}
+// // Add custom inspect symbol to Message
+// if (typeof Message !== "undefined" && Message.prototype) {
+//   (Message.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] =
+//     function (_depth: number, _opts: any) {
+//       return `Message ${util.inspect(this.toJSON())}`;
+//     };
+// }
 
-// Add custom inspect symbol to MessageOutput
-if (typeof MessageOutput !== "undefined" && MessageOutput.prototype) {
-  (MessageOutput.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] =
-    function (_depth: number, _opts: any) {
-      return `MessageOutput ${util.inspect(this.toJSON())}`;
-    };
-}
+// // Add custom inspect symbol to MessageOutput
+// if (typeof MessageOutput !== "undefined" && MessageOutput.prototype) {
+//   (MessageOutput.prototype as any)[Symbol.for("nodejs.util.inspect.custom")] =
+//     function (_depth: number, _opts: any) {
+//       return `MessageOutput ${util.inspect(this.toJSON())}`;
+//     };
+// }
 
-export { Message, MessageOutput, Part, Role };
-export {
-  Agent,
-  AgentRunIterator,
-  AnthropicLanguageModel,
-  BuiltinTool,
-  ChromaVectorStore,
-  FaissVectorStore,
-  GeminiLanguageModel,
-  JsFunctionTool,
-  LanguageModelRunIterator,
-  LocalEmbeddingModel,
-  LocalLanguageModel,
-  MCPTransport,
-  MCPTool,
-  MessageAggregator,
-  OpenAILanguageModel,
-  XAILanguageModel,
-} from "./ailoy_core";
-export type {
-  AgentRunIteratorResult,
-  CacheProgress,
-  Embedding,
-  EmbeddingModel,
-  LanguageModel,
-  LanguageModelIteratorResult,
-  Tool,
-  ToolDesc,
-  VectorStore,
-  VectorStoreAddInput,
-  VectorStoreGetResult,
-  VectorStoreRetrieveResult,
-} from "./ailoy_core";
+// export { Message, MessageOutput, Part, Role };
+// export {
+//   Agent,
+//   AgentRunIterator,
+//   AnthropicLanguageModel,
+//   BuiltinTool,
+//   ChromaVectorStore,
+//   FaissVectorStore,
+//   GeminiLanguageModel,
+//   JsFunctionTool,
+//   LanguageModelRunIterator,
+//   LocalEmbeddingModel,
+//   LocalLanguageModel,
+//   MCPTransport,
+//   MCPTool,
+//   MessageAggregator,
+//   OpenAILanguageModel,
+//   XAILanguageModel,
+// } from "./ailoy_core";
+// export type {
+//   AgentRunIteratorResult,
+//   CacheProgress,
+//   Embedding,
+//   EmbeddingModel,
+//   LanguageModel,
+//   LanguageModelIteratorResult,
+//   Tool,
+//   ToolDesc,
+//   VectorStore,
+//   VectorStoreAddInput,
+//   VectorStoreGetResult,
+//   VectorStoreRetrieveResult,
+// } from "./ailoy_core";
+
+export * from "./ailoy_core";
+export type * from "./ailoy_core";

--- a/v2/src/ffi/node/mod.rs
+++ b/v2/src/ffi/node/mod.rs
@@ -1,8 +1,8 @@
-mod agent;
-mod cache;
-mod common;
-mod embedding_model;
-mod language_model;
-mod tool;
-mod value;
-mod vector_store;
+// mod agent;
+// mod cache;
+// mod common;
+// mod embedding_model;
+// mod language_model;
+// mod tool;
+// mod value;
+// mod vector_store;

--- a/v2/src/value/bytes.rs
+++ b/v2/src/value/bytes.rs
@@ -163,10 +163,18 @@ mod node {
         fn type_name() -> &'static str {
             "Buffer"
         }
+
         fn value_type() -> ValueType {
             ValueType::Object
         }
     }
 
-    impl ValidateNapiValue for Bytes {}
+    impl ValidateNapiValue for Bytes {
+        unsafe fn validate(
+            env: sys::napi_env,
+            napi_val: sys::napi_value,
+        ) -> Result<sys::napi_value> {
+            unsafe { <Buffer as ValidateNapiValue>::validate(env, napi_val) }
+        }
+    }
 }

--- a/v2/src/value/bytes.rs
+++ b/v2/src/value/bytes.rs
@@ -43,7 +43,6 @@ mod py {
         exceptions::PyTypeError,
         types::{PyAnyMethods, PyBytes, PyBytesMethods as _},
     };
-    #[cfg(feature = "python")]
     use pyo3::{IntoPyObject, PyErr};
     use pyo3_stub_gen::{PyStubType, TypeInfo};
 
@@ -59,7 +58,6 @@ mod py {
         }
     }
 
-    #[cfg(feature = "python")]
     impl<'py> IntoPyObject<'py> for Bytes {
         type Target = PyBytes;
         type Output = Bound<'py, PyBytes>;
@@ -76,4 +74,99 @@ mod py {
             TypeInfo::any()
         }
     }
+}
+
+#[cfg(feature = "nodejs")]
+mod node {
+    use super::Bytes;
+    use napi::bindgen_prelude::*;
+    use napi::{Env, ValueType};
+
+    unsafe fn read_buffer(env: sys::napi_env, val: sys::napi_value) -> Result<Vec<u8>> {
+        let mut data_ptr: *mut core::ffi::c_void = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let status = unsafe { sys::napi_get_buffer_info(env, val, &mut data_ptr, &mut len) };
+        if status == sys::Status::napi_ok {
+            let slice = unsafe { std::slice::from_raw_parts(data_ptr as *const u8, len) };
+            return Ok(slice.to_vec());
+        }
+        Err(Error::new(Status::InvalidArg, "Not a Buffer"))
+    }
+
+    impl FromNapiValue for Bytes {
+        unsafe fn from_napi_value(env: sys::napi_env, val: sys::napi_value) -> Result<Self> {
+            let env = Env::from_raw(env);
+            if let Ok(data) = unsafe { read_buffer(env.raw(), val) } {
+                return Ok(Bytes(data));
+            }
+            Err(Error::new(
+                Status::InvalidArg,
+                "Expected Buffer".to_string(),
+            ))
+        }
+    }
+
+    impl ToNapiValue for Bytes {
+        unsafe fn to_napi_value(env: sys::napi_env, this: Self) -> Result<sys::napi_value> {
+            use std::{mem::ManuallyDrop, os::raw::c_void, ptr};
+
+            // Zero-copy: use napi_create_external_buffer
+            extern "C" fn finalize_vec(
+                _env: sys::napi_env,
+                _finalize_data: *mut c_void, // = data ptr (not used)
+                finalize_hint: *mut c_void,  // our (ptr, len, cap) tuple
+            ) {
+                unsafe {
+                    // Recover the Box -> get (ptr,len,cap) -> rebuild Vec -> drop
+                    let tuple = Box::from_raw(finalize_hint as *mut (*mut u8, usize, usize));
+                    let (ptr, len, cap) = *tuple;
+                    let _ = Vec::from_raw_parts(ptr, len, cap);
+                }
+            }
+
+            // Transfer ownership of Vec<u8> to JS
+            let mut vec = this.0;
+            let ptr_u8 = vec.as_mut_ptr();
+            let len = vec.len();
+            let cap = vec.capacity();
+
+            // Save (ptr,len,cap) as hint, to reconstruct Vec in finalizer
+            let hint = Box::into_raw(Box::new((ptr_u8, len, cap))) as *mut c_void;
+
+            // Prevent Rust from dropping vec
+            let _leak = ManuallyDrop::new(vec);
+
+            let mut out: sys::napi_value = ptr::null_mut();
+            let status = unsafe {
+                sys::napi_create_external_buffer(
+                    env,
+                    len,                   // size in bytes
+                    ptr_u8 as *mut c_void, // data pointer
+                    Some(finalize_vec),    // finalizer
+                    hint,                  // hint (tuple)
+                    &mut out,
+                )
+            };
+
+            if status == sys::Status::napi_ok {
+                Ok(out)
+            } else {
+                Err(Error::new(
+                    Status::GenericFailure,
+                    "Failed to create external Buffer",
+                ))
+            }
+        }
+    }
+
+    impl TypeName for Bytes {
+        fn type_name() -> &'static str {
+            "Buffer"
+        }
+        fn value_type() -> ValueType {
+            ValueType::Object
+        }
+    }
+
+    impl ValidateNapiValue for Bytes {}
 }

--- a/v2/src/value/message.rs
+++ b/v2/src/value/message.rs
@@ -23,6 +23,7 @@ pub enum Role {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", pyo3_stub_gen_derive::gen_stub_pyclass)]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi(object))]
 pub struct Message {
     pub role: Role,
 
@@ -86,6 +87,7 @@ impl Message {
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "python", pyo3_stub_gen_derive::gen_stub_pyclass)]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi(object))]
 pub struct MessageDelta {
     pub role: Option<Role>,
     pub id: Option<String>,
@@ -279,6 +281,7 @@ impl Delta for MessageDelta {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyo3_stub_gen_derive::gen_stub_pyclass_enum)]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi)]
 pub enum FinishReason {
     Stop(),
     Length(), // max_output_tokens
@@ -289,6 +292,7 @@ pub enum FinishReason {
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "python", pyo3_stub_gen_derive::gen_stub_pyclass)]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi(object))]
 pub struct MessageOutput {
     pub delta: MessageDelta,
     pub finish_reason: Option<FinishReason>,

--- a/v2/src/value/part.rs
+++ b/v2/src/value/part.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::value::{Value, delta::Delta};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "nodejs", napi_derive::napi(object))]
 pub struct PartFunction {
     pub name: String,
     #[serde(rename = "arguments")]
@@ -13,6 +14,7 @@ pub struct PartFunction {
     Clone, Debug, PartialEq, Eq, Serialize, Deserialize, strum::EnumString, strum::Display,
 )]
 #[serde(untagged)]
+#[cfg_attr(feature = "nodejs", napi_derive::napi(string_enum))]
 pub enum PartImageColorspace {
     #[strum(serialize = "grayscale")]
     #[serde(rename = "grayscale")]
@@ -26,7 +28,7 @@ pub enum PartImageColorspace {
 }
 
 impl PartImageColorspace {
-    pub fn channel(&self) -> usize {
+    pub fn channel(&self) -> u32 {
         match self {
             PartImageColorspace::Grayscale => 1,
             PartImageColorspace::RGB => 3,
@@ -50,15 +52,17 @@ impl TryFrom<String> for PartImageColorspace {
     pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum
 )]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi)]
 pub enum PartImage {
     #[serde(rename = "image/x-binary")]
     Binary {
         #[serde(rename = "height")]
-        h: usize,
+        h: u32,
         #[serde(rename = "width")]
-        w: usize,
+        w: u32,
         #[serde(rename = "colorspace")]
         c: PartImageColorspace,
+        #[cfg_attr(feature = "nodejs", napi_derive::napi(ts_type = "Buffer"))]
         data: super::bytes::Bytes,
     },
 }
@@ -70,6 +74,7 @@ pub enum PartImage {
     pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum
 )]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi)]
 pub enum Part {
     #[serde(rename = "text")]
     Text { text: String },
@@ -91,8 +96,8 @@ impl Part {
     }
 
     pub fn image_binary(
-        height: usize,
-        width: usize,
+        height: u32,
+        width: u32,
         colorspace: impl TryInto<PartImageColorspace>,
         data: impl IntoIterator<Item = u8>,
     ) -> Result<Self, String> {
@@ -100,14 +105,14 @@ impl Part {
             .try_into()
             .map_err(|_| String::from("Colorspace parsing failed"))?;
         let data = data.into_iter().collect::<Vec<_>>();
-        let nbytes = data.len() / height / width / colorspace.channel();
+        let nbytes = data.len() as u32 / height / width / colorspace.channel();
         if !(nbytes == 1 || nbytes == 2 || nbytes == 3 || nbytes == 4) {
             panic!("Invalid data length");
         }
         Ok(Self::Image {
             image: PartImage::Binary {
-                h: height,
-                w: width,
+                h: height as u32,
+                w: width as u32,
                 c: colorspace,
                 data: super::bytes::Bytes(data),
             },
@@ -237,7 +242,7 @@ impl Part {
                     },
             } => {
                 let (h, w) = (*h as u32, *w as u32);
-                let nbytes = buf.len() / h as usize / w as usize / c.channel();
+                let nbytes = buf.len() as u32 / h / w / c.channel();
                 match (c, nbytes) {
                     // Grayscale 8-bit
                     (&PartImageColorspace::Grayscale, 1) => {
@@ -296,6 +301,7 @@ impl Part {
     pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum
 )]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi)]
 pub enum PartDeltaFunction {
     Verbatim(String),
     WithStringArgs {
@@ -317,6 +323,7 @@ pub enum PartDeltaFunction {
     pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum
 )]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq))]
+#[cfg_attr(feature = "nodejs", napi_derive::napi)]
 pub enum PartDelta {
     Text {
         text: String,
@@ -606,3 +613,6 @@ mod py {
         }
     }
 }
+
+#[cfg(feature = "nodejs")]
+mod node {}

--- a/v2/src/value/value.rs
+++ b/v2/src/value/value.rs
@@ -958,8 +958,6 @@ mod node {
     use napi::bindgen_prelude::*;
     use napi::{Env, Result, Unknown};
 
-    const JS_SAFE_INT_MAX: u64 = (1u64 << 53) - 1;
-
     impl FromNapiValue for Value {
         unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
             let env = Env::from_raw(env);

--- a/v2/src/value/value.rs
+++ b/v2/src/value/value.rs
@@ -951,3 +951,133 @@ mod py {
         }
     }
 }
+
+#[cfg(feature = "nodejs")]
+mod node {
+    use super::Value;
+    use napi::bindgen_prelude::*;
+    use napi::{Env, Result, Unknown};
+
+    const JS_SAFE_INT_MAX: u64 = (1u64 << 53) - 1;
+
+    impl FromNapiValue for Value {
+        unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
+            let env = Env::from_raw(env);
+            let any = unsafe { Unknown::from_raw_unchecked(env.raw(), napi_val) };
+            match any.get_type()? {
+                ValueType::Undefined | ValueType::Null => Ok(Value::Null),
+                ValueType::Boolean => Ok(Value::Bool(any.coerce_to_bool()?)),
+                ValueType::Number => {
+                    let num = any.coerce_to_number()?;
+                    if let Ok(u) = num.get_uint32() {
+                        Ok(Value::Unsigned(u as u64))
+                    } else if let Ok(i) = num.get_int64() {
+                        Ok(Value::Integer(i))
+                    } else if let Ok(f) = num.get_double() {
+                        Ok(Value::Float(ordered_float::OrderedFloat(f)))
+                    } else {
+                        Err(Error::from_reason("Unsupported JS type for Value"))
+                    }
+                }
+                ValueType::BigInt => {
+                    let bi = BigInt::from_unknown(any)?;
+                    let (signed, u, lossless) = bi.get_u64();
+                    if !signed && lossless {
+                        return Ok(Value::Unsigned(u));
+                    }
+                    let (i, lossless) = bi.get_i64();
+                    if lossless {
+                        return Ok(Value::Integer(i));
+                    }
+                    Err(Error::from_reason(
+                        "BigInt value is out of supported i64/u64 range",
+                    ))
+                }
+                ValueType::String => Ok(Value::String(
+                    any.coerce_to_string()?.into_utf8()?.as_str()?.to_owned(),
+                )),
+                ValueType::Object => {
+                    let obj = any.coerce_to_object()?;
+
+                    if obj.is_array()? {
+                        // Array
+                        let len = obj.get_array_length()?;
+                        let mut out = Vec::with_capacity(len as usize);
+                        for i in 0..len {
+                            let el: Unknown = obj.get_element(i)?;
+                            let v = unsafe { Value::from_napi_value(env.raw(), el.raw()) }?;
+                            out.push(v);
+                        }
+                        Ok(Value::Array(out))
+                    } else {
+                        // Plain object
+                        let keys = obj.get_property_names()?; // JS 배열
+                        let klen = keys.get_array_length()?;
+                        let mut map = indexmap::IndexMap::with_capacity(klen as usize);
+
+                        for i in 0..klen {
+                            let k_any: Unknown = keys.get_element(i)?;
+                            let k = k_any.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+
+                            let v_any: Unknown = obj.get_named_property(&k)?;
+                            let v = unsafe { Value::from_napi_value(env.raw(), v_any.raw()) }?;
+                            map.insert(k, v);
+                        }
+                        Ok(Value::Object(map))
+                    }
+                }
+                ValueType::Symbol
+                | ValueType::Function
+                | ValueType::External
+                | ValueType::Unknown => Err(Error::from_reason("Unsupported JS type for Value")),
+            }
+        }
+    }
+
+    impl ToNapiValue for Value {
+        unsafe fn to_napi_value(env: sys::napi_env, this: Self) -> Result<sys::napi_value> {
+            let env = Env::from_raw(env);
+            Ok(match this {
+                Value::Null => ().into_unknown(&env)?,
+                Value::Bool(b) => b.into_unknown(&env)?,
+                Value::Unsigned(u) => {
+                    if u <= u32::MAX as u64 {
+                        env.create_uint32(u as u32)?.into_unknown(&env)?
+                    } else {
+                        BigInt::from(u).into_unknown(&env)? // 권장: Env API 대신 BigInt 변환 사용
+                    }
+                }
+                Value::Integer(i) => env.create_int64(i as i64)?.into_unknown(&env)?,
+                Value::Float(f) => env.create_double(*f)?.into_unknown(&env)?,
+                Value::String(s) => env.create_string(&s)?.into_unknown(&env)?,
+                Value::Array(arr) => {
+                    let js_arr = Array::from_vec(&env, arr)?;
+                    js_arr.into_unknown(&env)?
+                }
+
+                Value::Object(map) => {
+                    let mut obj = Object::new(&env)?;
+                    for (k, v) in map {
+                        let v = unsafe { <Value as ToNapiValue>::to_napi_value(env.raw(), v) }?;
+                        let v = unsafe { Unknown::from_raw_unchecked(env.raw(), v) };
+                        obj.set_named_property(&k, v)?;
+                    }
+                    obj.into_unknown(&env)?
+                }
+            }
+            .raw())
+        }
+    }
+
+    impl TypeName for Value {
+        fn type_name() -> &'static str {
+            "any"
+        }
+
+        fn value_type() -> ValueType {
+            ValueType::Unknown
+        }
+    }
+
+    impl ValidateNapiValue for Value {}
+}


### PR DESCRIPTION
In this PR, I added Node bindings to the value module, as a first job for the Node.js integration.

The implementation was written to be as close as possible to the Python version, while leveraging derive to avoid boilerplate code.

### Problem

Currently, the enum variants are exported in uppercase, but the convention is to use lowercase. This needs to be addressed.

```typescript
export type Part =
  | { type: "Text"; text: string }
  | { type: "Function"; id?: string; f: PartFunction }
  | { type: "Value"; value: any }
  | { type: "Image"; image: PartImage };

export type PartDelta =
  | { type: "Text"; text: string }
  | { type: "Function"; id?: string; f: PartDeltaFunction }
  | { type: "Value"; value: any }
  | { type: "Null" };
```