### PR TITLE
fix: allow mixed use of `Message` and `SingleTextMessage` in `Message`

### DIFF
--- a/bindings/nodejs/src/ailoy_core.d.ts
+++ b/bindings/nodejs/src/ailoy_core.d.ts
@@ -194,6 +194,44 @@ export declare function imageFromBytes(data: Uint8Array): Part;
 
 export declare function imageFromUrl(url: string): Part;
 
+/**
+ * Configuration parameters that control the behavior of model inference.
+ *
+ * `InferenceConfig` encapsulates all the configuration, controlling behavior of `LanguageModel`` inference.
+ *
+ * # Fields
+ *
+ * ## `document_polyfill`
+ * Configuration describing how retrieved documents are embedded into the model input.
+ * If `None`, it does not perform any polyfill, (ignoring documents).
+ *
+ * ## `think_effort`
+ * Controls the model’s reasoning intensity.
+ * In local models, `low`, `medium`, `high` is ignored.
+ * In API models, it is up to it's API. See API parameters.
+ *
+ * Possible values: `disable`, `enable`, `low`, `medium`, `high`.
+ *
+ * ## `temperature`
+ * Sampling temperature controlling randomness of output.
+ * Lower values make output more deterministic; higher values increase diversity.
+ *
+ * ## `top_p`
+ * Nucleus sampling parameter (probability mass cutoff).
+ * Limits token sampling to a cumulative probability ≤ `top_p`.`
+ *
+ * ## `max_tokens`
+ * Maximum number of tokens to generate for a single inference.
+ *
+ * ## `grammar`
+ * Optional grammar constraint that restricts valid output forms.
+ * Supported types include:
+ * - `Plain`: unconstrained text
+ * - `JSON`: ensures valid JSON output
+ * - `JSONSchema { schema }`: validates JSON against the given schema
+ * - `Regex { regex }`: constrains generation by a regular expression
+ * - `CFG { cfg }`: uses a context-free grammar definition
+ */
 export interface InferenceConfig {
   documentPolyfill?: DocumentPolyfill;
   thinkEffort?: ThinkEffort;
@@ -319,7 +357,7 @@ export interface MessageOutputIteratorResult {
   done: boolean;
 }
 
-export type Messages = Array<Message> | Array<SingleTextMessage> | string;
+export type Messages = Array<Message | SingleTextMessage> | string;
 
 export type Metadata = Record<string, any>;
 

--- a/bindings/web/src/ailoy-web.d.ts
+++ b/bindings/web/src/ailoy-web.d.ts
@@ -40,11 +40,11 @@ export class Agent {
   setKnowledge(knowledge: Knowledge): void;
   removeKnowledge(): void;
   runDelta(
-    messages: Array<Message> | Array<SingleTextMessage> | string,
+    messages: Array<Message | SingleTextMessage> | string,
     config?: AgentConfig | null
   ): AsyncIterable<MessageDeltaOutput>;
   run(
-    messages: Array<Message> | Array<SingleTextMessage> | string,
+    messages: Array<Message | SingleTextMessage> | string,
     config?: AgentConfig | null
   ): AsyncIterable<MessageOutput>;
 }
@@ -86,13 +86,13 @@ export class LangModel {
     apiKey: string
   ): Promise<LangModel>;
   inferDelta(
-    messages: Array<Message> | Array<SingleTextMessage> | string,
+    messages: Array<Message | SingleTextMessage> | string,
     tools?: ToolDesc[] | null,
     docs?: Document[] | null,
     config?: InferenceConfig | null
   ): AsyncIterable<MessageDeltaOutput>;
   infer(
-    messages: Array<Message> | Array<SingleTextMessage> | string,
+    messages: Array<Message | SingleTextMessage> | string,
     tools?: ToolDesc[] | null,
     docs?: Document[] | null,
     config?: InferenceConfig | null
@@ -200,6 +200,44 @@ export type Grammar =
   | { type: "regex"; regex: string }
   | { type: "cfg"; cfg: string };
 
+/**
+ * Configuration parameters that control the behavior of model inference.
+ *
+ * `InferenceConfig` encapsulates all the configuration, controlling behavior of `LanguageModel`` inference.
+ *
+ * # Fields
+ *
+ * ## `document_polyfill`
+ * Configuration describing how retrieved documents are embedded into the model input.
+ * If `None`, it does not perform any polyfill, (ignoring documents).
+ *
+ * ## `think_effort`
+ * Controls the model’s reasoning intensity.
+ * In local models, `low`, `medium`, `high` is ignored.
+ * In API models, it is up to it\'s API. See API parameters.
+ *
+ * Possible values: `disable`, `enable`, `low`, `medium`, `high`.
+ *
+ * ## `temperature`
+ * Sampling temperature controlling randomness of output.
+ * Lower values make output more deterministic; higher values increase diversity.
+ *
+ * ## `top_p`
+ * Nucleus sampling parameter (probability mass cutoff).
+ * Limits token sampling to a cumulative probability ≤ `top_p`.`
+ *
+ * ## `max_tokens`
+ * Maximum number of tokens to generate for a single inference.
+ *
+ * ## `grammar`
+ * Optional grammar constraint that restricts valid output forms.
+ * Supported types include:
+ * - `Plain`: unconstrained text
+ * - `JSON`: ensures valid JSON output
+ * - `JSONSchema { schema }`: validates JSON against the given schema
+ * - `Regex { regex }`: constrains generation by a regular expression
+ * - `CFG { cfg }`: uses a context-free grammar definition
+ */
 export interface InferenceConfig {
   documentPolyfill?: DocumentPolyfill;
   thinkEffort?: ThinkEffort;


### PR DESCRIPTION
## Description
This PR allows `Messages` to be an array containing both `Messages` and `SingleTextMessages`.
The modification can be understood by this line change:
```diff
- export type Messages = Array<Message> | Array<SingleTextMessage> | string;
+ export type Messages = Array<Message | SingleTextMessage> | string;
```
Because of the definition of `Messages`, when `Messages` was an array, its contents must all be `Messages` or all be `SingleTextMessages`.
These restrictions may seem harmless at first glance, but the users can suffer unexpected inconvenience by those(which I did), and since the required changes are not really big compared to the potention problems, it is considered better to remove them.