### PR TITLE
Improve documents related to tools

### DIFF
--- a/docs/docs/tutorial/mcp-integration.mdx
+++ b/docs/docs/tutorial/mcp-integration.mdx
@@ -33,7 +33,7 @@ client = await ai.MCPClient.from_stdio(
 )
 ```
 
-```javascript
+```typescript
 const client = await ai.MCPClient.newStdio("npx", [
   "-y",
   "@modelcontextprotocol/server-github",
@@ -60,7 +60,7 @@ tools = [
 ]
 ```
 
-```javascript
+```typescript
 const tools = [
   client.getTool("search_repositories"),
   client.getTool("get_file_contents"),
@@ -81,7 +81,7 @@ lm = await ai.LangModel.new_local("Qwen/Qwen3-8B", progress_callback=print)
 agent = ai.Agent(lm, tools)
 ```
 
-```javascript
+```typescrpt
 const lm = await ai.LangModel.newLocal("Qwen/Qwen3-8B", null, console.log);
 const agent = new ai.Agent(lm, tools);
 ```
@@ -135,7 +135,7 @@ async def main():
         client.get_tool("search_repositories"),
         client.get_tool("get_file_contents"),
     ]
-    lm = await ai.LangModel.new_local("Qwen/Qwen3-8B", progress_callback=print)
+    lm = await ai.LangModel.new_local("Qwen/Qwen3-4B", progress_callback=print)
     agent = ai.Agent(lm, tools)
     query = "Search the repository named brekkylab/ailoy and describe what it does based on its README.md."
     async for resp in agent.run(query):
@@ -158,7 +158,7 @@ async function main() {
     client.getTool("search_repositories"),
     client.getTool("get_file_contents"),
   ];
-  const lm = await ai.LangModel.newLocal("Qwen/Qwen3-8B", null, console.log);
+  const lm = await ai.LangModel.newLocal("Qwen/Qwen3-4B", null, console.log);
   const agent = new ai.Agent(lm, tools);
   const query =
     "Search the repository named brekkylab/ailoy and describe what it does based on its README.md.";

--- a/docs/docs/tutorial/using-tools.mdx
+++ b/docs/docs/tutorial/using-tools.mdx
@@ -8,7 +8,7 @@ even if it wasn’t part of the model’s training data.
 To use a tool, two components must be defined: **Tool Descripition** and **Tool
 Behavior**.
 
