### PR TITLE
API schema updated

### DIFF
--- a/src/agent/rt/lang_model/mod.rs
+++ b/src/agent/rt/lang_model/mod.rs
@@ -61,7 +61,7 @@ impl LangModelRuntime {
                     LangModelAPISchema::Gemini => {
                         Value::from(Marshaled::<LangModelRequest, api::GeminiMarshal>::new(&req))
                     }
-                    LangModelAPISchema::OpenAI | LangModelAPISchema::Responses => {
+                    LangModelAPISchema::OpenAI => {
                         Value::from(Marshaled::<LangModelRequest, api::OpenAIMarshal>::new(&req))
                     }
                 };
@@ -127,7 +127,7 @@ impl LangModelRuntime {
                     LangModelAPISchema::Gemini => {
                         api::GeminiUnmarshal::default().unmarshal(response_value)?
                     }
-                    LangModelAPISchema::OpenAI | LangModelAPISchema::Responses => {
+                    LangModelAPISchema::OpenAI => {
                         api::OpenAIUnmarshal::default().unmarshal(response_value)?
                     }
                 };

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -49,11 +49,17 @@ impl AgentSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LangModelAPISchema {
+    /// OpenAI-compatible `/v1/chat/completions` format
     ChatCompletion,
+
+    /// Anthropic Messages API format
     Anthropic,
+
+    /// Google Gemini API format
     Gemini,
+
+    /// OpenAI Responses API format
     OpenAI,
-    Responses,
 }
 
 /// Describes the runtime endpoint used to invoke a language model.

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -39,13 +39,6 @@ impl AgentSpec {
 }
 
 /// Wire protocol used when calling a language model API.
-///
-/// Each variant corresponds to a distinct request/response schema:
-/// - `ChatCompletion`: OpenAI-compatible `/v1/chat/completions` format.
-/// - `Anthropic`: Anthropic Messages API format.
-/// - `Gemini`: Google Gemini API format.
-/// - `OpenAI`: Alias for the canonical OpenAI schema (same as `ChatCompletion`).
-/// - `Responses`: OpenAI Responses API format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LangModelAPISchema {
@@ -63,13 +56,10 @@ pub enum LangModelAPISchema {
 }
 
 /// Describes the runtime endpoint used to invoke a language model.
-///
-/// # Variants
-/// - `API`: Calls a remote HTTP API. Requires the wire `schema`, the `url` of the endpoint,
-///   and an optional `api_key` for authentication.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum LangModelProvider {
+    /// Calls a remote HTTP API. Requires the wire `schema`, the `url` of the endpoint, and an optional `api_key` for authentication.
     API {
         schema: LangModelAPISchema,
 


### PR DESCRIPTION
1. Removed `Responses` schema (as it is alias of `OpenAI`)
2. Comment changed