### PR TITLE
Restore `LangModelInferConfig` with `max_tokens`

### DIFF
--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -78,7 +78,7 @@ impl AgentRuntime {
             let tool_descs: Vec<_> = self.tools.iter().map(|t| t.desc().clone()).collect();
 
             loop {
-                let output = match self.lm.run(&self.history, &tool_descs).await {
+                let output = match self.lm.run(&self.history, &tool_descs, &Default::default()).await {
                     Ok(o) => o,
                     Err(e) => {
                         yield Err(e);

--- a/src/agent/rt/lang_model/api/anthropic.rs
+++ b/src/agent/rt/lang_model/api/anthropic.rs
@@ -181,17 +181,16 @@ impl<'a> Marshal<LangModelRequest<'a>> for AnthropicMarshal {
         }
 
         #[cfg(target_arch = "wasm32")]
-        header
-            .as_object_mut()
-            .unwrap()
-            .insert(
-                "anthropic-dangerous-direct-browser-access".into(),
-                "true".into(),
-            );
+        header.as_object_mut().unwrap().insert(
+            "anthropic-dangerous-direct-browser-access".into(),
+            "true".into(),
+        );
 
+        // Anthropic requires an explicit max_tokens value, so we set it as 8192
+        let max_tokens = req.infer_config.max_tokens.unwrap_or(8192) as i64;
         let mut body = to_value!({
             "model": model,
-            "max_tokens": 8192_i64,
+            "max_tokens": max_tokens,
             "messages": messages,
         });
         if let Some(system) = system {
@@ -276,21 +275,15 @@ impl Unmarshal<MessageDeltaOutput> for AnthropicUnmarshal {
                         .unwrap_or("");
                     match ty {
                         "text" => {
-                            if let Some(text) =
-                                content_obj.get("text").and_then(|v| v.as_str())
-                            {
+                            if let Some(text) = content_obj.get("text").and_then(|v| v.as_str()) {
                                 text_parts.push(PartDelta::Text { text: text.into() });
                             }
                         }
                         "thinking" => {
-                            if let Some(t) =
-                                content_obj.get("thinking").and_then(|v| v.as_str())
-                            {
+                            if let Some(t) = content_obj.get("thinking").and_then(|v| v.as_str()) {
                                 thinking = Some(t.to_owned());
                             }
-                            if let Some(s) =
-                                content_obj.get("signature").and_then(|v| v.as_str())
-                            {
+                            if let Some(s) = content_obj.get("signature").and_then(|v| v.as_str()) {
                                 signature = Some(s.to_owned());
                             }
                         }
@@ -338,5 +331,91 @@ impl Unmarshal<MessageDeltaOutput> for AnthropicUnmarshal {
             delta,
             finish_reason,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::{
+        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        message::{FinishReason, Message, Part, Role, ToolDesc},
+    };
+
+    fn make_req<'a>(
+        model: &'a str,
+        url: &'a Url,
+        api_key: &'a Option<String>,
+        infer_config: &'a LangModelInferConfig,
+    ) -> LangModelRequest<'a> {
+        LangModelRequest {
+            model,
+            messages: &[],
+            tools: &[],
+            url,
+            api_key,
+            infer_config,
+        }
+    }
+
+    #[test]
+    fn test_marshal_max_tokens_set() {
+        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig {
+            max_tokens: Some(512),
+        };
+        let req = make_req("claude-sonnet-4-6", &url, &api_key, &config);
+
+        let val = AnthropicMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+        assert_eq!(max_tokens.as_integer().unwrap(), 512);
+    }
+
+    #[test]
+    fn test_marshal_max_tokens_default() {
+        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig::default();
+        let req = make_req("claude-sonnet-4-6", &url, &api_key, &config);
+
+        let val = AnthropicMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+        // Falls back to 8192 when not configured
+        assert_eq!(max_tokens.as_integer().unwrap(), 8192);
+    }
+
+    /// Verifies that max_tokens is respected by the Anthropic API (stop_reason: max_tokens).
+    #[tokio::test]
+    async fn test_run_max_tokens() {
+        dotenvy::dotenv().ok();
+        let api_key =
+            std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set in .env");
+
+        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let lm = LangModelRuntime::new(
+            "claude-haiku-4-5-20251001".to_string(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::Anthropic,
+                url,
+                api_key: Some(api_key),
+            },
+        );
+        let messages = vec![
+            Message::new(Role::User)
+                .with_contents([Part::text("Tell me a long story about a dragon.")]),
+        ];
+        let tools: Vec<ToolDesc> = vec![];
+        let config = LangModelInferConfig {
+            max_tokens: Some(5),
+        };
+
+        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        println!("{}", resp);
+        assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -136,9 +136,10 @@ impl<'a> Marshal<LangModelRequest<'a>> for ChatCompletionMarshal {
                 .insert("tools".to_owned(), tools);
         }
         if let Some(max_tokens) = req.infer_config.max_tokens {
-            body.as_object_mut()
-                .unwrap()
-                .insert("max_tokens".to_owned(), (max_tokens as i64).into());
+            body.as_object_mut().unwrap().insert(
+                "max_completion_tokens".to_owned(),
+                (max_tokens as i64).into(),
+            );
         }
         body.as_object_mut()
             .unwrap()
@@ -281,7 +282,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
@@ -305,7 +306,9 @@ mod tests {
     fn test_marshal_max_tokens_set() {
         let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
         let api_key = None;
-        let config = LangModelInferConfig { max_tokens: Some(256) };
+        let config = LangModelInferConfig {
+            max_tokens: Some(256),
+        };
         let req = make_req("gpt-4o", &url, &api_key, &config);
 
         let val = ChatCompletionMarshal::default().marshal(&req);
@@ -341,10 +344,14 @@ mod tests {
                 api_key: Some(api_key),
             },
         );
-        let messages = vec![Message::new(Role::User)
-            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let messages = vec![
+            Message::new(Role::User)
+                .with_contents([Part::text("Tell me a long story about a dragon.")]),
+        ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig { max_tokens: Some(5) };
+        let config = LangModelInferConfig {
+            max_tokens: Some(5),
+        };
 
         let resp = lm.run(&messages, &tools, &config).await.unwrap();
         println!("{}", resp);

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -135,6 +135,11 @@ impl<'a> Marshal<LangModelRequest<'a>> for ChatCompletionMarshal {
                 .unwrap()
                 .insert("tools".to_owned(), tools);
         }
+        if let Some(max_tokens) = req.infer_config.max_tokens {
+            body.as_object_mut()
+                .unwrap()
+                .insert("max_tokens".to_owned(), (max_tokens as i64).into());
+        }
         body.as_object_mut()
             .unwrap()
             .retain(|_key, value| !value.is_null());
@@ -267,5 +272,82 @@ impl Unmarshal<MessageDeltaOutput> for ChatCompletionUnmarshal {
             delta,
             finish_reason,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::{
+        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        message::{FinishReason, Message, Part, Role, ToolDesc},
+    };
+
+    fn make_req<'a>(
+        model: &'a str,
+        url: &'a Url,
+        api_key: &'a Option<String>,
+        infer_config: &'a LangModelInferConfig,
+    ) -> LangModelRequest<'a> {
+        LangModelRequest {
+            model,
+            messages: &[],
+            tools: &[],
+            url,
+            api_key,
+            infer_config,
+        }
+    }
+
+    #[test]
+    fn test_marshal_max_tokens_set() {
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig { max_tokens: Some(256) };
+        let req = make_req("gpt-4o", &url, &api_key, &config);
+
+        let val = ChatCompletionMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+        assert_eq!(max_tokens.as_integer().unwrap(), 256);
+    }
+
+    #[test]
+    fn test_marshal_max_tokens_absent_when_none() {
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig::default();
+        let req = make_req("gpt-4o", &url, &api_key, &config);
+
+        let val = ChatCompletionMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        assert!(body.as_object().unwrap().get("max_tokens").is_none());
+    }
+
+    /// Verifies that max_tokens is respected by the ChatCompletion API (finish_reason: length).
+    #[tokio::test]
+    async fn test_run_max_tokens() {
+        dotenvy::dotenv().ok();
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
+
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        let lm = LangModelRuntime::new(
+            "gpt-4o-mini".to_string(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::ChatCompletion,
+                url,
+                api_key: Some(api_key),
+            },
+        );
+        let messages = vec![Message::new(Role::User)
+            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let tools: Vec<ToolDesc> = vec![];
+        let config = LangModelInferConfig { max_tokens: Some(5) };
+
+        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        println!("{}", resp);
+        assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/gemini.rs
+++ b/src/agent/rt/lang_model/api/gemini.rs
@@ -192,6 +192,12 @@ impl<'a> Marshal<LangModelRequest<'a>> for GeminiMarshal {
         if !tools.is_null() {
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
+        if let Some(max_tokens) = req.infer_config.max_tokens {
+            body.as_object_mut().unwrap().insert(
+                "generationConfig".into(),
+                to_value!({"maxOutputTokens": max_tokens as i64}),
+            );
+        }
 
         to_value!({
             "url": url,
@@ -322,6 +328,91 @@ fn parse_candidate_content(candidate: &Value) -> anyhow::Result<MessageDelta> {
     }
 
     Ok(rv)
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::{
+        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        message::{FinishReason, Message, Part, Role, ToolDesc},
+    };
+
+    fn make_req<'a>(
+        model: &'a str,
+        url: &'a Url,
+        api_key: &'a Option<String>,
+        infer_config: &'a LangModelInferConfig,
+    ) -> LangModelRequest<'a> {
+        LangModelRequest {
+            model,
+            messages: &[],
+            tools: &[],
+            url,
+            api_key,
+            infer_config,
+        }
+    }
+
+    #[test]
+    fn test_marshal_max_output_tokens_set() {
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig {
+            max_tokens: Some(2048),
+        };
+        let req = make_req("gemini-2.0-flash", &url, &api_key, &config);
+
+        let val = GeminiMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
+        let max_tokens = gen_config
+            .as_object()
+            .unwrap()
+            .get("maxOutputTokens")
+            .unwrap();
+        assert_eq!(max_tokens.as_integer().unwrap(), 2048);
+    }
+
+    #[test]
+    fn test_marshal_max_output_tokens_absent_when_none() {
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig::default();
+        let req = make_req("gemini-2.0-flash", &url, &api_key, &config);
+
+        let val = GeminiMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        assert!(body.as_object().unwrap().get("generationConfig").is_none());
+    }
+
+    /// Verifies that max_tokens is respected by the Gemini API (finishReason: MAX_TOKENS).
+    #[tokio::test]
+    async fn test_run_max_tokens() {
+        dotenvy::dotenv().ok();
+        let api_key =
+            std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
+
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let lm = LangModelRuntime::new(
+            "gemini-2.5-flash-lite".to_string(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::Gemini,
+                url,
+                api_key: Some(api_key),
+            },
+        );
+        let messages = vec![Message::new(Role::User)
+            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let tools: Vec<ToolDesc> = vec![];
+        let config = LangModelInferConfig { max_tokens: Some(5) };
+
+        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        println!("{}", resp);
+        assert_eq!(resp.finish_reason, FinishReason::Length {});
+    }
 }
 
 // #[cfg(test)]

--- a/src/agent/rt/lang_model/api/openai.rs
+++ b/src/agent/rt/lang_model/api/openai.rs
@@ -170,6 +170,11 @@ impl<'a> Marshal<LangModelRequest<'a>> for OpenAIMarshal {
                 .insert("tool_choice".into(), to_value!("auto"));
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
+        if let Some(max_tokens) = req.infer_config.max_tokens {
+            body.as_object_mut()
+                .unwrap()
+                .insert("max_output_tokens".into(), (max_tokens as i64).into());
+        }
 
         to_value!({
             "url": url,
@@ -314,6 +319,84 @@ impl Unmarshal<MessageDeltaOutput> for OpenAIUnmarshal {
             delta,
             finish_reason,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::{
+        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        message::{FinishReason, Message, Part, Role, ToolDesc},
+    };
+
+    fn make_req<'a>(
+        model: &'a str,
+        url: &'a Url,
+        api_key: &'a Option<String>,
+        infer_config: &'a LangModelInferConfig,
+    ) -> LangModelRequest<'a> {
+        LangModelRequest {
+            model,
+            messages: &[],
+            tools: &[],
+            url,
+            api_key,
+            infer_config,
+        }
+    }
+
+    #[test]
+    fn test_marshal_max_output_tokens_set() {
+        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig { max_tokens: Some(1024) };
+        let req = make_req("gpt-4o", &url, &api_key, &config);
+
+        let val = OpenAIMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
+        assert_eq!(max_tokens.as_integer().unwrap(), 1024);
+    }
+
+    #[test]
+    fn test_marshal_max_output_tokens_absent_when_none() {
+        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
+        let api_key = None;
+        let config = LangModelInferConfig::default();
+        let req = make_req("gpt-4o", &url, &api_key, &config);
+
+        let val = OpenAIMarshal::default().marshal(&req);
+        let body = val.as_object().unwrap().get("body").unwrap();
+        assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
+    }
+
+    /// Verifies that max_tokens is respected by the OpenAI Responses API (incomplete: max_output_tokens).
+    /// Note: OpenAI Responses API enforces a minimum of 16 for max_output_tokens.
+    #[tokio::test]
+    async fn test_run_max_tokens() {
+        dotenvy::dotenv().ok();
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
+
+        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
+        let lm = LangModelRuntime::new(
+            "gpt-4o-mini".to_string(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::OpenAI,
+                url,
+                api_key: Some(api_key),
+            },
+        );
+        let messages = vec![Message::new(Role::User)
+            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let tools: Vec<ToolDesc> = vec![];
+        let config = LangModelInferConfig { max_tokens: Some(16) };
+
+        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        println!("{}", resp);
+        assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }
 

--- a/src/agent/rt/lang_model/mod.rs
+++ b/src/agent/rt/lang_model/mod.rs
@@ -4,7 +4,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use url::Url;
 
 use crate::{
-    agent::{LangModelAPISchema, LangModelProvider},
+    agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider},
     datatype::Value,
     message::{Delta as _, Marshaled, Message, MessageOutput, ToolDesc, Unmarshal as _},
 };
@@ -21,6 +21,7 @@ struct LangModelRequest<'a> {
     pub tools: &'a [ToolDesc],
     pub url: &'a Url,
     pub api_key: &'a Option<String>,
+    pub infer_config: &'a LangModelInferConfig,
 }
 
 impl LangModelRuntime {
@@ -32,6 +33,7 @@ impl LangModelRuntime {
         &self,
         messages: &[Message],
         tools: &[ToolDesc],
+        infer_config: &LangModelInferConfig,
     ) -> anyhow::Result<MessageOutput> {
         match &self.provider {
             LangModelProvider::API {
@@ -46,6 +48,7 @@ impl LangModelRuntime {
                     tools,
                     url: &url,
                     api_key: &api_key,
+                    infer_config,
                 };
 
                 let req = match schema {
@@ -142,12 +145,23 @@ impl LangModelRuntime {
 mod tests {
     use url::Url;
 
+    use super::*;
     use crate::{
         message::{FinishReason, Part, Role, ToolDescBuilder},
         to_value,
     };
 
-    use super::*;
+    fn openai_chat_completion(model: &str, api_key: String) -> LangModelRuntime {
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        LangModelRuntime::new(
+            model.to_string(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::ChatCompletion,
+                url,
+                api_key: Some(api_key),
+            },
+        )
+    }
 
     /// Verifies that the POST request is sent and response is parsed.
     #[tokio::test]
@@ -155,19 +169,14 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
-        let lm = LangModelRuntime::new(
-            "gpt-4".to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::ChatCompletion,
-                url,
-                api_key: Some(api_key),
-            },
-        );
+        let lm = openai_chat_completion("gpt-4", api_key);
         let messages = vec![Message::new(Role::User).with_contents([Part::text("Hi")])];
         let tools: Vec<ToolDesc> = vec![];
 
-        let resp = lm.run(&messages, &tools).await.unwrap();
+        let resp = lm
+            .run(&messages, &tools, &Default::default())
+            .await
+            .unwrap();
         println!("{}", resp);
     }
 
@@ -177,15 +186,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
-        let lm = LangModelRuntime::new(
-            "gpt-4".to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::ChatCompletion,
-                url,
-                api_key: Some(api_key),
-            },
-        );
+        let lm = openai_chat_completion("gpt-4", api_key);
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("What is the current temperature in Seoul?")]),
@@ -211,7 +212,10 @@ mod tests {
                 .build(),
         ];
 
-        let resp = lm.run(&messages, &tools).await.unwrap();
+        let resp = lm
+            .run(&messages, &tools, &Default::default())
+            .await
+            .unwrap();
 
         println!("{}", resp);
 

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -1,6 +1,16 @@
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+/// Inference-time parameters forwarded to the language model on each call.
+///
+/// All fields are optional. When a field is `None`, provider-specific defaults apply
+/// (e.g. Anthropic defaults `max_tokens` to 8192 because it is a required API field).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct LangModelInferConfig {
+    /// Maximum number of tokens the model may generate in a single response.
+    pub max_tokens: Option<u64>,
+}
+
 /// Defines the logical identity of an agent as configured by the user.
 ///
 /// `AgentSpec` captures what makes an agent distinct — the language model it uses,

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -62,6 +62,7 @@ pub enum LangModelAPISchema {
     Gemini,
 
     /// OpenAI Responses API format
+    #[serde(rename = "openai")]
     OpenAI,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod datatype;
 pub mod message;
 
 pub use agent::{
-    AgentProvider, AgentRuntime, AgentSpec, LangModelAPISchema, LangModelProvider, ToolProvider,
-    ToolRuntime, ToolSet,
+    AgentProvider, AgentRuntime, AgentSpec, LangModelAPISchema, LangModelInferConfig,
+    LangModelProvider, ToolProvider, ToolRuntime, ToolSet,
 };
 pub use datatype::Value;
 pub use message::{


### PR DESCRIPTION
This PR restores `LangModelInferConfig` with `max_tokens` parameter.
Also fixed unexpected serde of `LangModelAPISchema::OpenAI` (`open_a_i` -> `openai`).