### PR TITLE
fix(gemini): adjust finish reason for tool call responses

### DIFF
--- a/src/model/api/gemini.rs
+++ b/src/model/api/gemini.rs
@@ -364,7 +364,11 @@ pub(super) fn handle_event(evt: ServerEvent) -> MessageDeltaOutput {
 
     // Gemini always return "STOP" even for tool call responses,
     // so adjust the finish reason when tool calls exist.
-    if !delta.tool_calls.is_empty() && finish_reason.is_some() {
+    if !delta.tool_calls.is_empty()
+        && finish_reason
+            .clone()
+            .is_some_and(|reason| matches!(reason, FinishReason::Stop {}))
+    {
         finish_reason = Some(FinishReason::ToolCall {});
     }
 


### PR DESCRIPTION
Gemini always return the finish reason as `Stop` even for tool calls response. This PR adjusts the finish reason from `FinishReason::Stop` to `FinishReason::ToolCall` if any tool calls exist.