### PR TITLE
feat: add `schemars::JsonSchema` derive to all spec types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,6 +2152,7 @@ dependencies = [
  "schemars_derive 0.8.22",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ png = "0.18"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 rmcp = { version = "0.11.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 scraper = "0.24"
-schemars = { version = "0.8", features = ["preserve_order"] }
+schemars = { version = "0.8", features = ["preserve_order", "url"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -5,7 +6,7 @@ use url::Url;
 ///
 /// All fields are optional. When a field is `None`, provider-specific defaults apply
 /// (e.g. Anthropic defaults `max_tokens` to 8192 because it is a required API field).
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct LangModelInferConfig {
     /// Maximum number of tokens the model may generate in a single response.
     pub max_tokens: Option<u64>,
@@ -16,7 +17,7 @@ pub struct LangModelInferConfig {
 /// `AgentSpec` captures what makes an agent distinct — the language model it uses,
 /// the system instruction that shapes its behavior, and the set of tools it has access to.
 /// Changing any of these fields changes the fundamental nature of the agent.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AgentSpec {
     /// Identifier of the language model (e.g. `"claude-sonnet-4-6"`)
     pub lm: String,
@@ -49,7 +50,7 @@ impl AgentSpec {
 }
 
 /// Wire protocol used when calling a language model API.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum LangModelAPISchema {
     /// OpenAI-compatible `/v1/chat/completions` format
@@ -67,7 +68,7 @@ pub enum LangModelAPISchema {
 }
 
 /// Describes the runtime endpoint used to invoke a language model.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum LangModelProvider {
     /// Calls a remote HTTP API. Requires the wire `schema`, the `url` of the endpoint, and an optional `api_key` for authentication.
@@ -80,13 +81,14 @@ pub enum LangModelProvider {
     },
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum BuiltinToolProvider {
     WebSearch {},
 }
 
 /// Transport configuration for an MCP (Model Context Protocol) tool server.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum MCPToolProvider {
     /// Spawns a child process and communicates over its stdio
@@ -97,7 +99,7 @@ pub enum MCPToolProvider {
 }
 
 /// Identifies where a tool's implementation lives at runtime.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolProvider {
     /// A tool baked into the agent runtime, referenced by `name`
@@ -112,7 +114,7 @@ pub enum ToolProvider {
 /// `AgentProvider` is separate from [`AgentSpec`] because these settings describe *how*
 /// to run an agent, not *what* the agent is. Swapping the API endpoint or key does not
 /// change the agent's identity; swapping the model or instruction does.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AgentProvider {
     /// The concrete language model provider (API schema, endpoint URL, credentials)
     pub lm: LangModelProvider,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod datatype;
 pub mod message;
 
 pub use agent::{
-    AgentProvider, AgentRuntime, AgentSpec, LangModelAPISchema, LangModelInferConfig,
-    LangModelProvider, ToolProvider, ToolRuntime, ToolSet,
+    AgentProvider, AgentRuntime, AgentSpec, BuiltinToolProvider, LangModelAPISchema,
+    LangModelInferConfig, LangModelProvider, MCPToolProvider, ToolProvider, ToolRuntime, ToolSet,
 };
 pub use datatype::Value;
 pub use message::{


### PR DESCRIPTION
- Derive `schemars::JsonSchema` on `AgentSpec`, `AgentProvider`, `LangModelProvider`, `LangModelAPISchema`, `BuiltinToolProvider`, `MCPToolProvider`, `ToolProvider`, `LangModelInferConfig`
- Add `url` feature to schemars dependency for Url JsonSchema support
- Add `#[serde(tag = "type", rename_all = "snake_case")]` to BuiltinToolProvider
- Re-export BuiltinToolProvider and MCPToolProvider from top-level lib.rs