### PR TITLE
Add SubagentTool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "axum",
  "base64",
  "dedent",
  "derive_builder",
@@ -159,6 +160,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -1015,6 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1087,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1444,6 +1504,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2321,6 +2387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,6 +2770,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2731,6 +2809,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,6 @@ wreq = "5.3.0"
 wreq-util = "2.2.6"
 
 [dev-dependencies]
+axum = "0.8"
 dotenvy = "0.15"
+tokio = { version = "1.0", features = ["net"] }

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -3,7 +3,9 @@ use std::pin::Pin;
 use futures::{Stream, StreamExt as _};
 
 use crate::{
-    agent::{AgentProvider, AgentSpec, LangModelRuntime, ToolProvider, ToolRuntime, ToolSet},
+    agent::{
+        AgentProvider, AgentSpec, LangModelRuntime, ToolKind, ToolProvider, ToolRuntime, ToolSet,
+    },
     message::{FinishReason, Message, MessageOutput, Part, Role},
 };
 
@@ -26,15 +28,30 @@ impl AgentRuntime {
                 });
 
         // Collect tools from toolsets
-        let tools = spec
+        let tools: Vec<ToolRuntime> = spec
             .tools
             .iter()
             .filter_map(|name| tool_set.get(name).cloned())
             .collect();
 
-        // Initialize histroy
-        let history = spec
-            .instruction
+        let mut instruction = spec.instruction.clone();
+
+        // Append subagent suffix on instruction if exist
+        let subagent_tools = tools
+            .iter()
+            .filter(|t| t.kind == ToolKind::Subagent)
+            .map(|t| t.desc())
+            .collect::<Vec<_>>();
+        if !subagent_tools.is_empty() {
+            let suffix = build_subagent_system_suffix(&subagent_tools);
+            instruction = match instruction {
+                Some(existing) => Some(format!("{}\n\n{}", existing, suffix)),
+                None => Some(suffix),
+            };
+        }
+
+        // Initialize history
+        let history = instruction
             .map(|inst| vec![Message::new(Role::System).with_contents([Part::text(inst)])])
             .unwrap_or_default();
 
@@ -123,6 +140,34 @@ impl AgentRuntime {
     }
 }
 