-:::info
+:::note
 
 Please refer to **[Architecture](../concepts/architecture.mdx#tool)** section
 for more about the tool architecture.
@@ -20,10 +20,11 @@ Now, let's explore how to make a _tool-aware agent_ in Ailoy.
 In this example, we’ll use the **[Frankfurter API](https://frankfurter.dev/)**
 to enable your agent to look up real-time currency exchange rates.
 
-:::info
+:::note
 
-Please refer to **[MCP Integration](./mcp-integration.mdx)** section for using
-MCP tools.
+Ailoy also supports **[MCP](https://modelcontextprotocol.io/)** as tool. Please
+refer to **[MCP Integration](./mcp-integration.mdx)** section for using MCP
+tools.
 
 :::
 
@@ -176,13 +177,13 @@ You can register a tool by passing it to the `Agent` constructor.
 <CodeTabs>
 
 ```python
-lm = await ai.LangModel.new_local("Qwen/Qwen3-8B")
+lm = await ai.LangModel.new_local("Qwen/Qwen3-4B")
 tools = [ai.Tool.new_py_function(tool_behavior, tool_desc)]
 agent = ai.Agent(lm, tools)
 ```
 
 ```typescript
-const lm = await ai.LangModel.newLocal("Qwen/Qwen3-8B");
+const lm = await ai.LangModel.newLocal("Qwen/Qwen3-4B");
 const tools = [ai.Tool.newFunction(toolDesc, toolBehavior)];
 const agent = new ai.Agent(lm, tools);
 ```
@@ -336,10 +337,10 @@ def tool_behavior(base, symbols):
 
 
 async def main():
-    lm = await ai.LangModel.new_local("Qwen/Qwen3-8B", None, progress_callback=print)
+    lm = await ai.LangModel.new_local("Qwen/Qwen3-4B", None, progress_callback=print)
     tools = [ai.Tool.new_py_function(tool_behavior, tool_desc)]
     agent = ai.Agent(lm, tools)
-    query = "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take?"
+    query = "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take? Get the currency data if you need."
     print("Query:", query, "\n")
     async for resp in agent.run(query):
         if resp.message.role == "assistant":
@@ -410,14 +411,95 @@ async function toolBehavior(args) {
 
 async function main() {
   const lm = await ai.LangModel.newLocal(
-    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3-4B",
     undefined,
     console.log
   );
   const tools = [ai.Tool.newFunction(toolDesc, toolBehavior)];
   const agent = new ai.Agent(lm, tools);
   const query =
-    "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take?";
+    "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take? Get the currency data if you need.";
+  for await (const resp of agent.run(query)) {
+    if (resp.message.role === "assistant") {
+      if (resp.message.tool_calls?.length > 0) {
+        console.log("Tool call:", resp.message.tool_calls[0].function, "\n");
+      } else {
+        console.log(resp.message.contents[0].text, "\n");
+      }
+    } else if (resp.message.role === "tool") {
+      console.log("Tool response:", resp.message.contents[0].value, "\n");
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+});
+```
+
+```typescript web
+import * as ai from "ailoy-web";
+
+const toolDesc = {
+  name: "frankfurter",
+  description:
+    "Get the latest currency exchange rates of target currencies based on the 'base' currency",
+  parameters: {
+    type: "object",
+    properties: {
+      base: {
+        type: "string",
+        description:
+          "The ISO 4217 currency code to be the divider of the currency rate to be got.",
+      },
+      symbols: {
+        type: "string",
+        description: "The target ISO 4217 currency codes separated by comma.",
+      },
+    },
+  },
+};
+
+async function toolBehavior(args) {
+  const { base, symbols } = args;
+  if (!base) {
+    throw new Error("Missing 'base'");
+  }
+  if (!symbols) {
+    throw new Error("Missing 'symbols'");
+  }
+
+  const params = new URLSearchParams({ from: base, to: symbols });
+  const url = `https://api.frankfurter.app/latest?${params.toString()}`;
+
+  let resp;
+  try {
+    resp = await fetch(url, { timeout: 10000 });
+  } catch (err) {
+    throw new Error(`Failed to reach Frankfurter API: ${err.message}`);
+  }
+
+  if (!resp.ok) {
+    throw new Error(`Frankfurter API returned HTTP ${resp.status}`);
+  }
+
+  try {
+    return await resp.json();
+  } catch {
+    throw new Error("Failed to parse Frankfurter API response as JSON.");
+  }
+}
+
+async function main() {
+  const lm = await ai.LangModel.newLocal(
+    "Qwen/Qwen3-4B",
+    undefined,
+    console.log
+  );
+  const tools = [ai.Tool.newFunction(toolDesc, toolBehavior)];
+  const agent = new ai.Agent(lm, tools);
+  const query =
+    "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take? Get the currency data if you need.";
   for await (const resp of agent.run(query)) {
     if (resp.message.role === "assistant") {
       if (resp.message.tool_calls?.length > 0) {


### PR DESCRIPTION
## Changes
- added info admonition to guide to MCP integration in web
- added the description and an example for python function tool with docstring
- added `Complete Example` code for  in `Using Tool`
  - I didn't add any other code in the document because there is no difference between Nodejs and web, but I added it in `Complete Example` to imply that web environment is also supported. (There are also different parts in the code.)
- minor changes
  - 8B -> 4B in example codes
  - Some improvements to the prompt to allow agents to use the tool immediately without asking whether to use it.
  - info -> note for the cases of simple reference only