### PR TITLE
Add web_search builtin tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -560,3 +560,6 @@ test_*
 
 # omc
 .omc
+
+# git worktrees
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,23 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "wreq",
+ "wreq-util",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -65,10 +82,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-stream"
@@ -122,6 +167,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +204,56 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "boring-sys2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
+dependencies = [
+ "autocfg",
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
+name = "boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
+dependencies = [
+ "bitflags",
+ "boring-sys2",
+ "brotli",
+ "flate2",
+ "foreign-types 0.5.0",
+ "libc",
+ "openssl-macros",
+ "zstd",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -174,12 +287,23 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -209,10 +333,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -433,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "fdeflate"
@@ -485,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -511,7 +691,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -521,12 +722,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -674,10 +897,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.12"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -762,6 +991,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http2"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,12 +1087,32 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyper2"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http2",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1046,10 +1313,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1066,6 +1352,31 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1090,9 +1401,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru-slab"
@@ -1141,6 +1458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1207,6 +1530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,13 +1556,13 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -1249,15 +1582,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -1469,7 +1802,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -1506,7 +1839,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1601,6 +1934,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1870,12 +2215,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1883,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2037,6 +2382,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2160,7 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2254,9 +2609,20 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "tokio-boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
+dependencies = [
+ "boring-sys2",
+ "boring2",
+ "tokio",
 ]
 
 [[package]]
@@ -2395,6 +2761,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2595,6 +2981,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,6 +3006,28 @@ checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -2934,6 +3360,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wreq"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137ed11c4c418fb3dc41db7323ebc49aa9b6fe6a24ce152e6b2de9d6fadd9c8f"
+dependencies = [
+ "antidote",
+ "arc-swap",
+ "async-compression",
+ "base64",
+ "boring2",
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper2",
+ "ipnet",
+ "linked_hash_set",
+ "log",
+ "lru",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "socket2 0.5.10",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-boring2",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "typed-builder",
+ "url",
+ "webpki-root-certs 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
+name = "wreq-util"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28b3585973a8923c32c2f916e60b7b0d1cb4dd53e8cb2d7422c0ac001ef2487"
+dependencies = [
+ "typed-builder",
+ "wreq",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3517,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,22 @@
-[package]
-name = "ailoy"
+[workspace]
+members = [
+    "./",
+]
+exclude = [
+    ".worktrees",
+]
+
+[workspace.package]
 version = "0.3.0"
 edition = "2024"
+license = "Apache-2.0"
+repository = "https://github.com/brekkylab/ailoy"
+
+[package]
+name = "ailoy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["rlib"]
@@ -43,6 +58,8 @@ unicode-segmentation = "1.12.0"
 url = "2.5.4"
 urlencoding = "2.1"
 uuid = { version = "1.18.0", features = ["v4"] }
+wreq = "5.3.0"
+wreq-util = "2.2.6"
 
 [dev-dependencies]
 dotenvy = "0.15"

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -21,7 +21,7 @@ impl AgentRuntime {
                 .tools
                 .iter()
                 .fold(tool_set, |ts, tool_provider| match tool_provider {
-                    ToolProvider::Builtin { name } => ts.with_builtin(name),
+                    ToolProvider::Builtin(builtin) => ts.with_builtin(builtin),
                     ToolProvider::MCP(mcp) => ts.with_mcp(mcp),
                 });
 

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -8,6 +8,8 @@ use crate::{
     message::{Message, Part, Role, ToolDesc},
 };
 
+mod web_search;
+
 pub type ToolFunc = dyn Fn(Value) -> BoxFuture<'static, Value> + Send + Sync;
 
 #[derive(Clone)]
@@ -64,12 +66,17 @@ impl ToolSet {
         self.tools.remove(key)
     }
 
-    pub fn with_builtin(self, name: &str) -> Self {
-        if name == "knowledge" {
-            todo!()
-        } else {
-            // @jhlee: Should we raise?
-            self
+    pub fn with_builtin(mut self, name: &str) -> Self {
+        match name {
+            "web_search" => {
+                let tool = web_search::build_web_search_tool();
+                self.tools.insert("web_search".to_string(), tool);
+                self
+            }
+            _ => {
+                log::warn!("Unknown builtin tool name: '{}' — skipping", name);
+                self
+            }
         }
     }
 

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures::future::BoxFuture;
 
 use crate::{
-    agent::MCPToolProvider,
+    agent::{BuiltinToolProvider, MCPToolProvider},
     datatype::Value,
     message::{Message, Part, Role, ToolDesc},
 };
@@ -66,15 +66,11 @@ impl ToolSet {
         self.tools.remove(key)
     }
 
-    pub fn with_builtin(mut self, name: &str) -> Self {
-        match name {
-            "web_search" => {
+    pub fn with_builtin(mut self, provider: &BuiltinToolProvider) -> Self {
+        match provider {
+            BuiltinToolProvider::WebSearch {} => {
                 let tool = web_search::build_web_search_tool();
                 self.tools.insert("web_search".to_string(), tool);
-                self
-            }
-            _ => {
-                log::warn!("Unknown builtin tool name: '{}' — skipping", name);
                 self
             }
         }

--- a/src/agent/rt/tool/web_search/aggregator.rs
+++ b/src/agent/rt/tool/web_search/aggregator.rs
@@ -1,0 +1,360 @@
+use std::collections::HashMap;
+
+use futures::future::join_all;
+use reqwest::Client;
+
+use crate::agent::rt::tool::web_search::{
+    engine::{SearchEngine, SearchError, SearchResult},
+    engines::{Bing, Brave, DuckDuckGo, Google, LibreX, Mojeek, Startpage, Yahoo, Yandex},
+};
+
+/// A search result aggregated from multiple engines.
+#[derive(Debug, Clone)]
+pub struct AggregatedResult {
+    pub title: String,
+    pub url: String,
+    pub description: String,
+    /// Names of engines that returned this URL.
+    pub sources: Vec<&'static str>,
+    /// Number of engines that returned this URL (used for ranking).
+    pub relevance: f32,
+}
+
+/// Normalizes a URL for deduplication:
+/// - lowercases scheme and host
+/// - removes "www." prefix
+/// - strips trailing slash
+/// - removes common tracking query params (utm_*, ref, etc.)
+pub fn normalize_url(url: &str) -> String {
+    let url = url.trim();
+
+    // Remove fragment
+    let url = url.split('#').next().unwrap_or(url);
+
+    // Split at query string
+    let (base, query) = match url.split_once('?') {
+        Some((b, q)) => (b, Some(q)),
+        None => (url, None),
+    };
+
+    // Normalize the base: only lowercase scheme+host, preserve path case (RFC 3986)
+    let base = base.trim_end_matches('/');
+
+    // Split into scheme+host and path
+    let base = if let Some(authority_start) = base.find("://") {
+        let (scheme, after_scheme) = base.split_at(authority_start + 3);
+        let (host_part, path_part) = after_scheme
+            .split_once('/')
+            .map(|(h, p)| (h, format!("/{}", p)))
+            .unwrap_or((after_scheme, String::new()));
+        // Only lowercase scheme and host; path is case-sensitive
+        format!(
+            "{}{}{}",
+            scheme.to_lowercase(),
+            host_part.to_lowercase(),
+            path_part
+        )
+    } else {
+        base.to_lowercase()
+    };
+
+    // Remove www. from host (after scheme://)
+    let base = if let Some(after_scheme) = base.strip_prefix("https://www.") {
+        format!("https://{}", after_scheme)
+    } else if let Some(after_scheme) = base.strip_prefix("http://www.") {
+        format!("http://{}", after_scheme)
+    } else {
+        base
+    };
+
+    // Keep only non-tracking query params
+    let tracking_params = [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "ref",
+        "referrer",
+        "source",
+    ];
+    if let Some(q) = query {
+        let filtered: Vec<&str> = q
+            .split('&')
+            .filter(|param| {
+                let key = param.split('=').next().unwrap_or("");
+                !tracking_params.contains(&key)
+            })
+            .collect();
+        if filtered.is_empty() {
+            base
+        } else {
+            format!("{}?{}", base, filtered.join("&"))
+        }
+    } else {
+        base
+    }
+}
+
+pub struct MetaSearcher {
+    pub engines: Vec<Box<dyn SearchEngine>>,
+    pub client: Client,
+}
+
+impl MetaSearcher {
+    pub fn new() -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .user_agent(crate::agent::rt::tool::web_search::engine::USER_AGENT)
+            .build()
+            .expect("Failed to build HTTP client");
+
+        let engines: Vec<Box<dyn SearchEngine>> = vec![
+            Box::new(Bing::new().expect("Bing init failed")),
+            Box::new(Brave::new().expect("Brave init failed")),
+            Box::new(DuckDuckGo::new().expect("DuckDuckGo init failed")),
+            Box::new(Google::new().expect("Google init failed")),
+            Box::new(LibreX::new().expect("LibreX init failed")),
+            Box::new(Mojeek::new().expect("Mojeek init failed")),
+            Box::new(Startpage::new().expect("Startpage init failed")),
+            Box::new(Yahoo::new().expect("Yahoo init failed")),
+            Box::new(Yandex::new().expect("Yandex init failed")),
+        ];
+
+        Self { engines, client }
+    }
+
+    pub async fn search(&self, query: &str, max_results: usize) -> Vec<AggregatedResult> {
+        // Fan-out: search all engines concurrently
+        let futures: Vec<_> = self
+            .engines
+            .iter()
+            .map(|engine| engine.search(&self.client, query, max_results))
+            .collect();
+
+        let engine_results = join_all(futures).await;
+
+        // Collect successes, warn on failures
+        let mut flat: Vec<SearchResult> = Vec::new();
+        for (i, result) in engine_results.into_iter().enumerate() {
+            match result {
+                Ok(results) => flat.extend(results),
+                Err(SearchError::NoResults) => {} // silent
+                Err(e) => log::warn!("Search engine '{}' failed: {}", self.engines[i].name(), e),
+            }
+        }
+
+        // Deduplicate by normalized URL
+        let mut seen: HashMap<String, usize> = HashMap::new();
+        let mut deduped: Vec<AggregatedResult> = Vec::new();
+
+        for result in flat {
+            let key = normalize_url(&result.url);
+            if let Some(&idx) = seen.get(&key) {
+                deduped[idx].sources.push(result.engine);
+                deduped[idx].relevance += 1.0;
+            } else {
+                let idx = deduped.len();
+                seen.insert(key, idx);
+                deduped.push(AggregatedResult {
+                    title: result.title,
+                    url: result.url,
+                    description: result.description,
+                    sources: vec![result.engine],
+                    relevance: 1.0,
+                });
+            }
+        }
+
+        // Rank by relevance (higher = returned by more engines)
+        deduped.sort_by(|a, b| {
+            b.relevance
+                .partial_cmp(&a.relevance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        deduped.truncate(max_results);
+        deduped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use reqwest::Client;
+
+    use super::*;
+    use crate::agent::rt::tool::web_search::engine::{SearchEngine, SearchError, SearchResult};
+
+    // --- normalize_url tests ---
+
+    #[test]
+    fn test_normalize_removes_www() {
+        assert_eq!(
+            normalize_url("https://www.example.com/page"),
+            "https://example.com/page"
+        );
+    }
+
+    #[test]
+    fn test_normalize_removes_trailing_slash() {
+        assert_eq!(normalize_url("https://example.com/"), "https://example.com");
+    }
+
+    #[test]
+    fn test_normalize_removes_tracking_params() {
+        assert_eq!(
+            normalize_url("https://example.com/page?utm_source=google&id=42"),
+            "https://example.com/page?id=42"
+        );
+    }
+
+    #[test]
+    fn test_normalize_removes_fragment() {
+        assert_eq!(
+            normalize_url("https://example.com/page#section"),
+            "https://example.com/page"
+        );
+    }
+
+    #[test]
+    fn test_normalize_lowercases_host() {
+        // Only scheme and host should be lowercased, not the path
+        assert_eq!(
+            normalize_url("HTTPS://EXAMPLE.COM/Path"),
+            "https://example.com/Path"
+        );
+    }
+
+    // --- MetaSearcher aggregation tests ---
+
+    struct MockEngine {
+        name: &'static str,
+        results: Vec<SearchResult>,
+    }
+
+    #[async_trait]
+    impl SearchEngine for MockEngine {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn search(
+            &self,
+            _client: &Client,
+            _query: &str,
+            _max_results: usize,
+        ) -> Result<Vec<SearchResult>, SearchError> {
+            Ok(self.results.clone())
+        }
+    }
+
+    fn make_result(title: &str, url: &str, engine: &'static str) -> SearchResult {
+        SearchResult {
+            title: title.to_string(),
+            url: url.to_string(),
+            description: "test".to_string(),
+            engine,
+        }
+    }
+
+    fn make_searcher(engines: Vec<Box<dyn SearchEngine>>) -> MetaSearcher {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+        MetaSearcher { engines, client }
+    }
+
+    #[tokio::test]
+    async fn test_deduplication_by_url() {
+        let searcher = make_searcher(vec![
+            Box::new(MockEngine {
+                name: "A",
+                results: vec![make_result("Rust", "https://www.rust-lang.org", "A")],
+            }),
+            Box::new(MockEngine {
+                name: "B",
+                results: vec![make_result("Rust Lang", "https://rust-lang.org/", "B")],
+            }),
+        ]);
+
+        let results = searcher.search("rust", 10).await;
+        assert_eq!(
+            results.len(),
+            1,
+            "www. and trailing slash should deduplicate"
+        );
+        assert_eq!(results[0].sources.len(), 2);
+        assert!(results[0].relevance >= 2.0);
+    }
+
+    #[tokio::test]
+    async fn test_ranking_by_relevance() {
+        let searcher = make_searcher(vec![
+            Box::new(MockEngine {
+                name: "A",
+                results: vec![
+                    make_result("Alpha", "https://alpha.com", "A"),
+                    make_result("Beta", "https://beta.com", "A"),
+                ],
+            }),
+            Box::new(MockEngine {
+                name: "B",
+                results: vec![make_result("Beta Again", "https://beta.com", "B")],
+            }),
+        ]);
+
+        let results = searcher.search("test", 10).await;
+        assert_eq!(
+            results[0].url, "https://beta.com",
+            "URL appearing in 2 engines should rank first"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_graceful_degradation_on_all_failure() {
+        struct FailEngine;
+        #[async_trait]
+        impl SearchEngine for FailEngine {
+            fn name(&self) -> &'static str {
+                "FailEngine"
+            }
+            async fn search(
+                &self,
+                _: &Client,
+                _: &str,
+                _: usize,
+            ) -> Result<Vec<SearchResult>, SearchError> {
+                Err(SearchError::Blocked)
+            }
+        }
+
+        let searcher = make_searcher(vec![Box::new(FailEngine)]);
+        let results = searcher.search("anything", 10).await;
+        assert_eq!(
+            results.len(),
+            0,
+            "All engines failing should return empty results"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_results_limit() {
+        let searcher = make_searcher(vec![Box::new(MockEngine {
+            name: "A",
+            results: (0..20)
+                .map(|i| {
+                    make_result(
+                        &format!("Result {}", i),
+                        &format!("https://r{}.com", i),
+                        "A",
+                    )
+                })
+                .collect(),
+        })]);
+
+        let results = searcher.search("test", 5).await;
+        assert_eq!(results.len(), 5);
+    }
+}

--- a/src/agent/rt/tool/web_search/aggregator.rs
+++ b/src/agent/rt/tool/web_search/aggregator.rs
@@ -134,39 +134,42 @@ impl MetaSearcher {
 
         let engine_results = join_all(futures).await;
 
-        // Collect successes, warn on failures
-        let mut flat: Vec<SearchResult> = Vec::new();
+        // RRF constant: k=60 is standard (Cormack et al., 2009).
+        // Score for a URL at rank r from one engine = 1 / (k + r + 1).
+        const RRF_K: f32 = 60.0;
+
+        // Deduplicate by normalized URL, accumulating RRF scores per-engine result list.
+        let mut seen: HashMap<String, usize> = HashMap::new();
+        let mut deduped: Vec<AggregatedResult> = Vec::new();
+
         for (i, result) in engine_results.into_iter().enumerate() {
             match result {
-                Ok(results) => flat.extend(results),
+                Ok(results) => {
+                    for (rank, result) in results.into_iter().enumerate() {
+                        let key = normalize_url(&result.url);
+                        let rrf_score = 1.0 / (RRF_K + rank as f32 + 1.0);
+                        if let Some(&idx) = seen.get(&key) {
+                            deduped[idx].sources.push(result.engine);
+                            deduped[idx].relevance += rrf_score;
+                        } else {
+                            let idx = deduped.len();
+                            seen.insert(key, idx);
+                            deduped.push(AggregatedResult {
+                                title: result.title,
+                                url: result.url,
+                                description: result.description,
+                                sources: vec![result.engine],
+                                relevance: rrf_score,
+                            });
+                        }
+                    }
+                }
                 Err(SearchError::NoResults) => {} // silent
                 Err(e) => log::warn!("Search engine '{}' failed: {}", self.engines[i].name(), e),
             }
         }
 
-        // Deduplicate by normalized URL
-        let mut seen: HashMap<String, usize> = HashMap::new();
-        let mut deduped: Vec<AggregatedResult> = Vec::new();
-
-        for result in flat {
-            let key = normalize_url(&result.url);
-            if let Some(&idx) = seen.get(&key) {
-                deduped[idx].sources.push(result.engine);
-                deduped[idx].relevance += 1.0;
-            } else {
-                let idx = deduped.len();
-                seen.insert(key, idx);
-                deduped.push(AggregatedResult {
-                    title: result.title,
-                    url: result.url,
-                    description: result.description,
-                    sources: vec![result.engine],
-                    relevance: 1.0,
-                });
-            }
-        }
-
-        // Rank by relevance (higher = returned by more engines)
+        // Rank by RRF score (higher = ranked higher across more engines)
         deduped.sort_by(|a, b| {
             b.relevance
                 .partial_cmp(&a.relevance)
@@ -286,7 +289,8 @@ mod tests {
             "www. and trailing slash should deduplicate"
         );
         assert_eq!(results[0].sources.len(), 2);
-        assert!(results[0].relevance >= 2.0);
+        // With RRF, relevance = sum of 1/(k+rank+1) per engine; always > 0
+        assert!(results[0].relevance > 0.0);
     }
 
     #[tokio::test]

--- a/src/agent/rt/tool/web_search/aggregator.rs
+++ b/src/agent/rt/tool/web_search/aggregator.rs
@@ -4,7 +4,7 @@ use futures::future::join_all;
 use reqwest::Client;
 
 use crate::agent::rt::tool::web_search::{
-    engine::{SearchEngine, SearchError, SearchResult},
+    engine::{SearchEngine, SearchError},
     engines::{Bing, Brave, DuckDuckGo, Google, LibreX, Mojeek, Startpage, Yahoo, Yandex},
 };
 

--- a/src/agent/rt/tool/web_search/engine.rs
+++ b/src/agent/rt/tool/web_search/engine.rs
@@ -1,0 +1,201 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::{Html, Selector};
+
+/// A single search result extracted from a search engine.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub title: String,
+    pub url: String,
+    pub description: String,
+    pub engine: &'static str,
+}
+
+/// Errors that can occur during a search engine request.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum SearchError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Failed to parse HTML response: {0}")]
+    Parse(String),
+    #[error("Engine returned no results")]
+    NoResults,
+    #[error("Engine is blocking requests (rate limit or CAPTCHA)")]
+    Blocked,
+}
+
+/// Holds pre-compiled CSS selectors for extracting results from a search engine's HTML.
+pub struct SearchResultParser {
+    pub no_result: Selector,
+    pub results: Selector,
+    pub result_title: Selector,
+    pub result_url: Selector,
+    pub result_desc: Selector,
+}
+
+impl SearchResultParser {
+    pub fn new(
+        no_result: &str,
+        results: &str,
+        result_title: &str,
+        result_url: &str,
+        result_desc: &str,
+    ) -> Result<Self, SearchError> {
+        let parse = |s: &str| {
+            Selector::parse(s)
+                .map_err(|e| SearchError::Parse(format!("Invalid CSS selector '{}': {:?}", s, e)))
+        };
+        Ok(Self {
+            no_result: parse(no_result)?,
+            results: parse(results)?,
+            result_title: parse(result_title)?,
+            result_url: parse(result_url)?,
+            result_desc: parse(result_desc)?,
+        })
+    }
+
+    pub fn has_no_results(&self, document: &Html) -> bool {
+        document.select(&self.no_result).next().is_some()
+    }
+
+    pub fn extract<F>(
+        &self,
+        document: &Html,
+        engine_name: &'static str,
+        url_extractor: F,
+    ) -> Vec<SearchResult>
+    where
+        F: Fn(&scraper::ElementRef) -> Option<String>,
+    {
+        document
+            .select(&self.results)
+            .filter_map(|result_el| {
+                let title = result_el
+                    .select(&self.result_title)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())?;
+
+                let url = url_extractor(&result_el)?;
+                if url.is_empty() {
+                    return None;
+                }
+
+                let description = result_el
+                    .select(&self.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: engine_name,
+                })
+            })
+            .collect()
+    }
+}
+
+/// The interface all search engines must implement.
+#[async_trait]
+pub trait SearchEngine: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError>;
+}
+
+/// Shared browser-like User-Agent used by all engines.
+pub const USER_AGENT: &str =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_parser() -> SearchResultParser {
+        SearchResultParser::new(
+            ".no-results",
+            ".result",
+            ".result-title",
+            ".result-url",
+            ".result-desc",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_extract_basic_results() {
+        let parser = make_parser();
+        let html = r#"
+            <html><body>
+              <div class="result">
+                <a class="result-title">First Result</a>
+                <a class="result-url" href="https://example.com">https://example.com</a>
+                <p class="result-desc">A description</p>
+              </div>
+              <div class="result">
+                <a class="result-title">Second Result</a>
+                <a class="result-url" href="https://other.com">https://other.com</a>
+                <p class="result-desc">Another description</p>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results = parser.extract(&document, "test", |el| {
+            el.select(&parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+        });
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "First Result");
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].description, "A description");
+        assert_eq!(results[0].engine, "test");
+        assert_eq!(results[1].title, "Second Result");
+    }
+
+    #[test]
+    fn test_has_no_results() {
+        let parser = make_parser();
+        let html_with_no_results = r#"<html><body><div class="no-results">No results found</div></body></html>"#;
+        let html_with_results = r#"<html><body><div class="result"><a class="result-title">X</a></div></body></html>"#;
+
+        assert!(parser.has_no_results(&Html::parse_document(html_with_no_results)));
+        assert!(!parser.has_no_results(&Html::parse_document(html_with_results)));
+    }
+
+    #[test]
+    fn test_invalid_selector_returns_error() {
+        let result = SearchResultParser::new(">>>invalid", ".results", ".title", ".url", ".desc");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_skips_missing_title() {
+        let parser = make_parser();
+        let html = r#"
+            <html><body>
+              <div class="result">
+                <a class="result-url" href="https://example.com"></a>
+                <p class="result-desc">desc</p>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results = parser.extract(&document, "test", |el| {
+            el.select(&parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+        });
+        assert_eq!(results.len(), 0, "Results missing title should be skipped");
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/bing.rs
+++ b/src/agent/rt/tool/web_search/engines/bing.rs
@@ -1,0 +1,321 @@
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use reqwest::Client;
+use scraper::{Html, Selector};
+use wreq::header as rh;
+use wreq_util::Emulation;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, SearchResultParser,
+};
+
+pub struct Bing {
+    parser: SearchResultParser,
+    sel_results: Selector,
+    sel_title_link: Selector,
+    sel_caption: Selector,
+}
+
+impl Bing {
+    pub fn new() -> Result<Self, SearchError> {
+        let parser = SearchResultParser::new(".b_no", ".b_algo", "h2 a", "h2 a", ".b_caption p")?;
+        Ok(Self {
+            parser,
+            sel_results: Selector::parse("ol#b_results li.b_algo")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+            sel_title_link: Selector::parse("h2 a")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+            sel_caption: Selector::parse(".b_caption p")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+        })
+    }
+
+    /// Bing sometimes wraps the real URL in a tracking redirect of the form
+    ///   https://www.bing.com/ck/a?...&u=a1<base64url-no-pad>&...
+    /// Decode the `u` query parameter: strip the "a1" prefix, then
+    /// base64url-decode to recover the original URL.
+    fn decode_bing_redirect(href: &str) -> String {
+        if !href.starts_with("https://www.bing.com/ck/a?") {
+            return href.to_string();
+        }
+
+        let qs = match href.find('?') {
+            Some(pos) => &href[pos + 1..],
+            None => return href.to_string(),
+        };
+
+        let u_val = qs.split('&').find_map(|pair| {
+            let mut kv = pair.splitn(2, '=');
+            if kv.next() == Some("u") {
+                kv.next()
+            } else {
+                None
+            }
+        });
+
+        let u_val = match u_val {
+            Some(v) => v,
+            None => return href.to_string(),
+        };
+
+        if !u_val.starts_with("a1") {
+            return href.to_string();
+        }
+        let encoded = &u_val[2..];
+
+        match URL_SAFE_NO_PAD.decode(encoded) {
+            Ok(bytes) => String::from_utf8(bytes).unwrap_or_else(|_| href.to_string()),
+            Err(_) => href.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Bing {
+    fn name(&self) -> &'static str {
+        "Bing"
+    }
+
+    async fn search(
+        &self,
+        _client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        // Use wreq with Firefox TLS fingerprint emulation.
+        // Bing/Cloudflare uses JA3 TLS fingerprinting to detect bots.
+        // Standard Rust TLS backends (native-tls / rustls) have fingerprints that
+        // are blocked, while Firefox's TLS ClientHello passes.
+        // wreq with Emulation::Firefox135 replicates the Firefox TLS handshake.
+        let rq_client = wreq::Client::builder()
+            .emulation(Emulation::Firefox135)
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        // A homepage pre-fetch seeds cookies (e.g. _EDGE_S=F=1&SID=...) that
+        // cause Bing to switch to JS-rendered results with no SSR b_algo nodes.
+        // Without prior cookies, Bing serves server-side-rendered results directly.
+        let url = format!(
+            "https://www.bing.com/search?q={}&adlt=off",
+            urlencoding::encode(query)
+        );
+
+        let response = rq_client
+            .get(&url)
+            .header(rh::ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+            .header(rh::ACCEPT_LANGUAGE, "en-US,en;q=0.9")
+            .header(rh::ACCEPT_ENCODING, "gzip, deflate")
+            .header(rh::CACHE_CONTROL, "no-cache")
+            .header("DNT", "1")
+            .header(rh::CONNECTION, "keep-alive")
+            .send()
+            .await
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        if !response.status().is_success() {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response
+            .text()
+            .await
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        if !html_text.contains("b_algo") {
+            return Err(SearchError::Blocked);
+        }
+
+        let document = Html::parse_document(&html_text);
+
+        if self.parser.has_no_results(&document) {
+            return Ok(vec![]);
+        }
+
+        let mut results = Vec::new();
+
+        for item in document.select(&self.sel_results) {
+            let link = match item.select(&self.sel_title_link).next() {
+                Some(a) => a,
+                None => continue,
+            };
+            let href = match link.value().attr("href") {
+                Some(h) if !h.is_empty() => h,
+                _ => continue,
+            };
+            let title: String = link.text().collect::<Vec<_>>().join("");
+            if title.is_empty() {
+                continue;
+            }
+
+            // Decode Bing tracking redirects to recover the real destination URL.
+            let url = Self::decode_bing_redirect(href);
+
+            // Description: text from .b_caption p, skipping decorative icon spans
+            // (<span class="algoSlug_icon">) that Bing injects into snippet text.
+            let description = item
+                .select(&self.sel_caption)
+                .flat_map(|p| {
+                    p.children().filter_map(|child| {
+                        if let Some(el) = child.value().as_element() {
+                            if el.name() == "span" {
+                                if el.attr("class").unwrap_or("").contains("algoSlug_icon") {
+                                    return None;
+                                }
+                            }
+                        }
+                        Some(
+                            scraper::ElementRef::wrap(child)
+                                .map(|er| er.text().collect::<String>())
+                                .unwrap_or_else(|| {
+                                    child
+                                        .value()
+                                        .as_text()
+                                        .map(|t| t.to_string())
+                                        .unwrap_or_default()
+                                }),
+                        )
+                    })
+                })
+                .collect::<String>()
+                .trim()
+                .to_string();
+
+            results.push(SearchResult {
+                title,
+                url,
+                description,
+                engine: self.name(),
+            });
+
+            if results.len() >= max_results {
+                break;
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_decode_bing_redirect_passthrough() {
+        let url = "https://example.com/page";
+        assert_eq!(Bing::decode_bing_redirect(url), url);
+    }
+
+    #[test]
+    fn test_decode_bing_redirect_decodes_u_param() {
+        // "https://example.com" base64url-encoded without padding
+        let encoded = "aHR0cHM6Ly9leGFtcGxlLmNvbQ";
+        let href = format!("https://www.bing.com/ck/a?foo=bar&u=a1{encoded}&other=val");
+        assert_eq!(Bing::decode_bing_redirect(&href), "https://example.com");
+    }
+
+    #[test]
+    fn test_bing_parser_extracts_results() {
+        let engine = Bing::new().expect("Failed to create Bing engine");
+        let html = r#"
+            <html><body>
+              <ol id="b_results">
+                <li class="b_algo">
+                  <h2><a href="https://example.com">Bing Result</a></h2>
+                  <div class="b_caption"><p>Bing desc</p></div>
+                </li>
+              </ol>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results: Vec<_> = document.select(&engine.sel_results).collect();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_bing_parser_handles_no_results() {
+        let engine = Bing::new().expect("Failed to create Bing engine");
+        let html = r#"<html><body><div class="b_no">No results found</div></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(engine.parser.has_no_results(&document));
+    }
+
+    #[test]
+    fn test_icon_span_excluded_from_description() {
+        let engine = Bing::new().expect("Failed to create Bing engine");
+        let html = r#"
+            <html><body>
+              <ol id="b_results">
+                <li class="b_algo">
+                  <h2><a href="https://example.com">Title</a></h2>
+                  <div class="b_caption">
+                    <p><span class="algoSlug_icon">ICON</span>Real description text</p>
+                  </div>
+                </li>
+              </ol>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let item = document.select(&engine.sel_results).next().unwrap();
+        let desc: String = item
+            .select(&engine.sel_caption)
+            .flat_map(|p| {
+                p.children().filter_map(|child| {
+                    if let Some(el) = child.value().as_element() {
+                        if el.name() == "span" {
+                            if el.attr("class").unwrap_or("").contains("algoSlug_icon") {
+                                return None;
+                            }
+                        }
+                    }
+                    Some(
+                        scraper::ElementRef::wrap(child)
+                            .map(|er| er.text().collect::<String>())
+                            .unwrap_or_else(|| {
+                                child
+                                    .value()
+                                    .as_text()
+                                    .map(|t| t.to_string())
+                                    .unwrap_or_default()
+                            }),
+                    )
+                })
+            })
+            .collect::<String>();
+        assert!(!desc.contains("ICON"), "icon text must be excluded");
+        assert!(desc.contains("Real description text"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Bing::new().expect("Failed to create Bing engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Bing");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Bing is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/brave.rs
+++ b/src/agent/rt/tool/web_search/engines/brave.rs
@@ -1,0 +1,263 @@
+use async_trait::async_trait;
+use reqwest::{Client, header::SET_COOKIE};
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, USER_AGENT,
+};
+
+pub struct Brave {
+    /// Selector for a "no results" indicator element.
+    no_result: Selector,
+    /// Selector for individual result snippet containers.
+    results: Selector,
+    /// Selector for the title element inside a snippet.
+    result_title: Selector,
+    /// Selector for any anchor tag with an `href` inside a snippet.
+    result_link: Selector,
+    /// Selector for the description/content element inside a snippet.
+    result_desc: Selector,
+}
+
+impl Brave {
+    pub fn new() -> Result<Self, SearchError> {
+        let parse = |s: &str| {
+            Selector::parse(s)
+                .map_err(|e| SearchError::Parse(format!("Invalid CSS selector '{}': {:?}", s, e)))
+        };
+        Ok(Self {
+            no_result: parse(".no-results")?,
+            // Brave renders each web result in a <div class="snippet ..."> container.
+            // The leading-space variant (`div[class*=' snippet']`) avoids false-positives
+            // on sibling classes like "snippet-url" or "snippet-title".
+            results: parse("div[class^='snippet'], div[class*=' snippet']")?,
+            result_title: parse("div[class*='title']")?,
+            // The actual destination URL lives in the first <a href> of the snippet.
+            result_link: parse("a[href]")?,
+            // Brave wraps descriptions in a div whose class contains both
+            // "content" and "t-primary".  We match on "t-primary" to avoid
+            // accidentally selecting the breadcrumb (site-name-content) or
+            // other "content"-bearing divs.
+            result_desc: parse("div[class*='t-primary']")?,
+        })
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Brave {
+    fn name(&self) -> &'static str {
+        "Brave"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        // Pre-fetch the search homepage to acquire session cookies (__cf_bm, etc.)
+        // and make the subsequent search request look like an organic browser
+        // navigation (same-origin Sec-Fetch headers).
+        let init_resp = client
+            .get("https://search.brave.com/")
+            .header("User-Agent", USER_AGENT)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await?;
+
+        let cookies: Vec<String> = init_resp
+            .headers()
+            .get_all(SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or("").trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let cookie_header = cookies.join("; ");
+
+        // Disable spell-check so Brave doesn't silently rewrite the query
+        // (e.g. "ailoy" → "alloy").
+        let url = format!(
+            "https://search.brave.com/search?q={}&source=web&spellcheck=0",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Referer", "https://search.brave.com/")
+            .header("Sec-Fetch-Dest", "document")
+            .header("Sec-Fetch-Mode", "navigate")
+            .header("Sec-Fetch-Site", "same-origin")
+            .header("Sec-Fetch-User", "?1")
+            .header("Cookie", &cookie_header)
+            .send()
+            .await?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        if document.select(&self.no_result).next().is_some() {
+            return Ok(vec![]);
+        }
+
+        let mut results: Vec<SearchResult> = document
+            .select(&self.results)
+            .filter_map(|snippet| {
+                // Get URL from the first anchor's `href` attribute (not text content).
+                let href = snippet
+                    .select(&self.result_link)
+                    .find_map(|a| a.value().attr("href").map(str::to_owned))?;
+
+                // Only keep results with a proper absolute URL (filters out ads
+                // that have partial/relative paths).
+                let parsed = Url::parse(&href).ok()?;
+                if parsed.host().is_none() {
+                    return None;
+                }
+
+                // Title: text of the first element whose class contains "title".
+                let title = snippet
+                    .select(&self.result_title)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .filter(|s| !s.is_empty())?;
+
+                // Description: try a few common content selectors.
+                let description = snippet
+                    .select(&self.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+
+                Some(SearchResult {
+                    title,
+                    url: href,
+                    description,
+                    engine: self.name(),
+                })
+            })
+            .collect();
+
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_brave_parser_extracts_results() {
+        let engine = Brave::new().expect("Failed to create Brave engine");
+        // Simulate the actual Brave HTML structure (Svelte-based, 2025+).
+        // Key observations from live page inspection:
+        //   - Snippet container:  class="snippet  svelte-jmfu5f"
+        //   - Title:              class="title search-snippet-title line-clamp-1 svelte-14r20fy"
+        //   - Description/content: class="content desktop-default-regular t-primary line-clamp-dynamic svelte-1cwdgg3"
+        //   - URL: from <a href="..."> attribute (not text of <cite class="snippet-url">)
+        let html = r#"
+            <html><body>
+              <div id="results">
+                <div class="snippet  svelte-jmfu5f">
+                  <a href="https://example.com/page" class="svelte-abc l1">
+                    <div class="title search-snippet-title line-clamp-1 svelte-14r20fy">Brave Result</div>
+                  </a>
+                  <cite class="snippet-url desktop-small-regular t-tertiary svelte-on1hvy">example.com <span>  › page</span></cite>
+                  <div class="generic-snippet svelte-1cwdgg3">
+                    <div class="content desktop-default-regular t-primary line-clamp-dynamic svelte-1cwdgg3">A description of the result.</div>
+                  </div>
+                </div>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+
+        let results: Vec<SearchResult> = document
+            .select(&engine.results)
+            .filter_map(|snippet| {
+                let href = snippet
+                    .select(&engine.result_link)
+                    .find_map(|a| a.value().attr("href").map(str::to_owned))?;
+                let parsed = url::Url::parse(&href).ok()?;
+                if parsed.host().is_none() {
+                    return None;
+                }
+                let title = snippet
+                    .select(&engine.result_title)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .filter(|s| !s.is_empty())?;
+                let description = snippet
+                    .select(&engine.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+                Some(SearchResult {
+                    title,
+                    url: href,
+                    description,
+                    engine: engine.name(),
+                })
+            })
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Brave Result");
+        assert_eq!(results[0].url, "https://example.com/page");
+        assert_eq!(results[0].description, "A description of the result.");
+        assert_eq!(results[0].engine, "Brave");
+    }
+
+    #[test]
+    fn test_brave_parser_handles_no_results() {
+        let engine = Brave::new().expect("Failed to create Brave engine");
+        let html = r#"<html><body><div class="no-results">No results found</div></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(document.select(&engine.no_result).next().is_some());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Brave::new().expect("Failed to create Brave engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Brave");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Brave is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/duckduckgo.rs
+++ b/src/agent/rt/tool/web_search/engines/duckduckgo.rs
@@ -1,0 +1,359 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::{Html, Selector};
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, SearchResultParser, USER_AGENT,
+};
+
+pub struct DuckDuckGo {
+    parser: SearchResultParser,
+    /// Selector for the result title+URL anchor inside each web-result block.
+    /// DDG HTML uses `<h2><a class="result__a" href="...">title</a></h2>`.
+    title_url_selector: Selector,
+    /// Selector for the snippet anchor inside each web-result block.
+    snippet_selector: Selector,
+    /// Selector to detect DDG's bot-challenge / CAPTCHA page.
+    captcha_selector: Selector,
+}
+
+impl DuckDuckGo {
+    pub fn new() -> Result<Self, SearchError> {
+        let parse = |s: &str| {
+            Selector::parse(s)
+                .map_err(|e| SearchError::Parse(format!("Invalid CSS selector '{}': {:?}", s, e)))
+        };
+
+        // DDG HTML response structure (verified April 2026):
+        //
+        //   <div id="links">
+        //     <div class="result results_links results_links_deep web-result">
+        //       <div class="links_main links_deep result__body">
+        //         <h2 class="result__title">
+        //           <a rel="nofollow" class="result__a" href="https://...">Title text</a>
+        //         </h2>
+        //         <a class="result__snippet" href="https://...">Snippet text</a>
+        //       </div>
+        //     </div>
+        //     ...
+        //   </div>
+        //
+        // Ads have class "result--ad" and are NOT inside #links, so the
+        // `#links .web-result` selector naturally excludes them.
+
+        let parser = SearchResultParser::new(
+            ".no-results",
+            // Select only web-result blocks inside the #links container.
+            // Ads appear outside #links (or carry "result--ad") so this selector
+            // naturally excludes them.
+            "#links .web-result",
+            // Placeholder – title extraction is done via title_url_selector below.
+            "h2.result__title",
+            "h2.result__title",
+            "a.result__snippet",
+        )?;
+
+        Ok(Self {
+            parser,
+            title_url_selector: parse("h2.result__title > a.result__a")?,
+            snippet_selector: parse("a.result__snippet")?,
+            captcha_selector: parse("form#challenge-form")?,
+        })
+    }
+
+    /// Extract the actual destination URL from DuckDuckGo's redirect URLs.
+    /// DDG sometimes wraps URLs as: //duckduckgo.com/l/?uddg=<encoded_url>&...
+    fn extract_url(href: &str) -> String {
+        if let Some(uddg_start) = href.find("uddg=") {
+            let encoded = &href[uddg_start + 5..];
+            let end = encoded.find('&').unwrap_or(encoded.len());
+            let encoded_url = &encoded[..end];
+            return urlencoding::decode(encoded_url)
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| href.to_string());
+        }
+        href.to_string()
+    }
+
+    /// Returns `true` when DDG served its bot-challenge / CAPTCHA page.
+    fn is_captcha_page(&self, document: &Html) -> bool {
+        document.select(&self.captcha_selector).next().is_some()
+    }
+
+    /// Parse a pre-fetched HTML document and return search results.
+    /// Exposed for unit tests; in production, `search()` fetches and calls this.
+    fn search_document(&self, document: &Html) -> Result<Vec<SearchResult>, SearchError> {
+        if self.is_captcha_page(document) {
+            return Err(SearchError::Blocked);
+        }
+        if self.parser.has_no_results(document) {
+            return Ok(vec![]);
+        }
+
+        let title_url_sel = &self.title_url_selector;
+        let snippet_sel = &self.snippet_selector;
+
+        let results: Vec<SearchResult> = document
+            .select(&self.parser.results)
+            .filter_map(|result_el| {
+                let anchor = result_el.select(title_url_sel).next()?;
+                let title = anchor.text().collect::<String>().trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                let href = anchor.value().attr("href")?;
+                let url = Self::extract_url(href);
+                if url.is_empty() || !url.starts_with("http") {
+                    return None;
+                }
+
+                let description = result_el
+                    .select(snippet_sel)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: self.name(),
+                })
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl SearchEngine for DuckDuckGo {
+    fn name(&self) -> &'static str {
+        "DuckDuckGo"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        // POST to html.duckduckgo.com/html/ – the no-JS endpoint.
+        //
+        // Key headers required to avoid bot-detection (202 CAPTCHA challenge):
+        //   • Sec-Fetch-{Dest,Mode,Site,User} – mimic a real browser form submit
+        //   • Referer set to the DDG HTML page (Referrer-Policy: origin)
+        //
+        // Sending `kl=wt-wt` (all regions) gives broader results than an empty
+        // string.  `b=""` is the first-page marker; omit `df` for no date filter.
+        let response = client
+            .post("https://html.duckduckgo.com/html/")
+            .form(&[("q", query), ("b", ""), ("kl", "wt-wt")])
+            .header("User-Agent", USER_AGENT)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            )
+            .header("Accept-Language", "en-US,en;q=0.5")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Referer", "https://html.duckduckgo.com/")
+            .header("Sec-Fetch-Dest", "document")
+            .header("Sec-Fetch-Mode", "navigate")
+            .header("Sec-Fetch-Site", "same-origin")
+            .header("Sec-Fetch-User", "?1")
+            .send()
+            .await?;
+
+        let status = response.status();
+        // HTTP 429 = explicit rate-limit; HTTP 202 = bot-challenge page
+        if status == 429 || status == 202 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        let mut results = self.search_document(&document)?;
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_extract_url_with_uddg_redirect() {
+        let redirect_url =
+            "//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.rust-lang.org%2F&rut=123&h=456";
+        let extracted = DuckDuckGo::extract_url(redirect_url);
+        assert_eq!(extracted, "https://www.rust-lang.org/");
+    }
+
+    #[test]
+    fn test_extract_url_with_direct_url() {
+        let direct_url = "https://example.com/page";
+        let extracted = DuckDuckGo::extract_url(direct_url);
+        assert_eq!(extracted, "https://example.com/page");
+    }
+
+    /// Build a minimal DDG-style HTML page with the real structure:
+    ///
+    ///   <div id="links">
+    ///     <div class="result results_links results_links_deep web-result">
+    ///       <h2 class="result__title">
+    ///         <a class="result__a" href="URL">Title</a>
+    ///       </h2>
+    ///       <a class="result__snippet" href="URL">Snippet</a>
+    ///     </div>
+    ///     ...
+    ///   </div>
+    fn make_ddg_html(results: &[(&str, &str, &str)]) -> String {
+        let mut items = String::new();
+        for (title, url, snippet) in results {
+            items.push_str(&format!(
+                r#"<div class="result results_links results_links_deep web-result">
+                     <h2 class="result__title">
+                       <a class="result__a" href="{url}">{title}</a>
+                     </h2>
+                     <a class="result__snippet" href="{url}">{snippet}</a>
+                   </div>"#
+            ));
+        }
+        format!("<html><body><div id=\"links\">{items}</div></body></html>")
+    }
+
+    #[test]
+    fn test_parser_excludes_ads() {
+        // Ads appear OUTSIDE #links (or with result--ad class) so the
+        // `#links .web-result` selector naturally skips them.
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        // Ad lives outside #links
+        let html = format!(
+            r#"<html><body>
+              <div class="result result--ad">
+                <h2 class="result__title">
+                  <a class="result__a" href="https://ads.example.com">Sponsored Result</a>
+                </h2>
+                <a class="result__snippet" href="https://ads.example.com">Ad description</a>
+              </div>
+              <div id="links">
+                <div class="result results_links web-result">
+                  <h2 class="result__title">
+                    <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Flegit.com%2F">Legitimate Result</a>
+                  </h2>
+                  <a class="result__snippet" href="https://legit.com/">Real description</a>
+                </div>
+              </div>
+            </body></html>"#
+        );
+        let document = Html::parse_document(&html);
+
+        let results = engine
+            .search_document(&document)
+            .expect("parsing should succeed");
+
+        assert_eq!(
+            results.len(),
+            1,
+            "Should have exactly 1 result (ad excluded)"
+        );
+        assert_eq!(results[0].title, "Legitimate Result");
+        assert_eq!(results[0].url, "https://legit.com/");
+        assert_eq!(results[0].description, "Real description");
+        assert_eq!(results[0].engine, "DuckDuckGo");
+    }
+
+    #[test]
+    fn test_parser_extracts_all_fields() {
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        let html = make_ddg_html(&[(
+            "Learning Rust",
+            "https://example.com/rust",
+            "The Rust programming language homepage with documentation and resources",
+        )]);
+        let document = Html::parse_document(&html);
+        let results = engine
+            .search_document(&document)
+            .expect("parsing should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Learning Rust");
+        assert_eq!(results[0].url, "https://example.com/rust");
+        assert_eq!(
+            results[0].description,
+            "The Rust programming language homepage with documentation and resources"
+        );
+        assert_eq!(results[0].engine, "DuckDuckGo");
+    }
+
+    #[test]
+    fn test_parser_handles_no_results() {
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        let html = r#"
+            <html><body>
+              <div class="no-results">
+                <p>No results found</p>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        assert!(engine.parser.has_no_results(&document));
+    }
+
+    #[test]
+    fn test_parser_with_multiple_results() {
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        let html = make_ddg_html(&[
+            ("Result One", "https://example.com/1", "Description one"),
+            ("Result Two", "https://example.com/2", "Description two"),
+            ("Result Three", "https://example.com/3", "Description three"),
+        ]);
+        let document = Html::parse_document(&html);
+        let results = engine
+            .search_document(&document)
+            .expect("parsing should succeed");
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].title, "Result One");
+        assert_eq!(results[1].title, "Result Two");
+        assert_eq!(results[2].title, "Result Three");
+    }
+
+    #[test]
+    fn test_captcha_detection() {
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        let html = r#"<html><body><form id="challenge-form" action="//duckduckgo.com/anomaly.js"></form></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(engine.is_captcha_page(&document));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "DuckDuckGo");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("DuckDuckGo is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/google.rs
+++ b/src/agent/rt/tool/web_search/engines/google.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 use reqwest::Client;
 use scraper::{ElementRef, Html, Selector};
-use wreq::header as rh;
-use wreq_util::Emulation;
 
 use crate::agent::rt::tool::web_search::engine::{SearchEngine, SearchError, SearchResult};
 
@@ -95,20 +93,13 @@ impl SearchEngine for Google {
 
     async fn search(
         &self,
-        _client: &Client,
+        client: &Client,
         query: &str,
         max_results: usize,
     ) -> Result<Vec<SearchResult>, SearchError> {
-        // Google serves SSR search results (with data-ved attributes) only when it
-        // recognises the client as a mobile browser.  An Android Chrome Mobile UA
-        // (with the optional "GoogleApp/N" token from Google's own search app) reliably
-        // triggers the mobile-SSR code path.  Desktop or unknown UAs receive a
-        // JavaScript-only shell instead.
-        let rq_client = wreq::Client::builder()
-            .emulation(Emulation::Firefox135)
-            .timeout(std::time::Duration::from_secs(15))
-            .build()
-            .map_err(|e| SearchError::Parse(e.to_string()))?;
+        // Google does not use TLS fingerprinting for bot detection; plain reqwest works.
+        // The mobile Android Chrome UA is what triggers Google's SSR code path —
+        // desktop or unknown UAs receive a JavaScript-only shell that cannot be parsed.
 
         // hl=en-US   : interface language
         // lr=lang_en : restrict results to English documents
@@ -119,18 +110,16 @@ impl SearchEngine for Google {
             urlencoding::encode(query)
         );
 
-        let response = rq_client
+        let response = client
             .get(&url)
-            .header(rh::USER_AGENT, random_ua())
-            .header(rh::ACCEPT, "*/*")
-            .header(rh::ACCEPT_LANGUAGE, "en-US,en;q=0.9")
-            .header(rh::ACCEPT_ENCODING, "gzip, deflate")
-            .header(rh::CACHE_CONTROL, "no-cache")
+            .header("User-Agent", random_ua())
+            .header("Accept", "*/*")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Cache-Control", "no-cache")
             // CONSENT=YES+ bypasses Google's cookie-consent interstitial.
             .header("Cookie", "CONSENT=YES+")
             .send()
-            .await
-            .map_err(|e| SearchError::Parse(e.to_string()))?;
+            .await?;
 
         if response.status() == 429 {
             return Err(SearchError::Blocked);
@@ -140,10 +129,7 @@ impl SearchEngine for Google {
             return Err(SearchError::Blocked);
         }
 
-        let html_text = response
-            .text()
-            .await
-            .map_err(|e| SearchError::Parse(e.to_string()))?;
+        let html_text = response.error_for_status()?.text().await?;
 
         // Google redirects to sorry.google.com or /sorry/ when it detects automation.
         if html_text.contains("sorry.google.com")

--- a/src/agent/rt/tool/web_search/engines/google.rs
+++ b/src/agent/rt/tool/web_search/engines/google.rs
@@ -1,0 +1,366 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::{ElementRef, Html, Selector};
+use wreq::header as rh;
+use wreq_util::Emulation;
+
+use crate::agent::rt::tool::web_search::engine::{SearchEngine, SearchError, SearchResult};
+
+/// Android Chrome Mobile UAs from the Chrome/50-60 era.
+///
+/// Google's mobile-lite SSR code path (which contains parseable `data-ved` anchors
+/// with `div[style]` title elements) is consistently triggered by old Android Chrome
+/// UAs.  Modern Chrome UAs (130+) cause Google to return a React-based SPA instead,
+/// whose HTML structure does not match these selectors.
+///
+/// These strings describe real Android browser capabilities and are identical to what
+/// any Chrome/50-60 device sends.  The `GoogleApp/N` suffix is appended per-request
+/// by `random_ua()` to vary the UA across calls.
+static MOBILE_UAS: &[&str] = &[
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.1379.1923 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.1759.1577 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.1249.1438 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.1371.1215 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.1301.1032 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.1167.1790 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.1009.1234 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.1071.1894 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.1040.1510 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.1179.1282 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.1263.1435 Mobile Safari/537.36",
+];
+
+/// Pick a random base UA and append a random `GoogleApp/N` token.
+///
+/// Uses subsecond nanosecond timestamp as a lightweight entropy source —
+/// sufficient for UA rotation; no cryptographic quality needed.
+fn random_ua() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as usize;
+    let base = MOBILE_UAS[nanos % MOBILE_UAS.len()];
+    format!("{base} GoogleApp/{}", nanos % 10)
+}
+
+pub struct Google {
+    /// `a[data-ved]` — further filtered in code to skip anchors that have a class attribute.
+    sel_results: Selector,
+    /// Title text lives in the first `div` with a `style` attribute inside the anchor.
+    sel_title: Selector,
+    /// Description lives 2 DOM levels above the anchor, in a div carrying these three classes.
+    sel_desc: Selector,
+}
+
+impl Google {
+    pub fn new() -> Result<Self, SearchError> {
+        Ok(Self {
+            sel_results: Selector::parse("a[data-ved]")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+            sel_title: Selector::parse("div[style]")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+            sel_desc: Selector::parse("div.ilUpNd.H66NU.aSRlid")
+                .map_err(|e| SearchError::Parse(format!("{:?}", e)))?,
+        })
+    }
+
+    /// Strip Google's `/url?q=<percent-encoded-url>&sa=U&...` redirect wrapper.
+    ///
+    /// Direct `http(s)://` hrefs are returned as-is.  Everything else (relative
+    /// paths, fragment-only anchors, etc.) returns `None` and will be skipped.
+    fn clean_url(href: &str) -> Option<String> {
+        if href.starts_with("/url?q=") {
+            // Take the part after `/url?q=` and before the first `&sa=U` token.
+            let encoded = href[7..].split("&sa=U").next().unwrap_or("");
+            let decoded = urlencoding::decode(encoded).ok()?.into_owned();
+            if decoded.starts_with("http") {
+                Some(decoded)
+            } else {
+                None
+            }
+        } else if href.starts_with("http") {
+            Some(href.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Google {
+    fn name(&self) -> &'static str {
+        "Google"
+    }
+
+    async fn search(
+        &self,
+        _client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        // Google serves SSR search results (with data-ved attributes) only when it
+        // recognises the client as a mobile browser.  An Android Chrome Mobile UA
+        // (with the optional "GoogleApp/N" token from Google's own search app) reliably
+        // triggers the mobile-SSR code path.  Desktop or unknown UAs receive a
+        // JavaScript-only shell instead.
+        let rq_client = wreq::Client::builder()
+            .emulation(Emulation::Firefox135)
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        // hl=en-US   : interface language
+        // lr=lang_en : restrict results to English documents
+        // ie/oe      : character encoding (utf8)
+        // filter=0   : disable duplicate result filtering
+        let url = format!(
+            "https://www.google.com/search?q={}&hl=en-US&lr=lang_en&ie=utf8&oe=utf8&filter=0",
+            urlencoding::encode(query)
+        );
+
+        let response = rq_client
+            .get(&url)
+            .header(rh::USER_AGENT, random_ua())
+            .header(rh::ACCEPT, "*/*")
+            .header(rh::ACCEPT_LANGUAGE, "en-US,en;q=0.9")
+            .header(rh::ACCEPT_ENCODING, "gzip, deflate")
+            .header(rh::CACHE_CONTROL, "no-cache")
+            // CONSENT=YES+ bypasses Google's cookie-consent interstitial.
+            .header("Cookie", "CONSENT=YES+")
+            .send()
+            .await
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        if !response.status().is_success() {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response
+            .text()
+            .await
+            .map_err(|e| SearchError::Parse(e.to_string()))?;
+
+        // Google redirects to sorry.google.com or /sorry/ when it detects automation.
+        if html_text.contains("sorry.google.com")
+            || html_text.contains("/sorry/")
+            || html_text.contains("detected unusual traffic")
+        {
+            return Err(SearchError::Blocked);
+        }
+
+        let document = Html::parse_document(&html_text);
+        let mut results = Vec::new();
+
+        for a_el in document.select(&self.sel_results) {
+            // XPath equivalent: //a[@data-ved and not(@class)]
+            // Anchors that carry a class attribute are navigation links, image tiles, etc.
+            if a_el.value().attr("class").is_some() {
+                continue;
+            }
+
+            let href = match a_el.value().attr("href") {
+                Some(h) if !h.is_empty() => h,
+                _ => continue,
+            };
+            let url = match Self::clean_url(href) {
+                Some(u) => u,
+                None => continue,
+            };
+
+            // Title: first div[style] descendant of the anchor.
+            let title: String = match a_el.select(&self.sel_title).next() {
+                Some(el) => el.text().collect::<String>().trim().to_string(),
+                None => continue,
+            };
+            if title.is_empty() {
+                continue;
+            }
+
+            // Description: XPath `../..//div[contains(@class, "ilUpNd H66NU aSRlid")]`
+            // Walk up 2 DOM levels from the anchor, then search descendants.
+            let description = a_el
+                .parent()
+                .and_then(|p| p.parent())
+                .and_then(ElementRef::wrap)
+                .and_then(|gp| {
+                    gp.select(&self.sel_desc)
+                        .next()
+                        .map(|el| el.text().collect::<String>().trim().to_string())
+                })
+                .unwrap_or_default();
+
+            results.push(SearchResult {
+                title,
+                url,
+                description,
+                engine: self.name(),
+            });
+
+            if results.len() >= max_results {
+                break;
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Client;
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_clean_url_strips_google_redirect() {
+        let href = "/url?q=https%3A%2F%2Fwww.rust-lang.org%2F&sa=U&ved=xxx";
+        assert_eq!(
+            Google::clean_url(href),
+            Some("https://www.rust-lang.org/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_clean_url_passthrough_for_direct_http() {
+        let href = "https://example.com/page";
+        assert_eq!(
+            Google::clean_url(href),
+            Some("https://example.com/page".to_string())
+        );
+    }
+
+    #[test]
+    fn test_clean_url_rejects_relative_and_anchor_paths() {
+        assert_eq!(Google::clean_url("/search?q=foo"), None);
+        assert_eq!(Google::clean_url("#top"), None);
+        assert_eq!(Google::clean_url(""), None);
+    }
+
+    #[test]
+    fn test_google_parser_extracts_title_and_url() {
+        let engine = Google::new().expect("Failed to create Google engine");
+        // HTML mirrors Google's structure: grandparent wraps parent+anchor and the description.
+        let html = r#"
+            <html><body>
+              <div>
+                <div>
+                  <a data-ved="yyy" href="/url?q=https%3A%2F%2Fwww.rust-lang.org&sa=U&ved=zzz">
+                    <div style="font-size:20px">Rust Programming Language</div>
+                  </a>
+                </div>
+                <div class="ilUpNd H66NU aSRlid">A language empowering everyone.</div>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let a_el = document
+            .select(&engine.sel_results)
+            .find(|a| a.value().attr("class").is_none())
+            .expect("no classless a[data-ved] found");
+
+        let href = a_el.value().attr("href").unwrap();
+        assert_eq!(
+            Google::clean_url(href),
+            Some("https://www.rust-lang.org".to_string())
+        );
+
+        let title: String = a_el
+            .select(&engine.sel_title)
+            .next()
+            .unwrap()
+            .text()
+            .collect::<String>()
+            .trim()
+            .to_string();
+        assert_eq!(title, "Rust Programming Language");
+    }
+
+    #[test]
+    fn test_google_parser_skips_anchors_with_class() {
+        let engine = Google::new().expect("Failed to create Google engine");
+        let html = r#"
+            <html><body>
+              <a data-ved="1" class="nav-link" href="https://example.com">
+                <div style="">Should be skipped</div>
+              </a>
+              <a data-ved="2" href="https://example.com">
+                <div style="">Should be kept</div>
+              </a>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let classless: Vec<_> = document
+            .select(&engine.sel_results)
+            .filter(|a| a.value().attr("class").is_none())
+            .collect();
+        assert_eq!(classless.len(), 1);
+        let title: String = classless[0]
+            .select(&engine.sel_title)
+            .next()
+            .unwrap()
+            .text()
+            .collect();
+        assert_eq!(title.trim(), "Should be kept");
+    }
+
+    #[test]
+    fn test_description_extracted_from_grandparent() {
+        let engine = Google::new().expect("Failed to create Google engine");
+        let html = r#"
+            <html><body>
+              <div>
+                <div>
+                  <a data-ved="1" href="https://example.com">
+                    <div style="">Title</div>
+                  </a>
+                </div>
+                <div class="ilUpNd H66NU aSRlid">Description text here</div>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let a_el = document.select(&engine.sel_results).next().unwrap();
+        let desc = a_el
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(ElementRef::wrap)
+            .and_then(|gp| {
+                gp.select(&engine.sel_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+            });
+        assert_eq!(desc, Some("Description text here".to_string()));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Google::new().expect("Failed to create Google engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Google");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Google is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/librex.rs
+++ b/src/agent/rt/tool/web_search/engines/librex.rs
@@ -1,0 +1,143 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::Html;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, SearchResultParser, USER_AGENT,
+};
+
+pub struct LibreX {
+    parser: SearchResultParser,
+}
+
+impl LibreX {
+    pub fn new() -> Result<Self, SearchError> {
+        // search.davidovski.xyz now runs LibreY, which uses a different HTML structure:
+        // .text-result-wrapper > <a href="..."><h2>title</h2></a> <span>desc</span>
+        let parser =
+            SearchResultParser::new(".no-results", ".text-result-wrapper", "h2", "a", "span")?;
+        Ok(Self { parser })
+    }
+}
+
+#[async_trait]
+impl SearchEngine for LibreX {
+    fn name(&self) -> &'static str {
+        "LibreX"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        let url = format!(
+            "https://search.davidovski.xyz/search.php?q={}&p=0&type=1",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "text/html,application/xhtml+xml")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        if self.parser.has_no_results(&document) {
+            return Ok(vec![]);
+        }
+
+        let mut results = self.parser.extract(&document, self.name(), |el| {
+            el.select(&self.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+                .filter(|url| !url.is_empty())
+        });
+
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_librex_parser_extracts_results() {
+        let engine = LibreX::new().expect("Failed to create LibreX engine");
+        // Structure matches current LibreY HTML (search.davidovski.xyz)
+        let html = r#"
+            <html><body>
+              <div class="text-result-wrapper">
+                <a href="https://example.com">
+                  https://example.com
+                  <h2>LibreX Result</h2>
+                </a>
+                <span>desc</span>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results = engine.parser.extract(&document, engine.name(), |el| {
+            el.select(&engine.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+                .filter(|url| !url.is_empty())
+        });
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "LibreX Result");
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].description, "desc");
+        assert_eq!(results[0].engine, "LibreX");
+    }
+
+    #[test]
+    fn test_librex_parser_handles_no_results() {
+        let engine = LibreX::new().expect("Failed to create LibreX engine");
+        let html = r#"<html><body><div class="no-results">No results found</div></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(engine.parser.has_no_results(&document));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = LibreX::new().expect("Failed to create LibreX engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "LibreX");
+                }
+            }
+            // Public LibreX instances may be unavailable or rate-limited
+            Err(SearchError::Blocked) => {
+                eprintln!("LibreX is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/mod.rs
+++ b/src/agent/rt/tool/web_search/engines/mod.rs
@@ -1,0 +1,19 @@
+mod bing;
+mod brave;
+mod duckduckgo;
+mod google;
+mod librex;
+mod mojeek;
+mod startpage;
+mod yahoo;
+mod yandex;
+
+pub use bing::Bing;
+pub use brave::Brave;
+pub use duckduckgo::DuckDuckGo;
+pub use google::Google;
+pub use librex::LibreX;
+pub use mojeek::Mojeek;
+pub use startpage::Startpage;
+pub use yahoo::Yahoo;
+pub use yandex::Yandex;

--- a/src/agent/rt/tool/web_search/engines/mojeek.rs
+++ b/src/agent/rt/tool/web_search/engines/mojeek.rs
@@ -1,0 +1,143 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::Html;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, SearchResultParser, USER_AGENT,
+};
+
+pub struct Mojeek {
+    parser: SearchResultParser,
+}
+
+impl Mojeek {
+    pub fn new() -> Result<Self, SearchError> {
+        let parser = SearchResultParser::new(
+            ".no-results",
+            "ul.results-standard li",
+            "h2 a",
+            "h2 a",
+            "p.s",
+        )?;
+        Ok(Self { parser })
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Mojeek {
+    fn name(&self) -> &'static str {
+        "Mojeek"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        let url = format!(
+            "https://www.mojeek.com/search?q={}",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "text/html,application/xhtml+xml")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await?;
+
+        if response.status() == 429 || response.status() == 403 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        if self.parser.has_no_results(&document) {
+            return Ok(vec![]);
+        }
+
+        let mut results = self.parser.extract(&document, self.name(), |el| {
+            el.select(&self.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+                .filter(|url| !url.is_empty())
+        });
+
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_mojeek_parser_extracts_results() {
+        let engine = Mojeek::new().expect("Failed to create Mojeek engine");
+        let html = r#"
+            <html><body>
+              <ul class="results-standard">
+                <li>
+                  <h2><a href="https://example.com">Mojeek Result</a></h2>
+                  <p class="s">Mojeek desc</p>
+                </li>
+              </ul>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results = engine.parser.extract(&document, engine.name(), |el| {
+            el.select(&engine.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(String::from)
+                .filter(|url| !url.is_empty())
+        });
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Mojeek Result");
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].description, "Mojeek desc");
+        assert_eq!(results[0].engine, "Mojeek");
+    }
+
+    #[test]
+    fn test_mojeek_parser_handles_no_results() {
+        let engine = Mojeek::new().expect("Failed to create Mojeek engine");
+        let html = r#"<html><body><div class="no-results">No results found</div></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(engine.parser.has_no_results(&document));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Mojeek::new().expect("Failed to create Mojeek engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Mojeek");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Mojeek is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/startpage.rs
+++ b/src/agent/rt/tool/web_search/engines/startpage.rs
@@ -1,0 +1,293 @@
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, USER_AGENT,
+};
+
+/// Startpage search engine.
+///
+/// Startpage serves results via a React SPA. Results are embedded in the HTML as
+/// JSON props passed to `React.createElement(UIStartpage.AppSerpWeb, {...})`.
+/// The relevant path is: props["render"]["presenter"]["regions"]["mainline"]
+/// → find the item with `display_type == "web-google"` → `results[]`.
+///
+/// Each result has:
+/// - `clickUrl`: the actual destination URL
+/// - `title`: HTML string (bold tags around matched terms)
+/// - `description`: HTML string (bold tags around matched terms)
+pub struct Startpage;
+
+impl Startpage {
+    pub fn new() -> Result<Self, SearchError> {
+        Ok(Self)
+    }
+
+    /// Strip HTML tags from a string, returning plain text.
+    fn strip_html(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut in_tag = false;
+        for c in s.chars() {
+            match c {
+                '<' => in_tag = true,
+                '>' => in_tag = false,
+                _ if !in_tag => out.push(c),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// Extract the React props JSON string from the raw HTML.
+    ///
+    /// Looks for `React.createElement(UIStartpage.AppSerpWeb, {` and finds the
+    /// matching closing `}` by bracket-counting.
+    fn extract_props_json(html: &str) -> Option<&str> {
+        let marker = "React.createElement(UIStartpage.AppSerpWeb,";
+        let marker_pos = html.find(marker)?;
+        let after_marker = &html[marker_pos + marker.len()..];
+
+        // Skip optional whitespace to reach the opening '{'
+        let brace_offset = after_marker.find('{')?;
+        let json_start = marker_pos + marker.len() + brace_offset;
+
+        // Find the matching closing '}'
+        let mut depth: usize = 0;
+        let bytes = html.as_bytes();
+        for i in json_start..html.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(&html[json_start..=i]);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Startpage {
+    fn name(&self) -> &'static str {
+        "Startpage"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        let url = format!(
+            "https://www.startpage.com/sp/search?q={}",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "text/html,application/xhtml+xml")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+
+        let props_json = Self::extract_props_json(&html_text)
+            .ok_or_else(|| SearchError::Parse("React props JSON not found".to_string()))?;
+
+        let props: serde_json::Value = serde_json::from_str(props_json)
+            .map_err(|e| SearchError::Parse(format!("Failed to parse props JSON: {e}")))?;
+
+        let mainline = props
+            .pointer("/render/presenter/regions/mainline")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| SearchError::Parse("regions.mainline not found in props".to_string()))?;
+
+        let web_section = mainline
+            .iter()
+            .find(|item| item.get("display_type").and_then(|v| v.as_str()) == Some("web-google"))
+            .ok_or_else(|| SearchError::Parse("web-google section not found".to_string()))?;
+
+        let raw_results = web_section
+            .get("results")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| SearchError::Parse("web-google results array missing".to_string()))?;
+
+        let results = raw_results
+            .iter()
+            .take(max_results)
+            .filter_map(|item| {
+                let url = item.get("clickUrl")?.as_str()?.to_string();
+                if url.is_empty() {
+                    return None;
+                }
+                let title = item
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .map(Self::strip_html)
+                    .unwrap_or_default();
+                if title.is_empty() {
+                    return None;
+                }
+                let description = item
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(Self::strip_html)
+                    .unwrap_or_default();
+
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: self.name(),
+                })
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_html_removes_bold_tags() {
+        assert_eq!(
+            Startpage::strip_html("<b>Rust Programming</b> Language"),
+            "Rust Programming Language"
+        );
+        assert_eq!(Startpage::strip_html("No tags here"), "No tags here");
+        assert_eq!(
+            Startpage::strip_html("<b>Rust</b> is <b>fast</b>"),
+            "Rust is fast"
+        );
+    }
+
+    #[test]
+    fn test_extract_props_json_not_found() {
+        let html = "<html><body>no react here</body></html>";
+        assert!(Startpage::extract_props_json(html).is_none());
+    }
+
+    #[test]
+    fn test_extract_props_json_finds_balanced_braces() {
+        let html = r#"
+            React.createElement(UIStartpage.AppSerpWeb, {"key": "value", "nested": {"a": 1}})
+            extra stuff
+        "#;
+        let json = Startpage::extract_props_json(html).unwrap();
+        assert_eq!(json, r#"{"key": "value", "nested": {"a": 1}}"#);
+    }
+
+    #[test]
+    fn test_parse_web_results_from_props() {
+        let props_json = r#"{
+            "render": {
+                "presenter": {
+                    "regions": {
+                        "mainline": [
+                            {"display_type": "ads-top", "results": []},
+                            {
+                                "display_type": "web-google",
+                                "presented_count": 2,
+                                "results": [
+                                    {
+                                        "clickUrl": "https://rust-lang.org/",
+                                        "title": "<b>Rust Programming</b> Language",
+                                        "description": "<b>Rust</b> is blazingly fast"
+                                    },
+                                    {
+                                        "clickUrl": "https://doc.rust-lang.org/book/",
+                                        "title": "The <b>Rust</b> Book",
+                                        "description": "Learn <b>Rust</b> programming"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }"#;
+
+        let props: serde_json::Value = serde_json::from_str(props_json).unwrap();
+        let mainline = props
+            .pointer("/render/presenter/regions/mainline")
+            .and_then(|v| v.as_array())
+            .unwrap();
+
+        let web_section = mainline
+            .iter()
+            .find(|item| item.get("display_type").and_then(|v| v.as_str()) == Some("web-google"))
+            .unwrap();
+
+        let raw = web_section["results"].as_array().unwrap();
+        assert_eq!(raw.len(), 2);
+
+        let title = Startpage::strip_html(raw[0]["title"].as_str().unwrap());
+        let url = raw[0]["clickUrl"].as_str().unwrap();
+        let desc = Startpage::strip_html(raw[0]["description"].as_str().unwrap());
+
+        assert_eq!(title, "Rust Programming Language");
+        assert_eq!(url, "https://rust-lang.org/");
+        assert_eq!(desc, "Rust is blazingly fast");
+    }
+
+    #[test]
+    fn test_no_results_when_web_google_missing() {
+        // If the web-google section is absent, we get a parse error (not a panic)
+        let props: serde_json::Value = serde_json::from_str(
+            r#"{
+            "render": {"presenter": {"regions": {"mainline": [
+                {"display_type": "ads-top", "results": []}
+            ]}}}
+        }"#,
+        )
+        .unwrap();
+
+        let mainline = props
+            .pointer("/render/presenter/regions/mainline")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        let web = mainline
+            .iter()
+            .find(|i| i.get("display_type").and_then(|v| v.as_str()) == Some("web-google"));
+        assert!(web.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Startpage::new().expect("Failed to create Startpage engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Startpage");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Startpage is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/yahoo.rs
+++ b/src/agent/rt/tool/web_search/engines/yahoo.rs
@@ -1,0 +1,178 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::Html;
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, SearchResultParser, USER_AGENT,
+};
+
+pub struct Yahoo {
+    parser: SearchResultParser,
+}
+
+impl Yahoo {
+    pub fn new() -> Result<Self, SearchError> {
+        // Yahoo wraps <h3 class="title"> inside <a>, so "h3 a" finds nothing.
+        // The anchor (.compTitle a) is the parent of <h3>, not a child.
+        let parser = SearchResultParser::new(
+            ".no-results",
+            ".algo",
+            "h3.title",
+            ".compTitle a",
+            ".compText p",
+        )?;
+        Ok(Self { parser })
+    }
+
+    /// Extract the actual destination URL from Yahoo's redirect wrapper.
+    /// Yahoo wraps URLs as: /RU=<encoded_url>/RK=...
+    pub fn extract_redirect_url(href: &str) -> String {
+        if let Some(ru_start) = href.find("/RU=") {
+            let after_ru = &href[ru_start + 4..];
+            let end = after_ru.find('/').unwrap_or(after_ru.len());
+            let encoded_url = &after_ru[..end];
+            return urlencoding::decode(encoded_url)
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| href.to_string());
+        }
+        href.to_string()
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Yahoo {
+    fn name(&self) -> &'static str {
+        "Yahoo"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        let url = format!(
+            "https://search.yahoo.com/search?p={}&ei=UTF-8",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "text/html,application/xhtml+xml")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await?;
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        if self.parser.has_no_results(&document) {
+            return Ok(vec![]);
+        }
+
+        let mut results = self.parser.extract(&document, self.name(), |el| {
+            el.select(&self.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(|href| Self::extract_redirect_url(href))
+                .filter(|url| !url.is_empty())
+        });
+
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::*;
+
+    #[test]
+    fn test_yahoo_extract_redirect_url() {
+        assert_eq!(
+            Yahoo::extract_redirect_url("/RU=https%3A%2F%2Fexample.com/RK=2"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_yahoo_extract_direct_url() {
+        assert_eq!(
+            Yahoo::extract_redirect_url("https://example.com"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_yahoo_parser_extracts_results() {
+        let engine = Yahoo::new().expect("Failed to create Yahoo engine");
+        // Structure matches current Yahoo HTML: <a> wraps <h3>, not the other way around
+        let html = r#"
+            <html><body>
+              <div class="algo">
+                <div class="compTitle">
+                  <a href="/RU=https%3A%2F%2Fexample.com/RK=2">
+                    <h3 class="title">Yahoo Result</h3>
+                  </a>
+                </div>
+                <div class="compText"><p>Yahoo desc</p></div>
+              </div>
+            </body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results = engine.parser.extract(&document, engine.name(), |el| {
+            el.select(&engine.parser.result_url)
+                .next()
+                .and_then(|a| a.value().attr("href"))
+                .map(|href| Yahoo::extract_redirect_url(href))
+                .filter(|url| !url.is_empty())
+        });
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Yahoo Result");
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].description, "Yahoo desc");
+        assert_eq!(results[0].engine, "Yahoo");
+    }
+
+    #[test]
+    fn test_yahoo_parser_handles_no_results() {
+        let engine = Yahoo::new().expect("Failed to create Yahoo engine");
+        let html = r#"<html><body><div class="no-results">No results found</div></body></html>"#;
+        let document = Html::parse_document(html);
+        assert!(engine.parser.has_no_results(&document));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Yahoo::new().expect("Failed to create Yahoo engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Yahoo");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Yahoo is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/engines/yandex.rs
+++ b/src/agent/rt/tool/web_search/engines/yandex.rs
@@ -1,0 +1,315 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::{Html, Selector};
+
+use crate::agent::rt::tool::web_search::engine::{
+    SearchEngine, SearchError, SearchResult, USER_AGENT,
+};
+
+/// Yandex web search via the Yandex Site Search widget endpoint.
+///
+/// The widget endpoint (`/search/site/`) bypasses the main Yandex search
+/// anti-bot protections and returns a lightweight HTML page with a stable
+/// BEM-class structure that is straightforward to parse.
+///
+/// HTML structure (verified April 2026):
+///
+///   <ul class="b-serp-list">
+///     <li class="b-serp-item">
+///       <div class="b-serp-item__content">
+///         <h3 class="b-serp-item__title">
+///           <a class="b-serp-item__title-link" href="https://...">
+///             <span>Title text with <b>highlight</b></span>
+///           </a>
+///         </h3>
+///         <div class="b-serp-item__text">Description…</div>
+///       </div>
+///     </li>
+///   </ul>
+pub struct Yandex {
+    /// Selector for individual search result items.
+    results: Selector,
+    /// Selector for the title anchor inside a result item.
+    result_link: Selector,
+    /// Selector for the description text inside a result item.
+    result_desc: Selector,
+}
+
+impl Yandex {
+    pub fn new() -> Result<Self, SearchError> {
+        let parse = |s: &str| {
+            Selector::parse(s)
+                .map_err(|e| SearchError::Parse(format!("Invalid CSS selector '{}': {:?}", s, e)))
+        };
+        Ok(Self {
+            results: parse("li.b-serp-item")?,
+            result_link: parse("a.b-serp-item__title-link")?,
+            result_desc: parse("div.b-serp-item__text")?,
+        })
+    }
+}
+
+#[async_trait]
+impl SearchEngine for Yandex {
+    fn name(&self) -> &'static str {
+        "Yandex"
+    }
+
+    async fn search(
+        &self,
+        client: &Client,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchError> {
+        // Yandex.com redirects to yandex.ru for search; use the .ru host directly.
+        // The `searchid` identifies a public Site Search widget instance.
+        let url = format!(
+            "https://yandex.ru/search/site/?tmpl_version=releases&text={}&web=1&frame=1&searchid=3131712",
+            urlencoding::encode(query)
+        );
+
+        let response = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .header("Accept-Language", "en-US,en;q=0.5")
+            .send()
+            .await?;
+
+        // Yandex signals CAPTCHA challenges via a response header.
+        if response.headers().get("x-yandex-captcha").is_some() {
+            return Err(SearchError::Blocked);
+        }
+
+        if response.status() == 429 {
+            return Err(SearchError::Blocked);
+        }
+
+        let html_text = response.error_for_status()?.text().await?;
+        let document = Html::parse_document(&html_text);
+
+        let mut results: Vec<SearchResult> = document
+            .select(&self.results)
+            .filter_map(|item| {
+                let link = item.select(&self.result_link).next()?;
+
+                let url = link.value().attr("href")?.to_string();
+                if !url.starts_with("http") {
+                    return None;
+                }
+
+                let title = link.text().collect::<String>().trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+
+                let description = item
+                    .select(&self.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: self.name(),
+                })
+            })
+            .collect();
+
+        results.truncate(max_results);
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scraper::Html;
+
+    fn make_yandex_html(items: &[(&str, &str, &str)]) -> String {
+        let mut list = String::new();
+        for (title, url, desc) in items {
+            list.push_str(&format!(
+                r#"<li class="b-serp-item">
+                     <div class="b-serp-item__content">
+                       <h3 class="b-serp-item__title">
+                         <a class="b-serp-item__title-link" href="{url}">
+                           <span>{title}</span>
+                         </a>
+                       </h3>
+                       <div class="b-serp-item__text">{desc}</div>
+                     </div>
+                   </li>"#
+            ));
+        }
+        format!(
+            "<html><body><ul class=\"b-serp-list\">{list}</ul></body></html>"
+        )
+    }
+
+    #[test]
+    fn test_yandex_parser_extracts_results() {
+        let engine = Yandex::new().expect("Failed to create Yandex engine");
+        let html = make_yandex_html(&[(
+            "Introducing Ailoy",
+            "https://medium.com/ailoy/introducing-ailoy",
+            "Ailoy is a lightweight library for building AI applications.",
+        )]);
+        let document = Html::parse_document(&html);
+
+        let results: Vec<SearchResult> = document
+            .select(&engine.results)
+            .filter_map(|item| {
+                let link = item.select(&engine.result_link).next()?;
+                let url = link.value().attr("href")?.to_string();
+                if !url.starts_with("http") {
+                    return None;
+                }
+                let title = link.text().collect::<String>().trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                let description = item
+                    .select(&engine.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: engine.name(),
+                })
+            })
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Introducing Ailoy");
+        assert_eq!(results[0].url, "https://medium.com/ailoy/introducing-ailoy");
+        assert_eq!(
+            results[0].description,
+            "Ailoy is a lightweight library for building AI applications."
+        );
+        assert_eq!(results[0].engine, "Yandex");
+    }
+
+    #[test]
+    fn test_yandex_parser_filters_non_http_urls() {
+        let engine = Yandex::new().expect("Failed to create Yandex engine");
+        let html = r#"
+            <html><body><ul class="b-serp-list">
+              <li class="b-serp-item">
+                <div class="b-serp-item__content">
+                  <h3 class="b-serp-item__title">
+                    <a class="b-serp-item__title-link" href="/relative/path">
+                      <span>Relative Link</span>
+                    </a>
+                  </h3>
+                </div>
+              </li>
+              <li class="b-serp-item">
+                <div class="b-serp-item__content">
+                  <h3 class="b-serp-item__title">
+                    <a class="b-serp-item__title-link" href="https://example.com">
+                      <span>Absolute Link</span>
+                    </a>
+                  </h3>
+                </div>
+              </li>
+            </ul></body></html>
+        "#;
+        let document = Html::parse_document(html);
+        let results: Vec<SearchResult> = document
+            .select(&engine.results)
+            .filter_map(|item| {
+                let link = item.select(&engine.result_link).next()?;
+                let url = link.value().attr("href")?.to_string();
+                if !url.starts_with("http") {
+                    return None;
+                }
+                let title = link.text().collect::<String>().trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                Some(SearchResult {
+                    title,
+                    url,
+                    description: String::new(),
+                    engine: engine.name(),
+                })
+            })
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].url, "https://example.com");
+    }
+
+    #[test]
+    fn test_yandex_parser_multiple_results() {
+        let engine = Yandex::new().expect("Failed to create Yandex engine");
+        let html = make_yandex_html(&[
+            ("Result One", "https://example.com/1", "Desc one"),
+            ("Result Two", "https://example.com/2", "Desc two"),
+            ("Result Three", "https://example.com/3", "Desc three"),
+        ]);
+        let document = Html::parse_document(&html);
+        let results: Vec<SearchResult> = document
+            .select(&engine.results)
+            .filter_map(|item| {
+                let link = item.select(&engine.result_link).next()?;
+                let url = link.value().attr("href")?.to_string();
+                if !url.starts_with("http") {
+                    return None;
+                }
+                let title = link.text().collect::<String>().trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                let description = item
+                    .select(&engine.result_desc)
+                    .next()
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .unwrap_or_default();
+                Some(SearchResult {
+                    title,
+                    url,
+                    description,
+                    engine: engine.name(),
+                })
+            })
+            .collect();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].title, "Result One");
+        assert_eq!(results[1].title, "Result Two");
+        assert_eq!(results[2].title, "Result Three");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_search_returns_results() {
+        let engine = Yandex::new().expect("Failed to create Yandex engine");
+        let client = Client::new();
+        match engine.search(&client, "ailoy", 5).await {
+            Ok(results) => {
+                assert!(!results.is_empty(), "Expected at least one result");
+                for r in &results {
+                    println!("{:?}", r);
+                    assert!(!r.title.is_empty(), "title must not be empty");
+                    assert!(
+                        r.url.starts_with("http"),
+                        "url must start with http: {}",
+                        r.url
+                    );
+                    assert_eq!(r.engine, "Yandex");
+                }
+            }
+            Err(SearchError::Blocked) => {
+                eprintln!("Yandex is blocking requests — skipping assertions")
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+}

--- a/src/agent/rt/tool/web_search/mod.rs
+++ b/src/agent/rt/tool/web_search/mod.rs
@@ -1,0 +1,199 @@
+mod aggregator;
+mod engine;
+mod engines;
+
+use std::sync::Arc;
+
+use aggregator::MetaSearcher;
+use futures::future::BoxFuture;
+
+use crate::{
+    agent::rt::tool::{ToolFunc, ToolRuntime},
+    datatype::Value,
+    message::ToolDescBuilder,
+};
+
+pub fn build_web_search_tool() -> ToolRuntime {
+    let desc = ToolDescBuilder::new("web_search")
+        .description(
+            "Search the web using multiple search engines simultaneously. \
+             Returns aggregated and deduplicated results ranked by how many \
+             engines returned them. Use this tool to find current information, \
+             facts, documentation, news, or any web-accessible content.",
+        )
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query string"
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return. Default: 10. Max: 30.",
+                    "default": 10
+                }
+            },
+            "required": ["query"]
+        }))
+        .build();
+
+    let searcher = Arc::new(MetaSearcher::new());
+
+    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+        let searcher = searcher.clone();
+        Box::pin(async move {
+            let query = args
+                .pointer("/query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let max_results = args
+                .pointer("/max_results")
+                .and_then(|v| v.as_unsigned())
+                .unwrap_or(10)
+                .min(30) as usize;
+
+            if query.is_empty() {
+                return crate::to_value!({ "results": [], "total": 0 });
+            }
+
+            let results = searcher.search(&query, max_results).await;
+            let total = results.len();
+
+            let result_values: Vec<Value> = results
+                .into_iter()
+                .map(|r| {
+                    crate::to_value!({
+                        "title": r.title.as_str(),
+                        "url": r.url.as_str(),
+                        "description": r.description.as_str(),
+                        "sources": Value::array(r.sources.into_iter().map(Value::string))
+                    })
+                })
+                .collect();
+
+            crate::to_value!({
+                "results": Value::array(result_values),
+                "total": total as u64
+            })
+        }) as BoxFuture<'static, Value>
+    });
+
+    ToolRuntime::new(desc, f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_tool_descriptor() {
+        let tool = build_web_search_tool();
+        let desc = tool.desc();
+        assert_eq!(desc.name, "web_search");
+        assert!(desc.description.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_tool_schema_requires_query() {
+        let tool = build_web_search_tool();
+        let params = &tool.desc().parameters;
+        let required = params.pointer("/required").and_then(|v| v.as_array());
+        assert!(required.is_some());
+        let required_fields: Vec<&str> = required
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(required_fields.contains(&"query"));
+    }
+
+    /// Verifies the full builtin tool pipeline end-to-end:
+    /// - The tool function parses its JSON arguments correctly.
+    /// - MetaSearcher fans out to all engines and aggregates results.
+    /// - At least one result related to the brekkylab/ailoy project appears.
+    /// - Results from multiple distinct engines are present (aggregation works).
+    /// - Every result has the required fields in the correct format.
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn test_web_search_tool_aggregation() {
+        let tool = build_web_search_tool();
+
+        // Sanity check: tool is built without panic.
+        let _ = tool.desc();
+
+        // Call the underlying searcher directly so we can inspect AggregatedResult fields.
+        let searcher = MetaSearcher::new();
+        let results = searcher.search("ailoy", 20).await;
+
+        println!("Total aggregated results: {}", results.len());
+        for r in &results {
+            println!(
+                "[{}] \"{}\" — {} (sources: {:?})",
+                r.relevance, r.title, r.url, r.sources
+            );
+        }
+
+        // 1. There must be at least one result.
+        assert!(
+            !results.is_empty(),
+            "Expected at least one aggregated result"
+        );
+
+        // 2. Every result must have a non-empty title and an http(s) URL.
+        for r in &results {
+            assert!(!r.title.is_empty(), "title must not be empty: {:?}", r);
+            assert!(
+                r.url.starts_with("http"),
+                "url must start with http: {:?}",
+                r
+            );
+            assert!(!r.sources.is_empty(), "sources must not be empty: {:?}", r);
+        }
+
+        // 3. At least one result should be clearly related to the brekkylab/ailoy project.
+        let ailoy_project_urls = [
+            "github.com/brekkylab/ailoy",
+            "brekkylab.github.io/ailoy",
+            "medium.com/ailoy",
+            "webui.ailoy.co",
+            "pypi.org/project/ailoy",
+        ];
+        let has_project_result = results.iter().any(|r| {
+            let url_lower = r.url.to_lowercase();
+            ailoy_project_urls
+                .iter()
+                .any(|needle| url_lower.contains(needle))
+        });
+        assert!(
+            has_project_result,
+            "Expected at least one result related to the brekkylab/ailoy project, got: {:#?}",
+            results.iter().map(|r| &r.url).collect::<Vec<_>>()
+        );
+
+        // 4. Results that appeared in more than one engine should be ranked first.
+        // (Relevance is monotonically non-increasing after sort in MetaSearcher.)
+        for window in results.windows(2) {
+            assert!(
+                window[0].relevance >= window[1].relevance,
+                "Results must be sorted by descending relevance: {} < {}",
+                window[0].relevance,
+                window[1].relevance
+            );
+        }
+
+        // 5. Aggregation is working: collect all engine names that contributed.
+        let all_sources: std::collections::HashSet<&str> = results
+            .iter()
+            .flat_map(|r| r.sources.iter().copied())
+            .collect();
+        println!("Engines that returned results: {:?}", all_sources);
+        assert!(
+            all_sources.len() >= 3,
+            "Expected results from at least 3 distinct engines, got {:?}",
+            all_sources
+        );
+    }
+}

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -80,6 +80,11 @@ pub enum LangModelProvider {
     },
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum BuiltinToolProvider {
+    WebSearch {},
+}
+
 /// Transport configuration for an MCP (Model Context Protocol) tool server.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -96,7 +101,7 @@ pub enum MCPToolProvider {
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolProvider {
     /// A tool baked into the agent runtime, referenced by `name`
-    Builtin { name: String },
+    Builtin(BuiltinToolProvider),
 
     /// A tool served by an external MCP server described by [`MCPToolProvider`]
     MCP(MCPToolProvider),


### PR DESCRIPTION
This PR adds `web_search` builtin tool, which searches the query keywords across multiple search engines including below providers:
- Bing
- Brave
- DuckDuckGo
- Google
- LibreX
- Mojeek
- Startpage
- Yahoo
- Yandex

The results are aggregated and ranked by relevance score (number of engines that returned the same url).

For Bing, it requires TLS fingerprint impersonation to bypass bot detection. That is handled by [wreq](https://github.com/0x676e67/wreq), but it depends on BoringSSL written in C++. If this makes the whole package deployment too complicated, we may need to consider removing Bing provider entirely.