+fn build_subagent_system_suffix(descs: &[&crate::message::ToolDesc]) -> String {
+    let mut lines = vec![
+        "## Subagent Delegation".to_string(),
+        String::new(),
+        "You can delegate tasks to specialized subagents by calling their tools directly."
+            .to_string(),
+        String::new(),
+        "### Available Subagents".to_string(),
+        String::new(),
+    ];
+
+    for desc in descs {
+        lines.push(format!("#### {}", desc.name));
+        if let Some(d) = &desc.description {
+            lines.push(d.clone());
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(
+        "When a request clearly matches a subagent's capabilities, call their tool directly. \
+         If no subagent is a good fit, handle it yourself."
+            .to_string(),
+    );
+
+    lines.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -200,6 +245,118 @@ mod tests {
         assert!(
             resp.message.contents.iter().any(|p| p.is_text()),
             "Expected final assistant message to contain text"
+        );
+    }
+
+    /// Verifies that the main agent actually delegates to the in-memory subagent.
+    ///
+    /// Sets up a math subagent and registers it as a subagent tool on a coordinator agent.
+    /// Asks a math question and confirms the main agent's history contains a [`Role::Tool`]
+    /// message (proof that the subagent tool was called), and that the final reply is text.
+    #[tokio::test]
+    async fn test_delegate_to_in_memory_subagent() {
+        dotenvy::dotenv().ok();
+
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+
+        // Sub-agent: a minimal calculator that replies with just the numeric result.
+        let sub_agent = AgentRuntime::new(
+            AgentSpec::new("gpt-4o-mini").with_instruction(
+                "You are a calculator. Answer math questions with the numeric result only."
+                    .to_string(),
+            ),
+            AgentProvider {
+                lm: LangModelProvider::API {
+                    schema: LangModelAPISchema::ChatCompletion,
+                    url: url.clone(),
+                    api_key: Some(api_key.clone()),
+                },
+                tools: vec![],
+            },
+            ToolSet::new(),
+        );
+        let sub_agent = Arc::new(tokio::sync::Mutex::new(sub_agent));
+
+        // Main agent: coordinator that should always delegate math to math-agent.
+        let tool_set = ToolSet::new().with_subagent_in_memory(
+            "math-agent",
+            "Handles arithmetic and math computations. Use this for any math question.",
+            sub_agent,
+        );
+
+        let mut main_agent = AgentRuntime::new(
+            AgentSpec::new("gpt-4o-mini").with_tools(["math-agent"]),
+            AgentProvider {
+                lm: LangModelProvider::API {
+                    schema: LangModelAPISchema::ChatCompletion,
+                    url,
+                    api_key: Some(api_key),
+                },
+                tools: vec![],
+            },
+            tool_set,
+        );
+
+        let query =
+            Message::new(Role::User).with_contents([Part::text("What is 123 multiplied by 7?")]);
+
+        let outputs = {
+            let mut strm = main_agent.stream_turn(query);
+            let mut outputs = vec![];
+            while let Some(output) = strm.next().await {
+                outputs.push(output.unwrap());
+            }
+            outputs
+        };
+
+        // The history must contain a Tool message, confirming the subagent was called.
+        let history = main_agent.get_history();
+        assert!(
+            history.iter().any(|m| m.role == Role::Tool),
+            "Expected main agent history to contain a Tool message (subagent was called)"
+        );
+
+        // Final output must be an assistant text response.
+        let final_output = outputs.last().expect("Expected at least one output");
+        assert_eq!(final_output.message.role, Role::Assistant);
+        assert!(
+            final_output.message.contents.iter().any(|p| p.is_text()),
+            "Expected final assistant message to contain text"
+        );
+    }
+
+    #[test]
+    fn test_subagent_suffix_appended_to_system_message() {
+        let desc1 = ToolDescBuilder::new("math-agent")
+            .description("Handles arithmetic and math computations")
+            .parameters(serde_json::json!({"type":"object","properties":{"task":{"type":"string"}},"required":["task"]}))
+            .build();
+        let desc2 = ToolDescBuilder::new("search-agent")
+            .description("Searches the web for information")
+            .parameters(serde_json::json!({"type":"object","properties":{"task":{"type":"string"}},"required":["task"]}))
+            .build();
+
+        let refs: Vec<&crate::message::ToolDesc> = vec![&desc1, &desc2];
+        let suffix = build_subagent_system_suffix(&refs);
+
+        assert!(suffix.contains("math-agent"), "should contain agent name");
+        assert!(suffix.contains("search-agent"), "should contain agent name");
+        assert!(
+            suffix.contains("Handles arithmetic"),
+            "should contain description"
+        );
+        assert!(
+            suffix.contains("Searches the web"),
+            "should contain description"
+        );
+        assert!(
+            suffix.contains("Subagent Delegation"),
+            "should contain section header"
+        );
+        assert!(
+            suffix.contains("call their tool directly"),
+            "should contain delegation instruction"
         );
     }
 }

--- a/src/agent/rt/lang_model/api/anthropic.rs
+++ b/src/agent/rt/lang_model/api/anthropic.rs
@@ -379,7 +379,10 @@ mod tests {
     fn test_marshal_max_tokens_set() {
         with_req(
             "claude-haiku-4-5",
-            LangModelInferConfig { max_tokens: Some(512), ..Default::default() },
+            LangModelInferConfig {
+                max_tokens: Some(512),
+                ..Default::default()
+            },
             |req| {
                 let val = AnthropicMarshal::default().marshal(req);
                 let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -330,7 +330,10 @@ mod tests {
     fn test_marshal_max_tokens_set() {
         with_req(
             "gpt-4.1-mini",
-            LangModelInferConfig { max_tokens: Some(256), ..Default::default() },
+            LangModelInferConfig {
+                max_tokens: Some(256),
+                ..Default::default()
+            },
             |req| {
                 let val = ChatCompletionMarshal::default().marshal(req);
                 let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/agent/rt/lang_model/api/gemini.rs
+++ b/src/agent/rt/lang_model/api/gemini.rs
@@ -358,8 +358,7 @@ mod tests {
     {
         let messages: Vec<Message> = vec![];
         let tools: Vec<ToolDesc> = vec![];
-        let url =
-            Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
         let api_key: Option<String> = None;
         let req = LangModelRequest {
             model,
@@ -376,7 +375,10 @@ mod tests {
     fn test_marshal_max_output_tokens_set() {
         with_req(
             "gemini-2.5-flash-lite",
-            LangModelInferConfig { max_tokens: Some(2048), ..Default::default() },
+            LangModelInferConfig {
+                max_tokens: Some(2048),
+                ..Default::default()
+            },
             |req| {
                 let val = GeminiMarshal::default().marshal(req);
                 let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/agent/rt/lang_model/api/openai.rs
+++ b/src/agent/rt/lang_model/api/openai.rs
@@ -368,7 +368,10 @@ mod tests {
     fn test_marshal_max_output_tokens_set() {
         with_req(
             "gpt-5.4-mini",
-            LangModelInferConfig { max_tokens: Some(1024), ..Default::default() },
+            LangModelInferConfig {
+                max_tokens: Some(1024),
+                ..Default::default()
+            },
             |req| {
                 let val = OpenAIMarshal::default().marshal(req);
                 let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -1,26 +1,52 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures::future::BoxFuture;
+use tokio::sync::Mutex as TokioMutex;
 
 use crate::{
-    agent::{BuiltinToolProvider, MCPToolProvider},
+    agent::{AgentRuntime, BuiltinToolProvider, MCPToolProvider},
     datatype::Value,
     message::{Message, Part, Role, ToolDesc},
 };
 
+mod subagent;
 mod web_search;
 
 pub type ToolFunc = dyn Fn(Value) -> BoxFuture<'static, Value> + Send + Sync;
+
+/// Identifies the origin of a [`ToolRuntime`].
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum ToolKind {
+    /// Built into the agent runtime (e.g. web search).
+    Builtin,
+    /// Served by an external MCP server.
+    #[allow(dead_code)]
+    MCP,
+    /// Wraps another agent as a callable subagent.
+    Subagent,
+    /// Registered directly by the user.
+    Custom,
+}
 
 #[derive(Clone)]
 pub struct ToolRuntime {
     desc: ToolDesc,
     f: Arc<ToolFunc>,
+    pub(crate) kind: ToolKind,
 }
 
 impl ToolRuntime {
+    /// Create a user-defined tool. `kind` is set to [`ToolKind::Custom`].
     pub fn new(desc: ToolDesc, f: Arc<ToolFunc>) -> Self {
-        Self { desc, f }
+        Self {
+            desc,
+            f,
+            kind: ToolKind::Custom,
+        }
+    }
+
+    pub(crate) fn new_with_kind(desc: ToolDesc, f: Arc<ToolFunc>, kind: ToolKind) -> Self {
+        Self { desc, f, kind }
     }
 
     pub fn desc(&self) -> &ToolDesc {
@@ -81,6 +107,40 @@ impl ToolSet {
             MCPToolProvider::Stdio { command: _ } => todo!(),
             MCPToolProvider::StreamableHTTP { url: _ } => todo!(),
         }
+    }
+
+    /// Wrap an existing in-process [`AgentRuntime`] as a tool named `name`.
+    ///
+    /// The tool exposes a single `task` string parameter; when called it forwards the task to
+    /// the agent and returns its first text response.
+    /// Wrap an existing in-process [`AgentRuntime`] as a tool named `name`.
+    ///
+    /// The tool exposes a single `task` string parameter; when called it forwards the task to
+    /// the agent and returns its first text response.
+    pub fn with_subagent_in_memory(
+        mut self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        agent: Arc<TokioMutex<AgentRuntime>>,
+    ) -> Self {
+        let name = name.into();
+        let tool = subagent::build_in_memory_subagent_tool(&name, &description.into(), agent);
+        self.tools.insert(name, tool);
+        self
+    }
+
+    /// Discover a remote A2A agent at `url` and register it as a tool.
+    ///
+    /// Fetches the agent card from `{url}/.well-known/agent-card.json` to obtain the tool
+    /// name and description, then builds a tool that forwards calls via JSON-RPC
+    /// `message/send`.
+    pub async fn with_subagent_a2a(mut self, url: impl Into<String>) -> anyhow::Result<Self> {
+        let url = url.into();
+        let card = subagent::a2a::discover(&url).await?;
+        let name = card.name.clone();
+        let tool = subagent::build_a2a_subagent_tool(&card, url);
+        self.tools.insert(name, tool);
+        Ok(self)
     }
 
     pub fn get(&self, key: &str) -> Option<&ToolRuntime> {

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -113,10 +113,6 @@ impl ToolSet {
     ///
     /// The tool exposes a single `task` string parameter; when called it forwards the task to
     /// the agent and returns its first text response.
-    /// Wrap an existing in-process [`AgentRuntime`] as a tool named `name`.
-    ///
-    /// The tool exposes a single `task` string parameter; when called it forwards the task to
-    /// the agent and returns its first text response.
     pub fn with_subagent_in_memory(
         mut self,
         name: impl Into<String>,

--- a/src/agent/rt/tool/subagent/a2a.rs
+++ b/src/agent/rt/tool/subagent/a2a.rs
@@ -1,0 +1,392 @@
+use serde::{Deserialize, Serialize};
+
+// ── Agent Discovery ──────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentCard {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version: Option<String>,
+    #[serde(default)]
+    pub(crate) skills: Vec<AgentSkill>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) capabilities: Option<AgentCapabilities>,
+    #[serde(default = "default_input_modes")]
+    pub(crate) default_input_modes: Vec<String>,
+    #[serde(default = "default_output_modes")]
+    pub(crate) default_output_modes: Vec<String>,
+}
+
+fn default_input_modes() -> Vec<String> {
+    vec!["text/plain".into()]
+}
+
+fn default_output_modes() -> Vec<String> {
+    vec!["text/plain".into()]
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentSkill {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) examples: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentCapabilities {
+    pub(crate) streaming: bool,
+}
+
+// ── JSON-RPC 2.0 ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct JsonRpcRequest {
+    pub(crate) jsonrpc: String,
+    pub(crate) id: serde_json::Value,
+    pub(crate) method: String,
+    pub(crate) params: MessageSendParams,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct MessageSendParams {
+    pub(crate) message: A2AMessage,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct A2AMessage {
+    #[serde(default = "message_kind")]
+    pub(crate) kind: String,
+    pub(crate) role: A2ARole,
+    pub(crate) parts: Vec<A2APart>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) context_id: Option<String>,
+}
+
+fn message_kind() -> String {
+    "message".into()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum A2ARole {
+    User,
+    Agent,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum A2APart {
+    Text { text: String },
+}
+
+#[derive(Serialize)]
+struct TextPartSer<'a> {
+    kind: &'static str,
+    text: &'a str,
+}
+
+impl Serialize for A2APart {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            A2APart::Text { text } => TextPartSer { kind: "text", text }.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for A2APart {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map: serde_json::Map<String, serde_json::Value> =
+            serde_json::Map::deserialize(deserializer)?;
+        if let Some(text) = map.get("text").and_then(|v| v.as_str()) {
+            Ok(A2APart::Text {
+                text: text.to_owned(),
+            })
+        } else {
+            Err(serde::de::Error::missing_field("text"))
+        }
+    }
+}
+
+// ── Task ─────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Task {
+    #[serde(default = "task_kind")]
+    pub(crate) kind: String,
+    pub(crate) id: String,
+    pub(crate) context_id: String,
+    pub(crate) status: TaskStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) history: Vec<A2AMessage>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) artifacts: Vec<serde_json::Value>,
+}
+
+fn task_kind() -> String {
+    "task".into()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TaskStatus {
+    pub(crate) state: TaskState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) timestamp: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum TaskState {
+    Submitted,
+    Working,
+    Completed,
+    Failed,
+}
+
+// ── JSON-RPC Response ─────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct JsonRpcResponse {
+    pub(crate) jsonrpc: String,
+    pub(crate) id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) result: Option<Task>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    #[cfg(test)]
+    pub(crate) fn success(id: serde_json::Value, task: Task) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: Some(task),
+            error: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn error(id: serde_json::Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct JsonRpcError {
+    pub(crate) code: i32,
+    pub(crate) message: String,
+}
+
+// ── Client functions ──────────────────────────────────────────────────────────
+
+/// Fetch an agent's card from `{base_url}/.well-known/agent-card.json`.
+pub(crate) async fn discover(base_url: &str) -> anyhow::Result<AgentCard> {
+    let url = format!(
+        "{}/.well-known/agent-card.json",
+        base_url.trim_end_matches('/')
+    );
+    let card = reqwest::get(&url)
+        .await?
+        .error_for_status()?
+        .json::<AgentCard>()
+        .await?;
+    Ok(card)
+}
+
+/// Send a task to an A2A agent via JSON-RPC `message/send` and return the text response.
+pub(crate) async fn message_send(base_url: &str, task: &str) -> anyhow::Result<String> {
+    let url = base_url.trim_end_matches('/').to_string();
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(1.into()),
+        method: "message/send".into(),
+        params: MessageSendParams {
+            message: A2AMessage {
+                kind: "message".into(),
+                role: A2ARole::User,
+                parts: vec![A2APart::Text {
+                    text: task.to_string(),
+                }],
+                message_id: Some(uuid::Uuid::new_v4().to_string()),
+                task_id: None,
+                context_id: None,
+            },
+        },
+    };
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&req)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<JsonRpcResponse>()
+        .await?;
+
+    if let Some(err) = resp.error {
+        return Err(anyhow::anyhow!("A2A error {}: {}", err.code, err.message));
+    }
+
+    let task_result = resp
+        .result
+        .ok_or_else(|| anyhow::anyhow!("A2A response missing result"))?;
+    let text = task_result
+        .history
+        .iter()
+        .find(|m| m.role == A2ARole::Agent)
+        .and_then(|m| {
+            m.parts.iter().find_map(|p| match p {
+                A2APart::Text { text } => Some(text.clone()),
+            })
+        })
+        .ok_or_else(|| anyhow::anyhow!("No text in A2A agent response"))?;
+
+    Ok(text)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Json, Router,
+        routing::{get, post},
+    };
+
+    use super::*;
+
+    fn test_card() -> AgentCard {
+        AgentCard {
+            name: "test-agent".into(),
+            description: "A test agent".into(),
+            url: None,
+            version: Some("1.0.0".into()),
+            skills: vec![AgentSkill {
+                id: "test".into(),
+                name: "Test Skill".into(),
+                description: "Does something".into(),
+                tags: vec![],
+                examples: vec![],
+            }],
+            capabilities: None,
+            default_input_modes: vec!["text/plain".into()],
+            default_output_modes: vec!["text/plain".into()],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_discover_parses_card() -> anyhow::Result<()> {
+        let card = test_card();
+        let card_clone = card.clone();
+        let app = Router::new().route(
+            "/.well-known/agent-card.json",
+            get(move || async move { Json(card_clone.clone()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        let base_url = format!("http://{}", addr);
+        let fetched = discover(&base_url).await?;
+        assert_eq!(fetched.name, "test-agent");
+        assert_eq!(fetched.description, "A test agent");
+        assert_eq!(fetched.skills[0].id, "test");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_message_send_parses_response() -> anyhow::Result<()> {
+        let app = Router::new().route(
+            "/",
+            post(|Json(req): Json<JsonRpcRequest>| async move {
+                let agent_msg = A2AMessage {
+                    kind: "message".into(),
+                    role: A2ARole::Agent,
+                    parts: vec![A2APart::Text {
+                        text: "Hello from agent".into(),
+                    }],
+                    message_id: Some("msg-1".into()),
+                    task_id: Some("task-1".into()),
+                    context_id: Some("ctx-1".into()),
+                };
+                let task = Task {
+                    kind: "task".into(),
+                    id: "task-1".into(),
+                    context_id: "ctx-1".into(),
+                    status: TaskStatus {
+                        state: TaskState::Completed,
+                        timestamp: None,
+                    },
+                    history: vec![agent_msg],
+                    artifacts: vec![],
+                };
+                Json(JsonRpcResponse::success(req.id, task))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        let base_url = format!("http://{}", addr);
+        let text = message_send(&base_url, "Say hello").await?;
+        assert_eq!(text, "Hello from agent");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_message_send_handles_error() -> anyhow::Result<()> {
+        let app = Router::new().route(
+            "/",
+            post(|Json(req): Json<JsonRpcRequest>| async move {
+                Json(JsonRpcResponse::error(
+                    req.id,
+                    -32000,
+                    "Something went wrong",
+                ))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        let base_url = format!("http://{}", addr);
+        let result = message_send(&base_url, "do something").await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Something went wrong")
+        );
+        Ok(())
+    }
+}

--- a/src/agent/rt/tool/subagent/mod.rs
+++ b/src/agent/rt/tool/subagent/mod.rs
@@ -44,6 +44,14 @@ pub(crate) fn build_in_memory_subagent_tool(
 
             let msg = Message::new(Role::User).with_contents(vec![Part::text(task)]);
             let mut guard = agent.lock().await;
+            // Reset history to system message only before each invocation so that subagent
+            // calls remain stateless and history does not accumulate across tool calls.
+            let initial_history: Vec<Message> = guard
+                .get_history()
+                .into_iter()
+                .filter(|m| m.role == Role::System)
+                .collect();
+            guard.set_history(initial_history);
             match guard.run(msg).await {
                 Ok(result) => {
                     let text = result

--- a/src/agent/rt/tool/subagent/mod.rs
+++ b/src/agent/rt/tool/subagent/mod.rs
@@ -1,0 +1,101 @@
+pub(crate) mod a2a;
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex as TokioMutex;
+
+use super::{ToolFunc, ToolKind, ToolRuntime};
+use crate::{
+    agent::AgentRuntime,
+    message::{Message, Part, Role, ToolDescBuilder},
+};
+
+/// Build a [`ToolRuntime`] that delegates to an in-process [`AgentRuntime`].
+///
+/// The generated tool accepts a single `task` string parameter and forwards it to the
+/// wrapped agent, returning the agent's first text response as the tool result.
+pub(crate) fn build_in_memory_subagent_tool(
+    name: &str,
+    description: &str,
+    agent: Arc<TokioMutex<AgentRuntime>>,
+) -> ToolRuntime {
+    let desc = ToolDescBuilder::new(name)
+        .description(description)
+        .parameters(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "The task or question to send to this agent"
+                }
+            },
+            "required": ["task"]
+        }))
+        .build();
+
+    let f: Arc<ToolFunc> = Arc::new(move |args| {
+        let agent = agent.clone();
+        Box::pin(async move {
+            let task = args
+                .pointer("/task")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let msg = Message::new(Role::User).with_contents(vec![Part::text(task)]);
+            let mut guard = agent.lock().await;
+            match guard.run(msg).await {
+                Ok(result) => {
+                    let text = result
+                        .contents
+                        .iter()
+                        .find_map(|p: &Part| p.as_text())
+                        .unwrap_or_default()
+                        .to_string();
+                    text.into()
+                }
+                Err(e) => format!("Error: {}", e).into(),
+            }
+        })
+    });
+
+    ToolRuntime::new_with_kind(desc, f, ToolKind::Subagent)
+}
+
+/// Build a [`ToolRuntime`] that delegates to a remote A2A agent.
+///
+/// The generated tool accepts a single `task` string parameter, sends it to the remote
+/// agent via JSON-RPC `message/send`, and returns the response text as the tool result.
+pub(crate) fn build_a2a_subagent_tool(card: &a2a::AgentCard, url: String) -> ToolRuntime {
+    let desc = ToolDescBuilder::new(&card.name)
+        .description(&card.description)
+        .parameters(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "The task or question to send to this agent"
+                }
+            },
+            "required": ["task"]
+        }))
+        .build();
+
+    let f: Arc<ToolFunc> = Arc::new(move |args| {
+        let url = url.clone();
+        Box::pin(async move {
+            let task = args
+                .pointer("/task")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            match a2a::message_send(&url, &task).await {
+                Ok(result) => result.into(),
+                Err(e) => format!("Error: {}", e).into(),
+            }
+        })
+    });
+
+    ToolRuntime::new_with_kind(desc, f, ToolKind::Subagent)
+}

--- a/src/agent/rt/tool/web_search/mod.rs
+++ b/src/agent/rt/tool/web_search/mod.rs
@@ -8,7 +8,7 @@ use aggregator::MetaSearcher;
 use futures::future::BoxFuture;
 
 use crate::{
-    agent::rt::tool::{ToolFunc, ToolRuntime},
+    agent::rt::tool::{ToolFunc, ToolKind, ToolRuntime},
     datatype::Value,
     message::ToolDescBuilder,
 };
@@ -81,7 +81,7 @@ pub fn build_web_search_tool() -> ToolRuntime {
         }) as BoxFuture<'static, Value>
     });
 
-    ToolRuntime::new(desc, f)
+    ToolRuntime::new_with_kind(desc, f, ToolKind::Builtin)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR introduces `SubagentTool` support as requested in #368, allowing any `AgentRuntime` to be registered as a named tool on another agent. Two backends are supported:

- **InMemory** — wraps an existing in-process `AgentRuntime` (held behind `Arc<Mutex<_>>`) as a tool. Useful for composing agents within the same process.
- **A2A** — connects to a remote agent via the A2A protocol. Discovers the agent's name and description automatically from `/.well-known/agent-card.json`, then routes calls over JSON-RPC `message/send`.

Each subagent is registered as its own independently named tool (rather than a single dispatcher), so the LLM can read each tool's description directly and decide which subagent to call.

## Changes

### `src/agent/rt/tool/subagent/` *(new)*

- **`a2a.rs`** — minimal self-contained A2A client: protocol types (`AgentCard`, `JsonRpcRequest/Response`, `Task`, etc.), `discover()` for agent card fetching, and `message_send()` for task dispatch. Implemented directly in the `ailoy` crate to avoid a circular dependency with `ailoy-a2a`.
- **`mod.rs`** — `build_in_memory_subagent_tool()` and `build_a2a_subagent_tool()` builder functions that produce a `ToolRuntime` with a single `task: string` parameter.

### `src/agent/rt/tool/mod.rs`

- Added `ToolKind` enum (`Builtin`, `MCP`, `Subagent`, `Custom`) to `ToolRuntime`, so the runtime can identify tool origin without external bookkeeping.
- `ToolRuntime::new()` defaults to `ToolKind::Custom` (backward-compatible). Internal builders use `new_with_kind()`.
- Two new `ToolSet` builder methods:
  - `with_subagent_in_memory(name, description, Arc<Mutex<AgentRuntime>>) -> Self`
  - `with_subagent_a2a(url) -> anyhow::Result<Self>` *(async)*

### `src/agent/rt/agent.rs`

- `AgentRuntime::new()` now inspects the collected tools for any with `ToolKind::Subagent`. If found, a `## Subagent Delegation` section is appended to the system message, listing each subagent's name and description so the LLM knows when and how to delegate.

## Usage

```rust
// InMemory subagent
let tool_set = ToolSet::new()
    .with_subagent_in_memory(
        "math-agent",
        "Handles arithmetic and math computations.",
        Arc::new(Mutex::new(sub_agent)),
    );

// Remote A2A subagent
let tool_set = ToolSet::new()
    .with_subagent_a2a("https://remote-agent.example.com").await?;

// Pass to the main agent as usual
let agent = AgentRuntime::new(
    AgentSpec::new("gpt-4o-mini").with_tools(["math-agent"]),
    provider,
    tool_set,
);
```

The system message is automatically augmented when subagent tools are present:

```
## Subagent Delegation

You can delegate tasks to specialized subagents by calling their tools directly.

### Available Subagents

#### math-agent
Handles arithmetic and math computations.

When a request clearly matches a subagent's capabilities, call their tool directly.
If no subagent is a good fit, handle it yourself.
```

## Tests

| Test | Location | Type |
|---|---|---|
| `test_discover_parses_card` | `tool/subagent/a2a.rs` | Unit — mock Axum server |
| `test_message_send_parses_response` | `tool/subagent/a2a.rs` | Unit — mock Axum server |
| `test_message_send_handles_error` | `tool/subagent/a2a.rs` | Unit — mock Axum server |
| `test_subagent_suffix_appended_to_system_message` | `agent.rs` | Unit |
| `test_delegate_to_in_memory_subagent` | `agent.rs` | Integration (requires `OPENAI_API_KEY`) |

