### PR TITLE
fix: use `ready` instead of `Downloaded` in `CacheProgress` comments

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -316,7 +316,7 @@ impl Cache {
                 current_task += 1;
                 pairs.push((entry.clone(), bytes));
                 yield CacheProgress::<T> {
-                    comment: format!("Downloaded {}", entry.filename()),
+                    comment: format!("{} ready", entry.filename()),
                     current_task,
                     total_task,
                     result: None,


### PR DESCRIPTION
## Description
Ailoy's cache feature used the term "downloaded" for files(e.g. `"Downloaded tokenizer.json"`) that were downloaded or verified. This term could be interpreted as re-downloading files that already existed. Therefore, I believe a different term would be better.
I considered several terms, but since the purpose of this process is to prepare the files before use, I chose "ready." Please let me know if you have any alternatives.