### PR TITLE
Unify error handling into `anyhow`

### DIFF
--- a/v2/src/agent/system_message_renderer.rs
+++ b/v2/src/agent/system_message_renderer.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Context;
 use dedent::dedent;
 use minijinja::{Environment, context};
 use minijinja_contrib::{add_to_environment, pycompat::unknown_method_callback};
@@ -60,14 +60,14 @@ impl SystemMessageRenderer {
         &self,
         content: String,
         knowledge_results: Option<Vec<KnowledgeRetrieveResult>>,
-    ) -> Result<String> {
+    ) -> anyhow::Result<String> {
         let ctx = context!(content => content, knowledge_results => knowledge_results);
         let rendered = self
             .mj_env
             .get_template("template")
             .unwrap()
             .render(ctx)
-            .map_err(|e| anyhow!(format!("minijinja::render failed: {}", e.to_string())))?;
+            .context("minijinja::render failed")?;
 
         Ok(rendered)
     }

--- a/v2/src/bin/py_stub_gen.rs
+++ b/v2/src/bin/py_stub_gen.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 
 fn main() -> anyhow::Result<()> {
     #[cfg(feature = "python")]
@@ -17,7 +17,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 /// Inject TypeVar declaration after the last import line in a .pyi file
-fn inject_typevar<P: AsRef<Path>>(file_path: P, typevar_name: &str) -> Result<()> {
+fn inject_typevar<P: AsRef<Path>>(file_path: P, typevar_name: &str) -> anyhow::Result<()> {
     let file_path = file_path.as_ref();
 
     // Read the file

--- a/v2/src/cache/filesystem.rs
+++ b/v2/src/cache/filesystem.rs
@@ -2,6 +2,7 @@
 mod native {
     use std::path::Path;
 
+    use anyhow::{Context, bail};
     use tokio::fs::{
         create_dir_all as tokio_create_dir_all, read as tokio_read,
         remove_dir_all as tokio_remove_dir, remove_file as tokio_remove_file, write as tokio_write,
@@ -11,42 +12,40 @@ mod native {
         path.as_ref().exists()
     }
 
-    pub async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, String> {
-        tokio_read(path)
-            .await
-            .map_err(|e| format!("tokio::fs::read failed: {}", e.to_string()))
+    pub async fn read(path: impl AsRef<Path>) -> anyhow::Result<Vec<u8>> {
+        tokio_read(path).await.context("tokio::fs::read failed")
     }
 
     pub async fn write(
         path: impl AsRef<Path>,
         data: impl AsRef<[u8]>,
         create_parent: bool,
-    ) -> Result<(), String> {
+    ) -> anyhow::Result<()> {
         let parent_dir = path.as_ref().parent().unwrap();
         if !parent_dir.exists() && create_parent {
             tokio_create_dir_all(parent_dir)
                 .await
-                .map_err(|e| format!("tokio::fs::create_dir_all failed: {}", e.to_string()))?;
+                .context("tokio::fs::create_dir_all failed")?;
         }
         tokio_write(path, data)
             .await
-            .map_err(|e| format!("tokio::fs::write failed: {}", e.to_string()))
+            .context("tokio::fs::write failed")
     }
 
-    pub async fn _remove(path: impl AsRef<Path>) -> Result<(), String> {
+    pub async fn _remove(path: impl AsRef<Path>) -> anyhow::Result<()> {
         if path.as_ref().is_dir() {
             tokio_remove_dir(path)
                 .await
-                .map_err(|e| format!("tokio::fs::remove_dir_all failed: {}", e.to_string()))
+                .context("tokio::fs::remove_dir_all failed")
         } else if path.as_ref().is_file() {
             tokio_remove_file(path)
                 .await
-                .map_err(|e| format!("tokio::fs::remove_file failed: {}", e.to_string()))
+                .context("tokio::fs::remove_file failed")
         } else {
-            Err(format!(
+            bail!(
                 "Neither directory nor file: {}",
                 path.as_ref().as_os_str().to_string_lossy()
-            ))
+            )
         }
     }
 }
@@ -66,9 +65,9 @@ mod opfs {
     async fn get_dir_handle(
         path: &Path,
         create: bool,
-    ) -> Result<FileSystemDirectoryHandle, String> {
+    ) -> anyhow::Result<FileSystemDirectoryHandle> {
         if path.parent().is_none() {
-            return Err("Root is disallowed".to_owned());
+            bail!("Root is disallowed".to_owned());
         }
 
         // Initialize `handle` with OPFS root
@@ -78,9 +77,9 @@ mod opfs {
             .get_directory();
         let mut handle = JsFuture::from(promise)
             .await
-            .map_err(|_| "Failed to get OPFS root directory")?
+            .context("Failed to get OPFS root directory")?
             .dyn_into::<FileSystemDirectoryHandle>()
-            .map_err(|_| "Invalid root directory handle")?;
+            .context("Invalid root directory handle")?;
 
         // Call browser API `FileSystemDirectoryHandle` until the parent directory
         for component in path.parent().unwrap().components() {
@@ -93,19 +92,14 @@ mod opfs {
             let promise = handle.get_directory_handle_with_options(&component, &opts);
             handle = JsFuture::from(promise)
                 .await
-                .map_err(|err| {
-                    format!(
-                        "`FileSystemDirectoryHandle::GetDirectoryHandle failed`: {:?}",
-                        err
-                    )
-                })?
+                .context("`FileSystemDirectoryHandle::GetDirectoryHandle failed`")?
                 .dyn_into::<FileSystemDirectoryHandle>()
-                .map_err(|_| "Internal error(FileSystemDirectoryHandle)")?;
+                .context("Internal error(FileSystemDirectoryHandle)")?;
         }
         Ok(handle)
     }
 
-    async fn get_file_handle(path: &Path, create: bool) -> Result<FileSystemFileHandle, String> {
+    async fn get_file_handle(path: &Path, create: bool) -> anyhow::Result<FileSystemFileHandle> {
         let dir_handle = get_dir_handle(path, create).await?;
 
         // Call browser API `FileSystemDirectoryHandle::get_file_handle`
@@ -115,14 +109,9 @@ mod opfs {
             .get_file_handle_with_options(&path.file_name().unwrap().to_string_lossy(), &opts);
         let handle = JsFuture::from(promise)
             .await
-            .map_err(|err| {
-                format!(
-                    "`FileSystemDirectoryHandle::GetFileHandle failed`: {:?}",
-                    err
-                )
-            })?
+            .context("`FileSystemDirectoryHandle::GetFileHandle failed`")?
             .dyn_into::<FileSystemFileHandle>()
-            .map_err(|_| "Invalid file handle")?;
+            .context("Invalid file handle")?;
         Ok(handle)
     }
 
@@ -133,7 +122,7 @@ mod opfs {
         }
     }
 
-    pub async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, String> {
+    pub async fn read(path: impl AsRef<Path>) -> anyhow::Result<Vec<u8>> {
         // Get file handle
         let handle = get_file_handle(path.as_ref(), false).await?;
 
@@ -141,15 +130,15 @@ mod opfs {
         let promise = handle.get_file();
         let file = JsFuture::from(promise)
             .await
-            .map_err(|_| "Failed to get File object")?
+            .context("Failed to get File object")?
             .dyn_into::<web_sys::File>()
-            .map_err(|_| "Invalid File object")?;
+            .context("Invalid File object")?;
 
         // Call browser API `File::array_buffer()`
         let promise = file.array_buffer();
         let array_buffer = JsFuture::from(promise)
             .await
-            .map_err(|_| "Failed to read file as ArrayBuffer")?;
+            .context("Failed to read file as ArrayBuffer")?;
 
         // Convert to Uint8Array
         let uint8_array = Uint8Array::new(&array_buffer);
@@ -163,7 +152,7 @@ mod opfs {
         path: impl AsRef<Path>,
         data: impl AsRef<[u8]>,
         create_parent: bool,
-    ) -> Result<(), String> {
+    ) -> anyhow::Result<()> {
         // Get file handle
         let handle = get_file_handle(path.as_ref(), create_parent).await?;
 
@@ -171,28 +160,28 @@ mod opfs {
         let promise = handle.create_writable();
         let stream = JsFuture::from(promise)
             .await
-            .map_err(|_| "Failed to create writable stream")?
+            .context("Failed to create writable stream")?
             .dyn_into::<FileSystemWritableFileStream>()
-            .map_err(|_| "Invalid writable stream")?;
+            .context("Invalid writable stream")?;
 
         // Write to file
         let promise = stream
             .write_with_u8_array(data.as_ref())
-            .map_err(|_| "`write_with_u8_array` failed")?;
+            .context("`write_with_u8_array` failed")?;
         JsFuture::from(promise)
             .await
-            .map_err(|_| "Failed to write to file")?;
+            .context("Failed to write to file")?;
 
         // Close stream
         let close_promise = stream.close();
         JsFuture::from(close_promise)
             .await
-            .map_err(|_| "Failed to close file")?;
+            .context("Failed to close file")?;
 
         Ok(())
     }
 
-    pub async fn _remove(path: impl AsRef<Path>) -> Result<(), String> {
+    pub async fn _remove(path: impl AsRef<Path>) -> anyhow::Result<()> {
         let handle = get_dir_handle(path.as_ref(), false).await?;
 
         let opts = FileSystemRemoveOptions::new();
@@ -201,7 +190,7 @@ mod opfs {
         let promise = handle.remove_entry_with_options(&name, &opts);
         JsFuture::from(promise)
             .await
-            .map_err(|err| format!("FileSystemDirectoryHandle::remove_entry failed: {:?}", err))?;
+            .context("FileSystemDirectoryHandle::remove_entry failed")?;
         Ok(())
     }
 }

--- a/v2/src/cache/from_cache.rs
+++ b/v2/src/cache/from_cache.rs
@@ -39,7 +39,7 @@ use crate::{
 ///
 /// impl TryFromCache for MyModel {
 ///     fn claim_files(cache: Cache, key: impl AsRef<str>)
-///     -> BoxFuture<'static, Result<CacheClaim, String>> {
+///     -> BoxFuture<'static, anyhow::Result<CacheClaim>> {
 ///         let k = key.as_ref().to_owned();
 ///         Box::pin(async move {
 ///             Ok(CacheClaim::with_ctx(
@@ -53,7 +53,7 @@ use crate::{
 ///     }
 ///
 ///     fn try_from_contents(contents: CacheContents)
-///     -> BoxFuture<'static, Result<Self, String>> {
+///     -> BoxFuture<'static, anyhow::Result<Self>> {
 ///         Box::pin(async move {
 ///             let tokenizer = contents.remove_with_filename_str("tokenizer.json")
 ///                 .ok_or("missing tokenizer.json")?.1;
@@ -75,13 +75,13 @@ pub trait TryFromCache: Sized + MaybeSend {
     fn claim_files(
         cache: Cache,
         key: impl AsRef<str>,
-    ) -> BoxFuture<'static, Result<CacheClaim, String>>;
+    ) -> BoxFuture<'static, anyhow::Result<CacheClaim>>;
 
     /// Build `Self` from the previously fetched files.
     ///
     /// Implementations should verify that all required entries are present and valid,
     /// and return a descriptive `Err(String)` on failure.
-    fn try_from_contents(contents: CacheContents) -> BoxFuture<'static, Result<Self, String>>;
+    fn try_from_contents(contents: CacheContents) -> BoxFuture<'static, anyhow::Result<Self>>;
 }
 
 /// Infallible variant of [`TryFromCache`].

--- a/v2/src/ffi/dlpack_wrap.rs
+++ b/v2/src/ffi/dlpack_wrap.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::bail;
 
 use crate::{
     ffi::cxx_bridge::{DLDevice, DLPackTensor},
@@ -11,7 +11,7 @@ unsafe impl Send for DLPackTensor {}
 
 impl DLPackTensor {
     /// 1-dimensional float32 Tensor to Vec<f32>
-    pub fn to_vec_f32(&self) -> Result<Vec<f32>> {
+    pub fn to_vec_f32(&self) -> anyhow::Result<Vec<f32>> {
         let managed_tensor = self.inner.as_ref().unwrap();
         let dimension = managed_tensor.get_dimension();
         if dimension == -1 {

--- a/v2/src/ffi/node/agent.rs
+++ b/v2/src/ffi/node/agent.rs
@@ -25,7 +25,7 @@ pub struct AgentRunIteratorResult {
 #[derive(Clone)]
 #[napi]
 pub struct AgentRunIterator {
-    rx: Arc<Mutex<mpsc::UnboundedReceiver<std::result::Result<MessageOutput, String>>>>,
+    rx: Arc<Mutex<mpsc::UnboundedReceiver<anyhow::Result<MessageOutput>>>>,
 }
 
 #[napi]
@@ -99,7 +99,7 @@ impl JsAgent {
 
     fn create_iterator<'a>(&'a self, env: Env, parts: Vec<JsPart>) -> napi::Result<Object<'a>> {
         let inner = self.inner.clone();
-        let (tx, rx) = mpsc::unbounded_channel::<std::result::Result<MessageOutput, String>>();
+        let (tx, rx) = mpsc::unbounded_channel::<anyhow::Result<MessageOutput>>();
 
         let rt = get_or_create_runtime();
         rt.spawn(async move {

--- a/v2/src/ffi/node/language_model.rs
+++ b/v2/src/ffi/node/language_model.rs
@@ -27,7 +27,7 @@ pub struct LanguageModelIteratorResult {
 #[derive(Clone)]
 #[napi]
 pub struct LanguageModelRunIterator {
-    rx: Arc<Mutex<mpsc::UnboundedReceiver<std::result::Result<MessageOutput, String>>>>,
+    rx: Arc<Mutex<mpsc::UnboundedReceiver<Result<MessageOutput>>>>,
 }
 
 #[napi]
@@ -83,7 +83,7 @@ pub trait LanguageModelMethods {
         tools: Option<Vec<ToolDesc>>,
     ) -> napi::Result<Object<'a>> {
         let inner = self.get_inner()?;
-        let (tx, rx) = mpsc::unbounded_channel::<std::result::Result<MessageOutput, String>>();
+        let (tx, rx) = mpsc::unbounded_channel::<anyhow::Result<MessageOutput>>();
 
         let rt = get_or_create_runtime();
 

--- a/v2/src/ffi/node/tool.rs
+++ b/v2/src/ffi/node/tool.rs
@@ -232,13 +232,9 @@ impl Tool for JsFunctionTool {
         self.desc.clone()
     }
 
-    async fn run(&self, args: ToolCallArg) -> std::result::Result<Vec<Part>, String> {
+    async fn run(&self, args: ToolCallArg) -> anyhow::Result<Vec<Part>> {
         let kwargs = serde_json::to_value(args).unwrap();
-        let promise = self
-            .func
-            .call_async(kwargs)
-            .await
-            .map_err(|e| e.to_string())?;
+        let promise = self.func.call_async(kwargs).await?;
         let result = match promise.await {
             Ok(result) => result.to_string(),
             Err(e) => e.to_string(),

--- a/v2/src/ffi/py/tool.rs
+++ b/v2/src/ffi/py/tool.rs
@@ -218,8 +218,7 @@ fn function_tool_result_to_parts(result: Py<PyAny>) -> Result<Vec<Part>, String>
             let text = result.to_string();
             Ok(vec![Part::new_text(text)])
         }
-    })
-    .map_err(|e| e.to_string())
+    })?
 }
 
 #[derive(Debug, Clone)]
@@ -245,8 +244,7 @@ impl Tool for PythonFunctionTool {
             };
             let result = self.func.call(py, PyTuple::empty(py), kwargs)?;
             Ok(result)
-        })
-        .map_err(|e| e.to_string())?;
+        })?;
 
         function_tool_result_to_parts(result)
     }
@@ -327,8 +325,7 @@ impl Tool for PythonAsyncFunctionTool {
             };
 
             Ok(result.into())
-        })
-        .map_err(|e| e.to_string())?;
+        })?;
 
         function_tool_result_to_parts(result)
     }

--- a/v2/src/knowledge/base.rs
+++ b/v2/src/knowledge/base.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use ailoy_macros::{maybe_send_sync, multi_platform_async_trait};
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -23,7 +22,7 @@ pub struct KnowledgeRetrieveResult {
 pub trait Knowledge: std::fmt::Debug {
     fn name(&self) -> String;
 
-    async fn retrieve(&self, query: String) -> Result<Vec<KnowledgeRetrieveResult>>;
+    async fn retrieve(&self, query: String) -> anyhow::Result<Vec<KnowledgeRetrieveResult>>;
 }
 
 #[derive(Clone)]
@@ -77,7 +76,7 @@ impl Tool for KnowledgeTool {
         self.desc.clone()
     }
 
-    async fn run(&self, args: Value) -> Result<Value, String> {
+    async fn run(&self, args: Value) -> anyhow::Result<Value> {
         let args = match args.as_object() {
             Some(a) => a,
             None => {
@@ -124,7 +123,7 @@ mod tests {
             "about-ailoy".into()
         }
 
-        async fn retrieve(&self, _query: String) -> Result<Vec<KnowledgeRetrieveResult>> {
+        async fn retrieve(&self, _query: String) -> anyhow::Result<Vec<KnowledgeRetrieveResult>> {
             let documents = vec![
                 KnowledgeRetrieveResult {
                     document: "Ailoy is an awesome AI agent framework.".into(),
@@ -144,7 +143,7 @@ mod tests {
     }
 
     #[multi_platform_test]
-    async fn test_custom_knowledge_with_agent() -> Result<()> {
+    async fn test_custom_knowledge_with_agent() -> anyhow::Result<()> {
         let knowledge = CustomKnowledge {};
         let model = LangModel::try_new_local("Qwen/Qwen3-0.6B").await.unwrap();
         let mut agent = Agent::new(model, vec![]);

--- a/v2/src/model/custom.rs
+++ b/v2/src/model/custom.rs
@@ -14,7 +14,7 @@ pub(super) type CustomLangModelInferFunc =
         Vec<Message>,
         Vec<ToolDesc>,
         InferenceConfig,
-    ) -> BoxStream<'static, Result<MessageOutput, String>>;
+    ) -> BoxStream<'static, anyhow::Result<MessageOutput>>;
 
 #[derive(Clone)]
 pub(super) struct CustomLangModel {
@@ -27,7 +27,7 @@ impl LangModelInference for CustomLangModel {
         msg: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> BoxStream<'a, Result<MessageOutput, String>> {
+    ) -> BoxStream<'a, anyhow::Result<MessageOutput>> {
         (self.infer_func)(msg, tools, config)
     }
 }

--- a/v2/src/model/language_model.rs
+++ b/v2/src/model/language_model.rs
@@ -70,7 +70,7 @@ pub trait LangModelInference {
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> BoxStream<'a, Result<MessageOutput, String>>;
+    ) -> BoxStream<'a, anyhow::Result<MessageOutput>>;
 }
 
 #[derive(Clone)]
@@ -88,7 +88,7 @@ pub struct LangModel {
 }
 
 impl LangModel {
-    pub async fn try_new_local(model_name: impl Into<String>) -> Result<Self, String> {
+    pub async fn try_new_local(model_name: impl Into<String>) -> anyhow::Result<Self> {
         Ok(Self {
             inner: LangModelInner::Local(LocalLangModel::try_new(model_name).await?),
         })
@@ -96,7 +96,7 @@ impl LangModel {
 
     pub fn try_new_local_stream<'a>(
         model_name: impl Into<String>,
-    ) -> BoxStream<'a, Result<CacheProgress<Self>, String>> {
+    ) -> BoxStream<'a, anyhow::Result<CacheProgress<Self>>> {
         let model_name = model_name.into();
         Box::pin(async_stream::try_stream! {
             let mut strm = LocalLangModel::try_new_stream(model_name);
@@ -135,7 +135,7 @@ impl LangModelInference for LangModel {
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> BoxStream<'a, Result<MessageOutput, String>> {
+    ) -> BoxStream<'a, anyhow::Result<MessageOutput>> {
         match &mut self.inner {
             LangModelInner::Local(model) => model.infer(msgs, tools, config),
             LangModelInner::StreamAPI(model) => model.infer(msgs, tools, config),
@@ -162,11 +162,11 @@ mod py {
         messages: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> PyResult<(
+    ) -> anyhow::Result<(
         &'a tokio::runtime::Runtime,
-        async_channel::Receiver<Result<MessageOutput, String>>,
+        async_channel::Receiver<anyhow::Result<MessageOutput>>,
     )> {
-        let (tx, rx) = async_channel::unbounded::<Result<MessageOutput, String>>();
+        let (tx, rx) = async_channel::unbounded::<anyhow::Result<MessageOutput>>();
         let rt = pyo3_async_runtimes::tokio::get_runtime();
         rt.spawn(async move {
             let mut stream = model.infer(messages, tools, config).boxed();
@@ -185,7 +185,7 @@ mod py {
     #[gen_stub_pyclass]
     #[pyclass(unsendable)]
     pub struct LanguageModelRunIterator {
-        rx: async_channel::Receiver<Result<MessageOutput, String>>,
+        rx: async_channel::Receiver<anyhow::Result<MessageOutput>>,
     }
 
     #[gen_stub_pymethods]
@@ -196,7 +196,7 @@ mod py {
         }
 
         #[gen_stub(override_return_type(type_repr = "typing.Awaitable[MessageOutput]"))]
-        fn __anext__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        fn __anext__(&self, py: Python<'_>) -> anyhow::Result<Py<PyAny>> {
             let rx = self.rx.clone();
             let fut = async move {
                 match rx.recv().await {
@@ -213,7 +213,7 @@ mod py {
     #[pyclass(unsendable)]
     pub struct LanguageModelRunSyncIterator {
         rt: &'static tokio::runtime::Runtime,
-        rx: async_channel::Receiver<Result<MessageOutput, String>>,
+        rx: async_channel::Receiver<anyhow::Result<MessageOutput>>,
     }
 
     #[gen_stub_pymethods]
@@ -223,7 +223,7 @@ mod py {
             slf
         }
 
-        fn __next__(&mut self, py: Python<'_>) -> PyResult<MessageOutput> {
+        fn __next__(&mut self, py: Python<'_>) -> anyhow::Result<MessageOutput> {
             let item = py.detach(|| self.rt.block_on(self.rx.recv()));
             match item {
                 Ok(res) => res.map_err(|e| PyRuntimeError::new_err(e.to_string())),
@@ -244,7 +244,7 @@ mod py {
             model_name: String,
             #[gen_stub(override_type(type_repr = "typing.Callable[[CacheProgress], None]"))]
             progress_callback: Option<Py<PyAny>>,
-        ) -> PyResult<Bound<'a, PyAny>> {
+        ) -> Result<Bound<'a, PyAny>> {
             let fut = async move {
                 let inner =
                     await_cache_result::<LocalLangModel>(model_name, progress_callback).await?;
@@ -268,7 +268,7 @@ mod py {
             model_name: String,
             #[gen_stub(override_type(type_repr = "typing.Callable[[CacheProgress], None]"))]
             progress_callback: Option<Py<PyAny>>,
-        ) -> PyResult<Py<Self>> {
+        ) -> anyhow::Result<Py<Self>> {
             let inner = await_future(await_cache_result::<LocalLangModel>(
                 model_name,
                 progress_callback,
@@ -302,7 +302,7 @@ mod py {
             messages: Vec<Message>,
             tools: Vec<ToolDesc>,
             config: InferenceConfig,
-        ) -> PyResult<LanguageModelRunIterator> {
+        ) -> anyhow::Result<LanguageModelRunIterator> {
             let (_, rx) = spawn(self.clone(), messages, tools, config)?;
             Ok(LanguageModelRunIterator { rx })
         }
@@ -313,7 +313,7 @@ mod py {
             messages: Vec<Message>,
             tools: Vec<ToolDesc>,
             config: InferenceConfig,
-        ) -> PyResult<LanguageModelRunSyncIterator> {
+        ) -> anyhow::Result<LanguageModelRunSyncIterator> {
             let (rt, rx) = spawn(self.clone(), messages, tools, config)?;
             Ok(LanguageModelRunSyncIterator { rt, rx })
         }

--- a/v2/src/model/local/local_language_model.rs
+++ b/v2/src/model/local/local_language_model.rs
@@ -1,5 +1,6 @@
 use std::{any::Any, collections::BTreeMap, sync::Arc};
 
+use anyhow::bail;
 use async_stream::try_stream;
 use futures::StreamExt;
 use tokio::sync::mpsc;
@@ -21,7 +22,7 @@ struct Request {
     msgs: Vec<Message>,
     tools: Vec<ToolDesc>,
     config: InferenceConfig,
-    tx_resp: mpsc::UnboundedSender<Result<MessageOutput, String>>,
+    tx_resp: mpsc::UnboundedSender<anyhow::Result<MessageOutput>>,
 }
 
 #[derive(Clone, Debug)]
@@ -30,7 +31,7 @@ pub struct LocalLangModel {
 }
 
 impl LocalLangModel {
-    pub async fn try_new(model: impl Into<String>) -> Result<Self, String> {
+    pub async fn try_new(model: impl Into<String>) -> anyhow::Result<Self> {
         let cache = Cache::new();
         let mut strm = Box::pin(cache.try_create::<LocalLangModel>(model));
         while let Some(v) = strm.next().await {
@@ -43,7 +44,7 @@ impl LocalLangModel {
 
     pub fn try_new_stream<'a>(
         model: impl Into<String>,
-    ) -> BoxStream<'a, Result<CacheProgress<Self>, String>> {
+    ) -> BoxStream<'a, anyhow::Result<CacheProgress<Self>>> {
         let cache = Cache::new();
         Box::pin(cache.try_create::<Self>(model))
     }
@@ -53,11 +54,11 @@ impl TryFromCache for LocalLangModel {
     fn claim_files(
         cache: Cache,
         key: impl AsRef<str>,
-    ) -> BoxFuture<'static, Result<CacheClaim, String>> {
+    ) -> BoxFuture<'static, anyhow::Result<CacheClaim>> {
         LocalLangModelImpl::claim_files(cache, key)
     }
 
-    fn try_from_contents(contents: CacheContents) -> BoxFuture<'static, Result<Self, String>> {
+    fn try_from_contents(contents: CacheContents) -> BoxFuture<'static, anyhow::Result<Self>> {
         Box::pin(async move {
             let mut body = LocalLangModelImpl::try_from_contents(contents).await?;
             let (tx, mut rx) = mpsc::channel(1);
@@ -94,7 +95,7 @@ impl LangModelInference for LocalLangModel {
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> crate::utils::BoxStream<'a, Result<MessageOutput, String>> {
+    ) -> crate::utils::BoxStream<'a, anyhow::Result<MessageOutput>> {
         let (tx_resp, mut rx_resp) = tokio::sync::mpsc::unbounded_channel();
         let req = Request {
             msgs,
@@ -128,7 +129,7 @@ impl LocalLangModelImpl {
         msgs: Vec<Message>,
         tools: Vec<ToolDesc>,
         config: InferenceConfig,
-    ) -> BoxStream<'a, Result<MessageOutput, String>> {
+    ) -> BoxStream<'a, anyhow::Result<MessageOutput>> {
         let strm = try_stream! {
             match config.think_effort {
                 ThinkEffort::Disable => {
@@ -217,7 +218,7 @@ impl TryFromCache for LocalLangModelImpl {
     fn claim_files(
         cache: Cache,
         key: impl AsRef<str>,
-    ) -> BoxFuture<'static, Result<CacheClaim, String>> {
+    ) -> BoxFuture<'static, anyhow::Result<CacheClaim>> {
         let key = key.as_ref().to_owned();
         Box::pin(async move {
             let mut chat_template = ChatTemplate::claim_files(cache.clone(), &key).await?;
@@ -248,7 +249,7 @@ impl TryFromCache for LocalLangModelImpl {
         })
     }
 
-    fn try_from_contents(mut contents: CacheContents) -> BoxFuture<'static, Result<Self, String>>
+    fn try_from_contents(mut contents: CacheContents) -> BoxFuture<'static, anyhow::Result<Self>>
     where
         Self: Sized,
     {
@@ -259,9 +260,9 @@ impl TryFromCache for LocalLangModelImpl {
                         let [a, b, c] = *boxed;
                         (a, b, c)
                     }
-                    Err(_) => return Err("contents.ctx is not [Vec<CacheEntry>; 3]".into()),
+                    Err(_) => bail!("contents.ctx is not [Vec<CacheEntry>; 3]"),
                 },
-                None => return Err("contents.ctx is None".into()),
+                None => bail!("contents.ctx is None"),
             };
 
             let chat_template = {

--- a/v2/src/tool/builtin.rs
+++ b/v2/src/tool/builtin.rs
@@ -40,7 +40,7 @@ impl Tool for BuiltinTool {
         self.desc.clone()
     }
 
-    async fn run(&self, args: Value) -> Result<Value, String> {
+    async fn run(&self, args: Value) -> anyhow::Result<Value> {
         Ok(self.f.clone()(args))
     }
 }

--- a/v2/src/tool/mcp/common.rs
+++ b/v2/src/tool/mcp/common.rs
@@ -1,6 +1,6 @@
 use crate::{to_value, value::Value};
 
-pub fn handle_result(value: rmcp::model::CallToolResult) -> Result<Value, String> {
+pub fn handle_result(value: rmcp::model::CallToolResult) -> anyhow::Result<Value> {
     if let Some(result) = value.structured_content {
         Ok(result.into())
     } else if let Some(content) = value.content {

--- a/v2/src/tool/mcp/native.rs
+++ b/v2/src/tool/mcp/native.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ailoy_macros::multi_platform_async_trait;
+use anyhow::Context;
 use rmcp::{
     RoleClient, ServiceExt as _,
     model::CallToolRequestParam,
@@ -85,14 +86,14 @@ impl Tool for MCPTool {
         }
     }
 
-    async fn run(&self, args: Value) -> Result<Value, String> {
+    async fn run(&self, args: Value) -> anyhow::Result<Value> {
         let tool_name = self.inner.name.clone();
         let peer = self.service.clone();
 
         // Convert your ToolCall arguments → serde_json::Map (MCP expects JSON object)
         let arguments: Option<serde_json::Map<String, serde_json::Value>> =
             serde_json::to_value(args)
-                .map_err(|e| format!("serialize ToolCall arguments failed: {e}"))?
+                .context("serialize ToolCall arguments failed: {e}")?
                 .as_object()
                 .cloned();
 
@@ -103,10 +104,9 @@ impl Tool for MCPTool {
                 arguments,
             })
             .await
-            .map_err(|e| format!("mcp call_tool failed: {e}"))?;
+            .context("mcp call_tool failed: {e}")?;
 
-        let parts =
-            handle_result(result).map_err(|e| format!("call_tool_result_to_parts failed: {e}"))?;
+        let parts = handle_result(result).context("call_tool_result_to_parts failed: {e}")?;
         Ok(parts)
     }
 }

--- a/v2/src/tool/mcp/wasm32.rs
+++ b/v2/src/tool/mcp/wasm32.rs
@@ -239,9 +239,9 @@ impl StreamableHttpClient {
         );
         self.post_message(notification)
             .await
-            .map_err(|e| anyhow!("Failed to send initialized notification: {e}"))?
+            .context("Failed to send initialized notification")?
             .expect_accepted()
-            .map_err(|e| anyhow!("Response of initialized notification is not accepted: {e}"))?;
+            .context("Response of initialized notification is not accepted")?;
 
         Ok(())
     }
@@ -375,14 +375,14 @@ impl Tool for MCPTool {
         }
     }
 
-    async fn run(&self, args: Value) -> Result<Value, String> {
+    async fn run(&self, args: Value) -> anyhow::Result<Value> {
         let client = self.client.clone();
         let tool_name = self.inner.name.clone();
 
         // Convert your ToolCall arguments → serde_json::Map (MCP expects JSON object)
         let arguments: Option<serde_json::Map<String, serde_json::Value>> =
             serde_json::to_value(args)
-                .map_err(|e| format!("serialize ToolCall arguments failed: {e}"))?
+                .context("serialize ToolCall arguments failed: {e}")?
                 .as_object()
                 .cloned();
 
@@ -392,10 +392,9 @@ impl Tool for MCPTool {
                 arguments,
             })
             .await
-            .map_err(|e| format!("mcp call_tool failed: {e}"))?;
+            .context("mcp call_tool failed: {e}")?;
 
-        let parts =
-            handle_result(result).map_err(|e| format!("call_tool_result_to_parts failed: {e}"))?;
+        let parts = handle_result(result).context("call_tool_result_to_parts failed")?;
         Ok(parts)
     }
 }

--- a/v2/src/value/bytes.rs
+++ b/v2/src/value/bytes.rs
@@ -50,7 +50,7 @@ mod py {
     use super::*;
 
     impl<'py> FromPyObject<'py> for Bytes {
-        fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        fn extract_bound(ob: &Bound<'py, PyAny>) -> anyhow::Result<Self> {
             if let Ok(pybytes) = ob.downcast::<PyBytes>() {
                 Ok(Bytes(pybytes.as_bytes().to_vec()))
             } else {

--- a/v2/src/value/delta.rs
+++ b/v2/src/value/delta.rs
@@ -1,10 +1,11 @@
 pub trait Delta: Default {
     type Item;
+    type Err;
 
     /// similar to add operator overloading
     ///
     /// Raises error when enum is different between self & other
-    fn aggregate(self, other: Self) -> Result<Self, ()>;
+    fn aggregate(self, other: Self) -> Result<Self, Self::Err>;
 
-    fn finish(self) -> Result<Self::Item, String>;
+    fn finish(self) -> Result<Self::Item, Self::Err>;
 }

--- a/v2/src/value/marshal.rs
+++ b/v2/src/value/marshal.rs
@@ -9,7 +9,7 @@ pub trait Marshal<T>: Default {
 }
 
 pub trait Unmarshal<T: Delta>: Default {
-    fn unmarshal(&mut self, val: Value) -> Result<T, String>;
+    fn unmarshal(&mut self, val: Value) -> anyhow::Result<T>;
 }
 
 pub struct Marshaled<'d, D, M: Marshal<D>> {

--- a/v2/src/value/message.rs
+++ b/v2/src/value/message.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
 use crate::value::{Delta, Part, PartDelta};
@@ -141,15 +142,16 @@ impl MessageDelta {
         self
     }
 
-    pub fn to_message(self) -> Result<Message, String> {
+    pub fn to_message(self) -> anyhow::Result<Message> {
         self.finish()
     }
 }
 
 impl Delta for MessageDelta {
     type Item = Message;
+    type Err = anyhow::Error; // TODO: Define custom error for this.
 
-    fn aggregate(self, other: Self) -> Result<Self, ()> {
+    fn aggregate(self, other: Self) -> anyhow::Result<Self> {
         let Self {
             mut role,
             mut id,
@@ -164,7 +166,11 @@ impl Delta for MessageDelta {
             && let Some(rhs) = &other.role
         {
             if lhs != rhs {
-                return Err(());
+                bail!(
+                    "Cannot aggregate two message deltas with differenct roles. ({} != {})",
+                    lhs,
+                    rhs
+                );
             };
         } else if let Some(rhs) = other.role {
             role = Some(rhs);
@@ -238,7 +244,7 @@ impl Delta for MessageDelta {
         })
     }
 
-    fn finish(self) -> Result<Self::Item, String> {
+    fn finish(self) -> anyhow::Result<Self::Item> {
         let Self {
             role,
             id,
@@ -249,7 +255,7 @@ impl Delta for MessageDelta {
         } = self;
 
         let Some(role) = role else {
-            return Err("Role not specified".to_owned());
+            bail!("Role not specified")
         };
         let contents = {
             let mut contents_new = Vec::with_capacity(contents.len());

--- a/v2/src/vector_store/mod.rs
+++ b/v2/src/vector_store/mod.rs
@@ -2,7 +2,6 @@ mod api;
 mod local;
 
 use ailoy_macros::{maybe_send_sync, multi_platform_async_trait};
-use anyhow::Result;
 pub use api::*;
 pub use local::*;
 use serde_json::{Map, Value as Json};
@@ -36,23 +35,26 @@ pub struct VectorStoreRetrieveResult {
 #[maybe_send_sync]
 #[multi_platform_async_trait]
 pub trait VectorStore {
-    async fn add_vector(&mut self, input: VectorStoreAddInput) -> Result<String>;
-    async fn add_vectors(&mut self, inputs: Vec<VectorStoreAddInput>) -> Result<Vec<String>>;
-    async fn get_by_id(&self, id: &str) -> Result<Option<VectorStoreGetResult>>;
-    async fn get_by_ids(&self, ids: &[&str]) -> Result<Vec<VectorStoreGetResult>>;
+    async fn add_vector(&mut self, input: VectorStoreAddInput) -> anyhow::Result<String>;
+    async fn add_vectors(
+        &mut self,
+        inputs: Vec<VectorStoreAddInput>,
+    ) -> anyhow::Result<Vec<String>>;
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<VectorStoreGetResult>>;
+    async fn get_by_ids(&self, ids: &[&str]) -> anyhow::Result<Vec<VectorStoreGetResult>>;
     async fn retrieve(
         &self,
         query_embedding: Embedding,
         top_k: usize,
-    ) -> Result<Vec<VectorStoreRetrieveResult>>;
+    ) -> anyhow::Result<Vec<VectorStoreRetrieveResult>>;
     async fn batch_retrieve(
         &self,
         query_embeddings: Vec<Embedding>,
         top_k: usize,
-    ) -> Result<Vec<Vec<VectorStoreRetrieveResult>>>;
-    async fn remove_vector(&mut self, id: &str) -> Result<()>;
-    async fn remove_vectors(&mut self, ids: &[&str]) -> Result<()>;
-    async fn clear(&mut self) -> Result<()>;
+    ) -> anyhow::Result<Vec<Vec<VectorStoreRetrieveResult>>>;
+    async fn remove_vector(&mut self, id: &str) -> anyhow::Result<()>;
+    async fn remove_vectors(&mut self, ids: &[&str]) -> anyhow::Result<()>;
+    async fn clear(&mut self) -> anyhow::Result<()>;
 
-    async fn count(&self) -> Result<usize>;
+    async fn count(&self) -> anyhow::Result<usize>;
 }


### PR DESCRIPTION
## Description
Since Ailoy is a library, it is ultimately desirable to define and then generate Ailoy's own custom errors for various error situations that may occur within it, but since the code is still under active development and the method of generating anyhow and String-type error messages are being mixed to make the transition to custom errors relatively easy in the future, we would like to unify the error handling method to anyhow for now.

After application, we will sequentially replace error handling in API-related parts with custom error types, and gradually change the error handling part of the core code.

## Related document(internal)
https://brekkylab.getoutline.com/doc/ailoy-error-handling-cw3aUqnyH6

