### PR TITLE
Bump up to v0.2.0-rc0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "ailoy"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 dependencies = [
  "ailoy-macros",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ailoy"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 edition = "2024"
 
 [lib]

--- a/bindings/nodejs/package-lock.json
+++ b/bindings/nodejs/package-lock.json
@@ -1,12 +1,16 @@
 {
     "name": "ailoy-node",
-    "version": "0.2.0",
+    "version": "0.2.0-rc0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ailoy-node",
-            "version": "0.2.0",
+            "version": "0.2.0-rc0",
+            "cpu": [
+                "x64",
+                "arm64"
+            ],
             "license": "Apache-2.0",
             "os": [
                 "darwin",
@@ -31,9 +35,9 @@
                 "node": ">=20.3.0"
             },
             "optionalDependencies": {
-                "ailoy-node-darwin-arm64": "./npm/darwin-arm64",
-                "ailoy-node-linux-x64-gnu": "./npm/linux-x64-gnu",
-                "ailoy-node-win32-x64-msvc": "./npm/win32-x64-msvc"
+                "ailoy-node-darwin-arm64": "0.2.0",
+                "ailoy-node-linux-x64-gnu": "0.2.0",
+                "ailoy-node-win32-x64-msvc": "0.2.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ailoy-node",
-    "version": "0.2.0",
+    "version": "0.2.0-rc0",
     "author": "Brekkylab Inc. <contact@brekkylab.com>",
     "license": "Apache-2.0",
     "description": "Node.js binding for Ailoy API",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ailoy-py"
-version = "0.2.0"
+version = "0.2.0rc0"
 description = "A lightweight library for building AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/web/package-lock.json
+++ b/bindings/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ailoy-web",
-    "version": "0.2.0",
+    "version": "0.2.0-rc0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ailoy-web",
-            "version": "0.2.0",
+            "version": "0.2.0-rc0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@trivago/prettier-plugin-sort-imports": "^5.2.2",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ailoy-web",
-    "version": "0.2.0",
+    "version": "0.2.0-rc0",
     "author": "Brekkylab Inc. <contact@brekkylab.com>",
     "license": "Apache-2.0",
     "description": "Ailoy JavaScript API on Web browser environments",


### PR DESCRIPTION
Github release tag: `v0.2.0-rc0`
Rust crate version: `0.2.0-rc.0`
Python package version: `0.2.0rc0`
NPM package version: `0.2.0-rc0`

Manually versioned for now, but need to create the script to automate it later.