### PR TITLE
Fix ToolFunc and ToolRuntime

### DIFF
--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -7,14 +7,14 @@ use crate::{
     message::{FinishReason, Message, MessageOutput, Part, Role},
 };
 
-pub struct AgentRuntime<'a> {
+pub struct AgentRuntime {
     lm: LangModelRuntime,
-    tools: Vec<ToolRuntime<'a>>,
+    tools: Vec<ToolRuntime>,
     history: Vec<Message>,
 }
 
-impl<'a> AgentRuntime<'a> {
-    pub fn new(spec: AgentSpec, provider: AgentProvider, tool_set: ToolSet<'a>) -> Self {
+impl AgentRuntime {
+    pub fn new(spec: AgentSpec, provider: AgentProvider, tool_set: ToolSet) -> Self {
         // Prepare toolsets
         let tool_set =
             provider
@@ -59,6 +59,10 @@ impl<'a> AgentRuntime<'a> {
             last.map(|o: MessageOutput| o.message)
                 .ok_or_else(|| anyhow::anyhow!("No assistant response"))
         })
+    }
+
+    pub fn get_history(&self) -> Vec<Message> {
+        self.history.clone()
     }
 
     pub fn stream_turn(
@@ -122,13 +126,12 @@ mod tests {
     use futures::StreamExt as _;
     use url::Url;
 
+    use super::*;
     use crate::{
         agent::{LangModelAPISchema, LangModelProvider, ToolFunc},
         message::{Part, Role, ToolDescBuilder},
         to_value,
     };
-
-    use super::*;
 
     /// Verifies that the agent calls the temperature tool and returns a final answer.
     #[tokio::test]

--- a/src/agent/rt/tool.rs
+++ b/src/agent/rt/tool.rs
@@ -8,16 +8,16 @@ use crate::{
     message::{Message, Part, Role, ToolDesc},
 };
 
-pub type ToolFunc<'a> = dyn Fn(Value) -> BoxFuture<'a, Value>;
+pub type ToolFunc = dyn Fn(Value) -> BoxFuture<'static, Value> + Send + Sync;
 
 #[derive(Clone)]
-pub struct ToolRuntime<'a> {
+pub struct ToolRuntime {
     desc: ToolDesc,
-    f: Arc<ToolFunc<'a>>,
+    f: Arc<ToolFunc>,
 }
 
-impl<'a> ToolRuntime<'a> {
-    pub fn new(desc: ToolDesc, f: Arc<ToolFunc<'a>>) -> Self {
+impl ToolRuntime {
+    pub fn new(desc: ToolDesc, f: Arc<ToolFunc>) -> Self {
         Self { desc, f }
     }
 
@@ -45,22 +45,22 @@ impl<'a> ToolRuntime<'a> {
     }
 }
 
-pub struct ToolSet<'a> {
-    tools: HashMap<String, ToolRuntime<'a>>,
+pub struct ToolSet {
+    tools: HashMap<String, ToolRuntime>,
 }
 
-impl<'a> ToolSet<'a> {
+impl ToolSet {
     pub fn new() -> Self {
         Self {
             tools: HashMap::new(),
         }
     }
 
-    pub fn insert(&mut self, key: String, value: ToolRuntime<'a>) -> Option<ToolRuntime<'a>> {
+    pub fn insert(&mut self, key: String, value: ToolRuntime) -> Option<ToolRuntime> {
         self.tools.insert(key, value)
     }
 
-    pub fn remove(&mut self, key: &str) -> Option<ToolRuntime<'a>> {
+    pub fn remove(&mut self, key: &str) -> Option<ToolRuntime> {
         self.tools.remove(key)
     }
 
@@ -80,7 +80,7 @@ impl<'a> ToolSet<'a> {
         }
     }
 
-    pub fn get(&self, key: &str) -> Option<&ToolRuntime<'a>> {
+    pub fn get(&self, key: &str) -> Option<&ToolRuntime> {
         self.tools.values().find(|t| t.desc.name == key)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,12 @@ extern crate self as ailoy;
 pub mod agent;
 pub mod datatype;
 pub mod message;
+
+pub use agent::{
+    AgentProvider, AgentRuntime, AgentSpec, LangModelAPISchema, LangModelProvider, ToolProvider,
+    ToolRuntime, ToolSet,
+};
+pub use datatype::Value;
+pub use message::{
+    Message, MessageDeltaOutput, MessageOutput, Part, Role, ToolDesc, ToolDescBuilder,
+};


### PR DESCRIPTION
- Added `Send` and `Sync` to `ToolRuntime` since it can be used in multi threads environments such as tokio.
- Removed lifetime from `ToolFunc` since its lifetime has nothing to do with the returned BoxFuture value.
- Added `get_history()` on `AgentRuntime` to access to agent's message history.