### PR TITLE
Add helper constructors for LangModelProvider

### DIFF
--- a/src/agent/rt/lang_model/api/anthropic.rs
+++ b/src/agent/rt/lang_model/api/anthropic.rs
@@ -1,5 +1,7 @@
 use anyhow::bail;
+use url::Url;
 
+use super::super::{LangModelAPISchema, LangModelProvider};
 use crate::{
     agent::rt::lang_model::LangModelRequest,
     datatype::Value,
@@ -9,6 +11,16 @@ use crate::{
     },
     to_value,
 };
+
+impl LangModelProvider {
+    pub fn anthropic(api_key: String) -> Self {
+        Self::API {
+            schema: LangModelAPISchema::Anthropic,
+            url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct AnthropicMarshal;
@@ -141,9 +153,9 @@ impl Marshal<ToolDesc> for AnthropicMarshal {
     }
 }
 
-impl<'a> Marshal<LangModelRequest<'a>> for AnthropicMarshal {
+impl Marshal<LangModelRequest> for AnthropicMarshal {
     fn marshal(&mut self, req: &LangModelRequest) -> Value {
-        let model = Value::from(req.model);
+        let model = Value::from(&req.model);
 
         // Extract system message text if present
         let system = req
@@ -159,10 +171,10 @@ impl<'a> Marshal<LangModelRequest<'a>> for AnthropicMarshal {
                 }
             });
 
-        let messages = marshal_messages(req.messages);
+        let messages = marshal_messages(&req.messages);
 
         let tools = if !req.tools.is_empty() {
-            self.marshal(req.tools)
+            self.marshal(&req.tools)
         } else {
             Value::Null
         };
@@ -340,35 +352,30 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req<'a>(
-        model: &'a str,
-        url: &'a Url,
-        api_key: &'a Option<String>,
-        infer_config: &'a LangModelInferConfig,
-    ) -> LangModelRequest<'a> {
+    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
         LangModelRequest {
-            model,
-            messages: &[],
-            tools: &[],
-            url,
-            api_key,
-            infer_config,
+            model: model.into(),
+            messages: vec![],
+            tools: vec![],
+            url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
+            api_key: None,
+            infer_config: infer_config.clone(),
         }
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig {
-            max_tokens: Some(512),
-        };
-        let req = make_req("claude-sonnet-4-6", &url, &api_key, &config);
-
+        let req = make_req(
+            "claude-haiku-4-5",
+            &LangModelInferConfig {
+                max_tokens: Some(512),
+                ..Default::default()
+            },
+        );
         let val = AnthropicMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
@@ -377,11 +384,7 @@ mod tests {
 
     #[test]
     fn test_marshal_max_tokens_default() {
-        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig::default();
-        let req = make_req("claude-sonnet-4-6", &url, &api_key, &config);
-
+        let req = make_req("claude-haiku-4-5", &LangModelInferConfig::default());
         let val = AnthropicMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
@@ -396,14 +399,9 @@ mod tests {
         let api_key =
             std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set in .env");
 
-        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
         let lm = LangModelRuntime::new(
-            "claude-haiku-4-5-20251001".to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::Anthropic,
-                url,
-                api_key: Some(api_key),
-            },
+            "claude-haiku-4-5".to_string(),
+            LangModelProvider::anthropic(api_key),
         );
         let messages = vec![
             Message::new(Role::User)
@@ -412,10 +410,10 @@ mod tests {
         let tools: Vec<ToolDesc> = vec![];
         let config = LangModelInferConfig {
             max_tokens: Some(5),
+            ..Default::default()
         };
 
         let resp = lm.run(&messages, &tools, &config).await.unwrap();
-        println!("{}", resp);
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/anthropic.rs
+++ b/src/agent/rt/lang_model/api/anthropic.rs
@@ -153,9 +153,9 @@ impl Marshal<ToolDesc> for AnthropicMarshal {
     }
 }
 
-impl Marshal<LangModelRequest> for AnthropicMarshal {
-    fn marshal(&mut self, req: &LangModelRequest) -> Value {
-        let model = Value::from(&req.model);
+impl Marshal<LangModelRequest<'_>> for AnthropicMarshal {
+    fn marshal(&mut self, req: &LangModelRequest<'_>) -> Value {
+        let model = Value::from(req.model);
 
         // Extract system message text if present
         let system = req
@@ -174,7 +174,7 @@ impl Marshal<LangModelRequest> for AnthropicMarshal {
         let messages = marshal_messages(&req.messages);
 
         let tools = if !req.tools.is_empty() {
-            self.marshal(&req.tools)
+            self.marshal(req.tools)
         } else {
             Value::Null
         };
@@ -356,40 +356,48 @@ mod tests {
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
-        LangModelRequest {
-            model: model.into(),
-            messages: vec![],
-            tools: vec![],
-            url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
-            api_key: None,
-            infer_config: infer_config.clone(),
-        }
+    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    where
+        F: FnOnce(&LangModelRequest<'_>) -> R,
+    {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![];
+        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model,
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            infer_config: &infer_config,
+        };
+        f(&req)
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        let req = make_req(
+        with_req(
             "claude-haiku-4-5",
-            &LangModelInferConfig {
-                max_tokens: Some(512),
-                ..Default::default()
+            LangModelInferConfig { max_tokens: Some(512), ..Default::default() },
+            |req| {
+                let val = AnthropicMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+                assert_eq!(max_tokens.as_integer().unwrap(), 512);
             },
         );
-        let val = AnthropicMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
-        assert_eq!(max_tokens.as_integer().unwrap(), 512);
     }
 
     #[test]
     fn test_marshal_max_tokens_default() {
-        let req = make_req("claude-haiku-4-5", &LangModelInferConfig::default());
-        let val = AnthropicMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
-        // Falls back to 8192 when not configured
-        assert_eq!(max_tokens.as_integer().unwrap(), 8192);
+        with_req("claude-haiku-4-5", LangModelInferConfig::default(), |req| {
+            let val = AnthropicMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+            // Falls back to 8192 when not configured
+            assert_eq!(max_tokens.as_integer().unwrap(), 8192);
+        });
     }
 
     /// Verifies that max_tokens is respected by the Anthropic API (stop_reason: max_tokens).

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -122,12 +122,12 @@ impl Marshal<ToolDesc> for ChatCompletionMarshal {
     }
 }
 
-impl Marshal<LangModelRequest> for ChatCompletionMarshal {
-    fn marshal(&mut self, req: &LangModelRequest) -> Value {
-        let model = Value::from(&req.model);
-        let messages = self.marshal(&req.messages);
+impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
+    fn marshal(&mut self, req: &LangModelRequest<'_>) -> Value {
+        let model = Value::from(req.model);
+        let messages = self.marshal(req.messages);
         let tools = if !req.tools.is_empty() {
-            self.marshal(&req.tools)
+            self.marshal(req.tools)
         } else {
             Value::Null
         };
@@ -307,47 +307,55 @@ mod tests {
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
-        LangModelRequest {
-            model: model.into(),
-            messages: vec![],
-            tools: vec![],
-            url: Url::parse("https://api.openai.com/v1/chat/completions").unwrap(),
-            api_key: None,
-            infer_config: infer_config.clone(),
-        }
+    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    where
+        F: FnOnce(&LangModelRequest<'_>) -> R,
+    {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![];
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model,
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            infer_config: &infer_config,
+        };
+        f(&req)
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        let req = make_req(
+        with_req(
             "gpt-4.1-mini",
-            &LangModelInferConfig {
-                max_tokens: Some(256),
-                ..Default::default()
+            LangModelInferConfig { max_tokens: Some(256), ..Default::default() },
+            |req| {
+                let val = ChatCompletionMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let max_tokens = body
+                    .as_object()
+                    .unwrap()
+                    .get("max_completion_tokens")
+                    .unwrap();
+                assert_eq!(max_tokens.as_integer().unwrap(), 256);
             },
         );
-        let val = ChatCompletionMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        let max_tokens = body
-            .as_object()
-            .unwrap()
-            .get("max_completion_tokens")
-            .unwrap();
-        assert_eq!(max_tokens.as_integer().unwrap(), 256);
     }
 
     #[test]
     fn test_marshal_max_tokens_absent_when_none() {
-        let req = make_req("gpt-4.1-mini", &LangModelInferConfig::default());
-        let val = ChatCompletionMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        assert!(
-            body.as_object()
-                .unwrap()
-                .get("max_completion_tokens")
-                .is_none()
-        );
+        with_req("gpt-4.1-mini", LangModelInferConfig::default(), |req| {
+            let val = ChatCompletionMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            assert!(
+                body.as_object()
+                    .unwrap()
+                    .get("max_completion_tokens")
+                    .is_none()
+            );
+        });
     }
 
     /// Verifies that max_tokens is respected by the ChatCompletion API (finish_reason: length).

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -1,3 +1,6 @@
+use url::Url;
+
+use super::super::{LangModelAPISchema, LangModelProvider};
 use crate::{
     agent::rt::lang_model::LangModelRequest,
     datatype::Value,
@@ -7,6 +10,24 @@ use crate::{
     },
     to_value,
 };
+
+impl LangModelProvider {
+    pub fn grok(api_key: String) -> Self {
+        Self::API {
+            schema: LangModelAPISchema::ChatCompletion,
+            url: Url::parse("https://api.x.ai/v1/chat/completions").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+
+    pub fn chat_completion(url: &str, api_key: Option<String>) -> anyhow::Result<Self> {
+        Ok(Self::API {
+            schema: LangModelAPISchema::ChatCompletion,
+            url: Url::parse(url)?,
+            api_key,
+        })
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct ChatCompletionMarshal;
@@ -101,12 +122,12 @@ impl Marshal<ToolDesc> for ChatCompletionMarshal {
     }
 }
 
-impl<'a> Marshal<LangModelRequest<'a>> for ChatCompletionMarshal {
+impl Marshal<LangModelRequest> for ChatCompletionMarshal {
     fn marshal(&mut self, req: &LangModelRequest) -> Value {
-        let model = Value::from(req.model);
-        let messages = self.marshal(req.messages);
+        let model = Value::from(&req.model);
+        let messages = self.marshal(&req.messages);
         let tools = if !req.tools.is_empty() {
-            self.marshal(req.tools)
+            self.marshal(&req.tools)
         } else {
             Value::Null
         };
@@ -282,51 +303,51 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req<'a>(
-        model: &'a str,
-        url: &'a Url,
-        api_key: &'a Option<String>,
-        infer_config: &'a LangModelInferConfig,
-    ) -> LangModelRequest<'a> {
+    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
         LangModelRequest {
-            model,
-            messages: &[],
-            tools: &[],
-            url,
-            api_key,
-            infer_config,
+            model: model.into(),
+            messages: vec![],
+            tools: vec![],
+            url: Url::parse("https://api.openai.com/v1/chat/completions").unwrap(),
+            api_key: None,
+            infer_config: infer_config.clone(),
         }
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig {
-            max_tokens: Some(256),
-        };
-        let req = make_req("gpt-4o", &url, &api_key, &config);
-
+        let req = make_req(
+            "gpt-4.1-mini",
+            &LangModelInferConfig {
+                max_tokens: Some(256),
+                ..Default::default()
+            },
+        );
         let val = ChatCompletionMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
-        let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+        let max_tokens = body
+            .as_object()
+            .unwrap()
+            .get("max_completion_tokens")
+            .unwrap();
         assert_eq!(max_tokens.as_integer().unwrap(), 256);
     }
 
     #[test]
     fn test_marshal_max_tokens_absent_when_none() {
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig::default();
-        let req = make_req("gpt-4o", &url, &api_key, &config);
-
+        let req = make_req("gpt-4.1-mini", &LangModelInferConfig::default());
         let val = ChatCompletionMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
-        assert!(body.as_object().unwrap().get("max_tokens").is_none());
+        assert!(
+            body.as_object()
+                .unwrap()
+                .get("max_completion_tokens")
+                .is_none()
+        );
     }
 
     /// Verifies that max_tokens is respected by the ChatCompletion API (finish_reason: length).
@@ -335,14 +356,13 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
         let lm = LangModelRuntime::new(
-            "gpt-4o-mini".to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::ChatCompletion,
-                url,
-                api_key: Some(api_key),
-            },
+            "gpt-4.1-mini".to_string(),
+            LangModelProvider::chat_completion(
+                "https://api.openai.com/v1/chat/completions",
+                Some(api_key),
+            )
+            .unwrap(),
         );
         let messages = vec![
             Message::new(Role::User)
@@ -350,11 +370,11 @@ mod tests {
         ];
         let tools: Vec<ToolDesc> = vec![];
         let config = LangModelInferConfig {
-            max_tokens: Some(5),
+            max_tokens: Some(32),
+            ..Default::default()
         };
 
         let resp = lm.run(&messages, &tools, &config).await.unwrap();
-        println!("{}", resp);
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/gemini.rs
+++ b/src/agent/rt/lang_model/api/gemini.rs
@@ -1,5 +1,7 @@
 use anyhow::bail;
+use url::Url;
 
+use super::super::{LangModelAPISchema, LangModelProvider};
 use crate::{
     agent::rt::lang_model::LangModelRequest,
     datatype::Value,
@@ -9,6 +11,16 @@ use crate::{
     },
     to_value,
 };
+
+impl LangModelProvider {
+    pub fn gemini(api_key: String) -> Self {
+        Self::API {
+            schema: LangModelAPISchema::Gemini,
+            url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct GeminiMarshal;
@@ -140,7 +152,7 @@ impl Marshal<ToolDesc> for GeminiMarshal {
     }
 }
 
-impl<'a> Marshal<LangModelRequest<'a>> for GeminiMarshal {
+impl Marshal<LangModelRequest> for GeminiMarshal {
     fn marshal(&mut self, req: &LangModelRequest) -> Value {
         // Extract system instruction from system message if present
         let system_instruction = req
@@ -156,7 +168,7 @@ impl<'a> Marshal<LangModelRequest<'a>> for GeminiMarshal {
                 }
             });
 
-        let contents = marshal_messages(req.messages);
+        let contents = marshal_messages(&req.messages);
 
         let tools = if !req.tools.is_empty() {
             let declarations = req
@@ -336,35 +348,30 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req<'a>(
-        model: &'a str,
-        url: &'a Url,
-        api_key: &'a Option<String>,
-        infer_config: &'a LangModelInferConfig,
-    ) -> LangModelRequest<'a> {
+    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
         LangModelRequest {
-            model,
-            messages: &[],
-            tools: &[],
-            url,
-            api_key,
-            infer_config,
+            model: model.into(),
+            messages: vec![],
+            tools: vec![],
+            url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap(),
+            api_key: None,
+            infer_config: infer_config.clone(),
         }
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig {
-            max_tokens: Some(2048),
-        };
-        let req = make_req("gemini-2.0-flash", &url, &api_key, &config);
-
+        let req = make_req(
+            "gemini-2.5-flash-lite",
+            &LangModelInferConfig {
+                max_tokens: Some(2048),
+                ..Default::default()
+            },
+        );
         let val = GeminiMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
@@ -378,11 +385,7 @@ mod tests {
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig::default();
-        let req = make_req("gemini-2.0-flash", &url, &api_key, &config);
-
+        let req = make_req("gemini-2.5-flash-lite", &LangModelInferConfig::default());
         let val = GeminiMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         assert!(body.as_object().unwrap().get("generationConfig").is_none());
@@ -392,25 +395,23 @@ mod tests {
     #[tokio::test]
     async fn test_run_max_tokens() {
         dotenvy::dotenv().ok();
-        let api_key =
-            std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
+        let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
 
-        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
         let lm = LangModelRuntime::new(
             "gemini-2.5-flash-lite".to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::Gemini,
-                url,
-                api_key: Some(api_key),
-            },
+            LangModelProvider::gemini(api_key),
         );
-        let messages = vec![Message::new(Role::User)
-            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let messages = vec![
+            Message::new(Role::User)
+                .with_contents([Part::text("Tell me a long story about a dragon.")]),
+        ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig { max_tokens: Some(5) };
+        let config = LangModelInferConfig {
+            max_tokens: Some(5),
+            ..Default::default()
+        };
 
         let resp = lm.run(&messages, &tools, &config).await.unwrap();
-        println!("{}", resp);
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/gemini.rs
+++ b/src/agent/rt/lang_model/api/gemini.rs
@@ -152,8 +152,8 @@ impl Marshal<ToolDesc> for GeminiMarshal {
     }
 }
 
-impl Marshal<LangModelRequest> for GeminiMarshal {
-    fn marshal(&mut self, req: &LangModelRequest) -> Value {
+impl Marshal<LangModelRequest<'_>> for GeminiMarshal {
+    fn marshal(&mut self, req: &LangModelRequest<'_>) -> Value {
         // Extract system instruction from system message if present
         let system_instruction = req
             .messages
@@ -352,43 +352,56 @@ mod tests {
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
-        LangModelRequest {
-            model: model.into(),
-            messages: vec![],
-            tools: vec![],
-            url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap(),
-            api_key: None,
-            infer_config: infer_config.clone(),
-        }
+    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    where
+        F: FnOnce(&LangModelRequest<'_>) -> R,
+    {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![];
+        let url =
+            Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model,
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            infer_config: &infer_config,
+        };
+        f(&req)
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        let req = make_req(
+        with_req(
             "gemini-2.5-flash-lite",
-            &LangModelInferConfig {
-                max_tokens: Some(2048),
-                ..Default::default()
+            LangModelInferConfig { max_tokens: Some(2048), ..Default::default() },
+            |req| {
+                let val = GeminiMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
+                let max_tokens = gen_config
+                    .as_object()
+                    .unwrap()
+                    .get("maxOutputTokens")
+                    .unwrap();
+                assert_eq!(max_tokens.as_integer().unwrap(), 2048);
             },
         );
-        let val = GeminiMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
-        let max_tokens = gen_config
-            .as_object()
-            .unwrap()
-            .get("maxOutputTokens")
-            .unwrap();
-        assert_eq!(max_tokens.as_integer().unwrap(), 2048);
     }
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        let req = make_req("gemini-2.5-flash-lite", &LangModelInferConfig::default());
-        let val = GeminiMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        assert!(body.as_object().unwrap().get("generationConfig").is_none());
+        with_req(
+            "gemini-2.5-flash-lite",
+            LangModelInferConfig::default(),
+            |req| {
+                let val = GeminiMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                assert!(body.as_object().unwrap().get("generationConfig").is_none());
+            },
+        );
     }
 
     /// Verifies that max_tokens is respected by the Gemini API (finishReason: MAX_TOKENS).

--- a/src/agent/rt/lang_model/api/openai.rs
+++ b/src/agent/rt/lang_model/api/openai.rs
@@ -132,8 +132,8 @@ impl Marshal<ToolDesc> for OpenAIMarshal {
     }
 }
 
-impl Marshal<LangModelRequest> for OpenAIMarshal {
-    fn marshal(&mut self, req: &LangModelRequest) -> Value {
+impl Marshal<LangModelRequest<'_>> for OpenAIMarshal {
+    fn marshal(&mut self, req: &LangModelRequest<'_>) -> Value {
         // Extract system instruction from system message if present
         let instructions = req
             .messages
@@ -169,7 +169,7 @@ impl Marshal<LangModelRequest> for OpenAIMarshal {
         }
 
         let mut body = to_value!({
-            "model": req.model.clone(),
+            "model": req.model,
             "input": input,
         });
         if let Some(instructions) = instructions {
@@ -345,38 +345,46 @@ mod tests {
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
-        LangModelRequest {
-            model: model.into(),
-            messages: vec![],
-            tools: vec![],
-            url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
-            api_key: None,
-            infer_config: infer_config.clone(),
-        }
+    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    where
+        F: FnOnce(&LangModelRequest<'_>) -> R,
+    {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![];
+        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model,
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            infer_config: &infer_config,
+        };
+        f(&req)
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        let req = make_req(
+        with_req(
             "gpt-5.4-mini",
-            &LangModelInferConfig {
-                max_tokens: Some(1024),
-                ..Default::default()
+            LangModelInferConfig { max_tokens: Some(1024), ..Default::default() },
+            |req| {
+                let val = OpenAIMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
+                assert_eq!(max_tokens.as_integer().unwrap(), 1024);
             },
         );
-        let val = OpenAIMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
-        assert_eq!(max_tokens.as_integer().unwrap(), 1024);
     }
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        let req = make_req("gpt-5.4-mini", &LangModelInferConfig::default());
-        let val = OpenAIMarshal::default().marshal(&req);
-        let body = val.as_object().unwrap().get("body").unwrap();
-        assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
+        with_req("gpt-5.4-mini", LangModelInferConfig::default(), |req| {
+            let val = OpenAIMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
+        });
     }
 
     /// Verifies that max_tokens is respected by the OpenAI Responses API (incomplete: max_output_tokens).

--- a/src/agent/rt/lang_model/api/openai.rs
+++ b/src/agent/rt/lang_model/api/openai.rs
@@ -1,3 +1,6 @@
+use url::Url;
+
+use super::super::{LangModelAPISchema, LangModelProvider};
 use crate::{
     agent::rt::lang_model::LangModelRequest,
     datatype::Value,
@@ -7,6 +10,16 @@ use crate::{
     },
     to_value,
 };
+
+impl LangModelProvider {
+    pub fn openai(api_key: String) -> Self {
+        Self::API {
+            schema: LangModelAPISchema::OpenAI,
+            url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct OpenAIMarshal;
@@ -119,7 +132,7 @@ impl Marshal<ToolDesc> for OpenAIMarshal {
     }
 }
 
-impl<'a> Marshal<LangModelRequest<'a>> for OpenAIMarshal {
+impl Marshal<LangModelRequest> for OpenAIMarshal {
     fn marshal(&mut self, req: &LangModelRequest) -> Value {
         // Extract system instruction from system message if present
         let instructions = req
@@ -135,7 +148,7 @@ impl<'a> Marshal<LangModelRequest<'a>> for OpenAIMarshal {
                 }
             });
 
-        let input = marshal_messages(req.messages);
+        let input = marshal_messages(&req.messages);
 
         let tools = if !req.tools.is_empty() {
             Value::Array(req.tools.iter().map(|t| self.marshal(t)).collect())
@@ -156,7 +169,7 @@ impl<'a> Marshal<LangModelRequest<'a>> for OpenAIMarshal {
         }
 
         let mut body = to_value!({
-            "model": req.model,
+            "model": req.model.clone(),
             "input": input,
         });
         if let Some(instructions) = instructions {
@@ -328,33 +341,30 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelAPISchema, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn make_req<'a>(
-        model: &'a str,
-        url: &'a Url,
-        api_key: &'a Option<String>,
-        infer_config: &'a LangModelInferConfig,
-    ) -> LangModelRequest<'a> {
+    fn make_req(model: &str, infer_config: &LangModelInferConfig) -> LangModelRequest {
         LangModelRequest {
-            model,
-            messages: &[],
-            tools: &[],
-            url,
-            api_key,
-            infer_config,
+            model: model.into(),
+            messages: vec![],
+            tools: vec![],
+            url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
+            api_key: None,
+            infer_config: infer_config.clone(),
         }
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig { max_tokens: Some(1024) };
-        let req = make_req("gpt-4o", &url, &api_key, &config);
-
+        let req = make_req(
+            "gpt-5.4-mini",
+            &LangModelInferConfig {
+                max_tokens: Some(1024),
+                ..Default::default()
+            },
+        );
         let val = OpenAIMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
@@ -363,11 +373,7 @@ mod tests {
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
-        let api_key = None;
-        let config = LangModelInferConfig::default();
-        let req = make_req("gpt-4o", &url, &api_key, &config);
-
+        let req = make_req("gpt-5.4-mini", &LangModelInferConfig::default());
         let val = OpenAIMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
@@ -382,17 +388,22 @@ mod tests {
 
         let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
         let lm = LangModelRuntime::new(
-            "gpt-4o-mini".to_string(),
+            "gpt-5.4-mini".to_string(),
             LangModelProvider::API {
                 schema: LangModelAPISchema::OpenAI,
                 url,
                 api_key: Some(api_key),
             },
         );
-        let messages = vec![Message::new(Role::User)
-            .with_contents([Part::text("Tell me a long story about a dragon.")])];
+        let messages = vec![
+            Message::new(Role::User)
+                .with_contents([Part::text("Tell me a long story about a dragon.")]),
+        ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig { max_tokens: Some(16) };
+        let config = LangModelInferConfig {
+            max_tokens: Some(16),
+            ..Default::default()
+        };
 
         let resp = lm.run(&messages, &tools, &config).await.unwrap();
         println!("{}", resp);

--- a/src/agent/rt/lang_model/mod.rs
+++ b/src/agent/rt/lang_model/mod.rs
@@ -15,13 +15,13 @@ pub struct LangModelRuntime {
     provider: LangModelProvider,
 }
 
-struct LangModelRequest {
-    pub model: String,
-    pub messages: Vec<Message>,
-    pub tools: Vec<ToolDesc>,
-    pub url: Url,
-    pub api_key: Option<String>,
-    pub infer_config: LangModelInferConfig,
+struct LangModelRequest<'a> {
+    pub model: &'a str,
+    pub messages: &'a [Message],
+    pub tools: &'a [ToolDesc],
+    pub url: &'a Url,
+    pub api_key: &'a Option<String>,
+    pub infer_config: &'a LangModelInferConfig,
 }
 
 impl LangModelRuntime {
@@ -43,12 +43,12 @@ impl LangModelRuntime {
             } => {
                 // Create request
                 let req = LangModelRequest {
-                    model: self.model.clone(),
-                    messages: messages.into(),
-                    tools: tools.into(),
-                    url: url.clone(),
-                    api_key: api_key.clone(),
-                    infer_config: infer_config.clone(),
+                    model: &self.model,
+                    messages,
+                    tools,
+                    url,
+                    api_key,
+                    infer_config,
                 };
 
                 let req = match schema {

--- a/src/agent/rt/lang_model/mod.rs
+++ b/src/agent/rt/lang_model/mod.rs
@@ -15,13 +15,13 @@ pub struct LangModelRuntime {
     provider: LangModelProvider,
 }
 
-struct LangModelRequest<'a> {
-    pub model: &'a str,
-    pub messages: &'a [Message],
-    pub tools: &'a [ToolDesc],
-    pub url: &'a Url,
-    pub api_key: &'a Option<String>,
-    pub infer_config: &'a LangModelInferConfig,
+struct LangModelRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    pub tools: Vec<ToolDesc>,
+    pub url: Url,
+    pub api_key: Option<String>,
+    pub infer_config: LangModelInferConfig,
 }
 
 impl LangModelRuntime {
@@ -43,12 +43,12 @@ impl LangModelRuntime {
             } => {
                 // Create request
                 let req = LangModelRequest {
-                    model: &self.model,
-                    messages,
-                    tools,
-                    url: &url,
-                    api_key: &api_key,
-                    infer_config,
+                    model: self.model.clone(),
+                    messages: messages.into(),
+                    tools: tools.into(),
+                    url: url.clone(),
+                    api_key: api_key.clone(),
+                    infer_config: infer_config.clone(),
                 };
 
                 let req = match schema {
@@ -143,8 +143,6 @@ impl LangModelRuntime {
 
 #[cfg(test)]
 mod tests {
-    use url::Url;
-
     use super::*;
     use crate::{
         message::{FinishReason, Part, Role, ToolDescBuilder},
@@ -152,14 +150,13 @@ mod tests {
     };
 
     fn openai_chat_completion(model: &str, api_key: String) -> LangModelRuntime {
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
         LangModelRuntime::new(
             model.to_string(),
-            LangModelProvider::API {
-                schema: LangModelAPISchema::ChatCompletion,
-                url,
-                api_key: Some(api_key),
-            },
+            LangModelProvider::chat_completion(
+                "https://api.openai.com/v1/chat/completions",
+                Some(api_key),
+            )
+            .unwrap(),
         )
     }
 
@@ -169,7 +166,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let lm = openai_chat_completion("gpt-4", api_key);
+        let lm = openai_chat_completion("gpt-5.4-mini", api_key);
         let messages = vec![Message::new(Role::User).with_contents([Part::text("Hi")])];
         let tools: Vec<ToolDesc> = vec![];
 
@@ -177,7 +174,14 @@ mod tests {
             .run(&messages, &tools, &Default::default())
             .await
             .unwrap();
-        println!("{}", resp);
+        assert!(
+            !resp.message.contents.is_empty(),
+            "Expected at least one message content"
+        );
+        assert!(
+            resp.message.contents.first().unwrap().is_text(),
+            "Expected a text type content"
+        );
     }
 
     /// Verifies that the API returns tool calls when tools are provided.
@@ -186,7 +190,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let lm = openai_chat_completion("gpt-4", api_key);
+        let lm = openai_chat_completion("gpt-5.4-mini", api_key);
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("What is the current temperature in Seoul?")]),
@@ -216,8 +220,6 @@ mod tests {
             .run(&messages, &tools, &Default::default())
             .await
             .unwrap();
-
-        println!("{}", resp);
 
         // The model should respond with a tool call
         assert_eq!(resp.finish_reason, FinishReason::ToolCall {});


### PR DESCRIPTION
In order to create a new `LangModelProvider`, users should be aware of each provider's API endpoint, as well as importing `url::Url` and `LangModelAPISchema` too, which results in poor developer experience.
This PR adds some helper constructors of `LangModelProvider` for each well-known API providers, so users don't need to import any other. Users can still provide arbitrary API endpoints via `LangModelProvider::chat_completion()`.