### PR TITLE
fix(web): get `navigator.storage` properly on web worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ web-sys = { version = "0.3", features = [
     "Navigator",
     "Storage",
     "StorageManager",
+    "WorkerNavigator",
     "console"
 ] }
 web-time = "1.1"


### PR DESCRIPTION
There's no `window` object in web worker environment, which results in the failure of getting `window.navigator.storage`. This PR fixes this error by following the solution in https://github.com/gfx-rs/wgpu/pull/2858.