### PR TITLE
feat: Add python_repl builtin tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "base64",
  "dedent",
  "derive_builder",
+ "dirs",
  "dotenvy",
  "fancy-regex",
  "futures",
@@ -45,14 +46,17 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "shellexpand",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror",
  "tokio",
  "unicode-segmentation",
  "url",
  "urlencoding",
  "uuid",
+ "which",
  "wreq",
  "wreq-util",
 ]
@@ -563,6 +567,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +645,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1364,6 +1395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1637,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1914,6 +1960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2340,6 +2397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -3009,6 +3075,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3431,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -47,7 +47,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hex",
  "image",
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "log",
  "ordered-float",
  "parking_lot",
@@ -64,13 +64,14 @@ dependencies = [
  "strum_macros",
  "tar",
  "tempfile",
+ "test-with",
  "thiserror",
  "tokio",
  "unicode-segmentation",
  "url",
  "urlencoding",
  "uuid",
- "which",
+ "which 7.0.3",
  "wreq",
  "wreq-util",
  "zip",
@@ -108,9 +109,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -132,13 +133,12 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.33"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -281,9 +281,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -346,15 +346,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -370,9 +370,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -428,16 +428,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.32"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
@@ -734,21 +734,22 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -781,7 +782,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -803,9 +804,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -862,7 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -878,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -910,9 +911,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -923,6 +924,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1003,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1018,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1028,15 +1035,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1045,15 +1052,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,21 +1069,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1086,7 +1093,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1120,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1140,9 +1146,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1163,7 +1182,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1178,9 +1197,18 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1216,12 +1244,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1260,7 +1287,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1280,9 +1307,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1295,7 +1322,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1336,14 +1362,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1352,12 +1377,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
- "system-configuration",
+ "socket2 0.6.3",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -1382,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1392,7 +1417,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.1",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1406,12 +1431,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1419,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1432,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1446,15 +1472,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1466,15 +1492,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1484,6 +1510,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1514,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.8"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1551,12 +1583,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1572,15 +1604,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1597,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1613,19 +1645,27 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.176"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -1634,19 +1674,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1666,15 +1706,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1760,9 +1800,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1788,20 +1828,20 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "moxcms"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1869,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
@@ -1925,9 +1965,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -1952,16 +1992,16 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "pastey"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d6c094ee800037dff99e02cab0eaf3142826586742a270ab3d7a62656bd27a"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
@@ -2033,15 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -2057,9 +2091,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -2070,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2099,10 +2133,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2114,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "nix",
  "tokio",
  "tracing",
@@ -2123,12 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.24"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"
@@ -2149,7 +2212,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2158,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2186,16 +2249,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2205,6 +2268,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2223,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2233,7 +2302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2247,27 +2316,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2278,7 +2347,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -2317,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2328,15 +2397,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -2387,7 +2456,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2409,7 +2478,7 @@ dependencies = [
  "process-wrap",
  "reqwest",
  "rmcp-macros",
- "schemars 1.0.4",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -2435,28 +2504,37 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -2468,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2478,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2495,17 +2573,17 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2524,14 +2602,14 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.0.4",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -2550,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2583,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2622,6 +2700,12 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2676,16 +2760,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2748,30 +2832,31 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2791,19 +2876,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2814,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
@@ -2878,9 +2963,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2919,6 +3004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
 name = "system-configuration-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,15 +3037,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2964,19 +3060,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-with"
+version = "0.16.0"
+source = "git+https://github.com/brekkylab/test-with.git?branch=main#eb77a2711bf17f5e5fc486cf5a114a9d512a243b"
+dependencies = [
+ "test-with-derive",
+ "which 8.0.2",
+]
+
+[[package]]
+name = "test-with-derive"
+version = "0.16.0"
+source = "git+https://github.com/brekkylab/test-with.git?branch=main#eb77a2711bf17f5e5fc486cf5a114a9d512a243b"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "which 8.0.2",
+]
+
+[[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3004,9 +3122,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3014,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3029,18 +3147,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3056,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3087,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3098,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3111,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3127,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3157,9 +3275,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3169,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3180,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3221,21 +3339,27 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3245,14 +3369,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3275,11 +3400,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3313,18 +3438,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3335,22 +3469,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3358,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3371,11 +3502,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3392,10 +3545,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.82"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3443,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3460,6 +3625,15 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3521,15 +3695,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3545,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3556,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.2"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3573,9 +3747,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -3599,6 +3773,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,11 +3794,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3627,11 +3812,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3645,29 +3830,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3688,19 +3864,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.0",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3720,9 +3896,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3732,9 +3908,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3744,9 +3920,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -3756,9 +3932,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3768,9 +3944,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3780,9 +3956,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3792,9 +3968,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3804,9 +3980,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winsafe"
@@ -3816,9 +3992,91 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wreq"
@@ -3849,7 +4107,7 @@ dependencies = [
  "serde_urlencoded",
  "socket2 0.5.10",
  "sync_wrapper",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-boring2",
  "tokio-util",
@@ -3858,7 +4116,7 @@ dependencies = [
  "typed-builder",
  "url",
  "webpki-root-certs 0.26.11",
- "windows-registry",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -3873,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -3898,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3909,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3921,18 +4179,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3941,18 +4199,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3993,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4004,9 +4262,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4030,7 +4288,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.11.4",
+ "indexmap 2.14.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",
@@ -4042,6 +4300,12 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"
@@ -4085,15 +4349,15 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,6 +2152,7 @@ dependencies = [
  "schemars_derive 0.8.22",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +41,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "fancy-regex",
+ "flate2",
  "futures",
  "getrandom 0.3.4",
  "hex",
@@ -49,6 +61,7 @@ dependencies = [
  "shellexpand",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
@@ -59,6 +72,7 @@ dependencies = [
  "which",
  "wreq",
  "wreq-util",
+ "zip",
 ]
 
 [[package]]
@@ -96,6 +110,15 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -210,6 +233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boring-sys2"
 version = "4.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +322,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +388,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,12 +470,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -516,6 +623,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +697,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -692,6 +836,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -892,6 +1047,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1140,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1328,6 +1502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1583,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1456,6 +1642,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "mac"
@@ -1580,6 +1787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,7 +1886,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-link 0.2.0",
 ]
@@ -1683,6 +1896,16 @@ name = "pastey"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d6c094ee800037dff99e02cab0eaf3142826586742a270ab3d7a62656bd27a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1761,6 +1984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +2010,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1958,6 +2193,15 @@ name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -2400,6 +2644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2852,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2905,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2850,6 +3135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3210,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -3502,6 +3799,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +3886,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3602,6 +3932,48 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.11.4",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ strum_macros = "0.27"
 thiserror = "2.0.15"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }
 unicode-segmentation = "1.12.0"
-url = "2.5.4"
+url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1"
 uuid = { version = "1.18.0", features = ["v4"] }
 wreq = "5.3.0"
@@ -71,4 +71,5 @@ wreq-util = "2.2.6"
 [dev-dependencies]
 axum = "0.8"
 dotenvy = "0.15"
+test-with = { git = "https://github.com/brekkylab/test-with.git", branch = "main", default-features = false, features = ["executable"] }
 tokio = { version = "1.0", features = ["net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ png = "0.18"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 rmcp = { version = "0.11.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 scraper = "0.24"
-schemars = { version = "0.8", features = ["preserve_order"] }
+schemars = { version = "0.8", features = ["preserve_order", "url"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 strum = { version = "0.27", features = ["derive"] }
+shellexpand = "3"
+tempfile = "3"
+dirs = "6"
+which = "7"
 strum_macros = "0.27"
 thiserror = "2.0.15"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,10 @@ strum = { version = "0.27", features = ["derive"] }
 shellexpand = "3"
 tempfile = "3"
 dirs = "6"
+flate2 = "1"
+tar = "0.4"
 which = "7"
+zip = "2"
 strum_macros = "0.27"
 thiserror = "2.0.15"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -14,16 +14,19 @@ pub struct AgentRuntime {
 }
 
 impl AgentRuntime {
-    pub fn new(spec: AgentSpec, provider: AgentProvider, tool_set: ToolSet) -> Self {
+    pub async fn new(
+        spec: AgentSpec,
+        provider: AgentProvider,
+        tool_set: ToolSet,
+    ) -> anyhow::Result<Self> {
         // Prepare toolsets
-        let tool_set =
-            provider
-                .tools
-                .iter()
-                .fold(tool_set, |ts, tool_provider| match tool_provider {
-                    ToolProvider::Builtin(builtin) => ts.with_builtin(builtin),
-                    ToolProvider::MCP(mcp) => ts.with_mcp(mcp),
-                });
+        let mut tool_set = tool_set;
+        for tool_provider in &provider.tools {
+            tool_set = match tool_provider {
+                ToolProvider::Builtin(builtin) => tool_set.with_builtin(builtin).await?,
+                ToolProvider::MCP(mcp) => tool_set.with_mcp(mcp),
+            };
+        }
 
         // Collect tools from toolsets
         let tools = spec
@@ -32,18 +35,18 @@ impl AgentRuntime {
             .filter_map(|name| tool_set.get(name).cloned())
             .collect();
 
-        // Initialize histroy
+        // Initialize history
         let history = spec
             .instruction
             .map(|inst| vec![Message::new(Role::System).with_contents([Part::text(inst)])])
             .unwrap_or_default();
 
         // Create `AgentRuntime`
-        Self {
+        Ok(Self {
             lm: LangModelRuntime::new(spec.lm, provider.lm),
             tools,
             history,
-        }
+        })
     }
 
     pub fn run(
@@ -125,20 +128,20 @@ impl AgentRuntime {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{path::Path, sync::Arc};
 
     use futures::StreamExt as _;
-    use url::Url;
 
     use super::*;
     use crate::{
-        agent::{LangModelAPISchema, LangModelProvider, ToolFunc},
+        agent::{BuiltinToolProvider, LangModelProvider, ToolFunc},
         message::{Part, Role, ToolDescBuilder},
         to_value,
     };
 
     /// Verifies that the agent calls the temperature tool and returns a final answer.
     #[tokio::test]
+    #[ignore = "requires network + OPENAI_API_KEY"]
     async fn test_run_agent() {
         dotenvy::dotenv().ok();
 
@@ -167,20 +170,17 @@ mod tests {
         );
 
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
-        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
 
         let mut agent = AgentRuntime::new(
             AgentSpec::new("gpt-4").with_tools(["temperature"]),
             AgentProvider {
-                lm: LangModelProvider::API {
-                    schema: LangModelAPISchema::ChatCompletion,
-                    url,
-                    api_key: Some(api_key),
-                },
+                lm: LangModelProvider::openai(api_key),
                 tools: vec![],
             },
             tool_set,
-        );
+        )
+        .await
+        .unwrap();
 
         let query = Message::new(Role::User)
             .with_contents([Part::text("What is the current temperature in Seoul?")]);
@@ -200,6 +200,111 @@ mod tests {
         assert!(
             resp.message.contents.iter().any(|p| p.is_text()),
             "Expected final assistant message to contain text"
+        );
+    }
+
+    /// End-to-end test: agent uses python_repl to generate a numpy sine-wave
+    /// chart with matplotlib, saves it as a PNG, and we validate the file.
+    ///
+    /// Requires: OPENAI_API_KEY env var, network access.
+    #[tokio::test]
+    #[ignore = "requires network + OPENAI_API_KEY"]
+    async fn test_python_repl_numpy_matplotlib_chart() {
+        dotenvy::dotenv().ok();
+
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
+
+        // Temp dir for the chart output — kept alive for the duration of the test.
+        // let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let chart_path = Path::new("./").join("sine_chart.png");
+
+        let prompt = format!(
+            "Install numpy and matplotlib, then write Python code that:\n\
+             1. Generates 200 points of a sine wave using numpy (x: 0 to 4π)\n\
+             2. Plots the sine wave with matplotlib\n\
+             3. Saves the figure to '{}'\n\
+             \n\
+             Use pip_install for the packages. Do not call plt.show().",
+            chart_path.display()
+        );
+
+        let mut agent = AgentRuntime::new(
+            AgentSpec::new("gpt-4o-mini").with_tools(["python_repl"]),
+            AgentProvider {
+                lm: LangModelProvider::openai(api_key),
+                tools: vec![ToolProvider::Builtin(BuiltinToolProvider::PythonRepl {
+                    python_version: None,
+                    venv_path: None,
+                    packages: vec![],
+                })],
+            },
+            ToolSet::new(),
+        )
+        .await
+        .unwrap();
+
+        let query = Message::new(Role::User).with_contents([Part::text(prompt)]);
+        let mut outputs = vec![];
+        let mut strm = agent.stream_turn(query);
+        while let Some(out) = strm.next().await {
+            let out = out.unwrap();
+            println!("{}", out);
+            outputs.push(out);
+        }
+
+        // ── assertions ────────────────────────────────────────────────────────
+
+        // 1. The agent must have made at least one python_repl tool call.
+        let tool_outputs: Vec<_> = outputs
+            .iter()
+            .filter(|o| o.message.role == Role::Tool)
+            .collect();
+        assert!(
+            !tool_outputs.is_empty(),
+            "expected at least one python_repl tool call, got none"
+        );
+
+        // 2. Every tool call that returned must have exit_code 0 (success).
+        for tool_out in &tool_outputs {
+            for part in &tool_out.message.contents {
+                if let Some(v) = part.as_value() {
+                    let exit_code = v
+                        .pointer("/exit_code")
+                        .and_then(|c| c.as_integer())
+                        .unwrap_or(-1);
+                    let stdout = v.pointer("/stdout").and_then(|s| s.as_str()).unwrap_or("");
+                    let stderr = v.pointer("/stderr").and_then(|s| s.as_str()).unwrap_or("");
+                    assert_eq!(
+                        exit_code, 0,
+                        "python_repl returned non-zero exit code.\nstdout: {stdout}\nstderr: {stderr}"
+                    );
+                }
+            }
+        }
+
+        // 3. Chart file must exist.
+        assert!(
+            chart_path.exists(),
+            "chart file was not created at {:?}",
+            chart_path
+        );
+
+        // 4. File must be a valid PNG (check 8-byte magic signature).
+        const PNG_MAGIC: &[u8] = b"\x89PNG\r\n\x1a\n";
+        let header = std::fs::read(&chart_path).unwrap();
+        assert!(
+            header.starts_with(PNG_MAGIC),
+            "file at {:?} is not a valid PNG (got {:?})",
+            chart_path,
+            &header[..header.len().min(8)]
+        );
+
+        // 5. The final message must be an assistant text reply.
+        let final_msg = outputs.last().expect("expected at least one output");
+        assert_eq!(final_msg.message.role, Role::Assistant);
+        assert!(
+            final_msg.message.contents.iter().any(|p| p.is_text()),
+            "expected assistant to summarise its work in text"
         );
     }
 }

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -215,8 +215,8 @@ mod tests {
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
         // Temp dir for the chart output — kept alive for the duration of the test.
-        // let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
-        let chart_path = Path::new("./").join("sine_chart.png");
+        let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let chart_path = chart_dir.path().join("sine_chart.png");
 
         let prompt = format!(
             "Install numpy and matplotlib, then write Python code that:\n\

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -207,7 +207,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{BuiltinToolProvider, LangModelProvider, ToolFunc},
+        agent::{LangModelProvider, ToolFunc},
         message::{Part, Role, ToolDescBuilder},
         to_value,
     };
@@ -273,111 +273,6 @@ mod tests {
         assert!(
             resp.message.contents.iter().any(|p| p.is_text()),
             "Expected final assistant message to contain text"
-        );
-    }
-
-    /// End-to-end test: agent uses python_repl to generate a numpy sine-wave
-    /// chart with matplotlib, saves it as a PNG, and we validate the file.
-    ///
-    /// Requires: OPENAI_API_KEY env var, network access.
-    #[test_with::env(OPENAI_API_KEY)]
-    #[tokio::test]
-    async fn test_python_repl_numpy_matplotlib_chart() {
-        dotenvy::dotenv().ok();
-
-        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
-
-        // Temp dir for the chart output — kept alive for the duration of the test.
-        let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
-        let chart_path = chart_dir.path().join("sine_chart.png");
-
-        let prompt = format!(
-            "Install numpy and matplotlib, then write Python code that:\n\
-             1. Generates 200 points of a sine wave using numpy (x: 0 to 4π)\n\
-             2. Plots the sine wave with matplotlib\n\
-             3. Saves the figure to '{}'\n\
-             \n\
-             Use pip_install for the packages. Do not call plt.show().",
-            chart_path.display()
-        );
-
-        let mut agent = AgentRuntime::new(
-            AgentSpec::new("gpt-4o-mini").with_tools(["python_repl"]),
-            AgentProvider {
-                lm: LangModelProvider::openai(api_key),
-                tools: vec![ToolProvider::Builtin(BuiltinToolProvider::PythonRepl {
-                    python_version: None,
-                    venv_path: None,
-                    packages: vec![],
-                })],
-            },
-            ToolSet::new(),
-        )
-        .await
-        .unwrap();
-
-        let query = Message::new(Role::User).with_contents([Part::text(prompt)]);
-        let mut outputs = vec![];
-        let mut strm = agent.stream_turn(query);
-        while let Some(out) = strm.next().await {
-            let out = out.unwrap();
-            println!("{}", out);
-            outputs.push(out);
-        }
-
-        // ── assertions ────────────────────────────────────────────────────────
-
-        // 1. The agent must have made at least one python_repl tool call.
-        let tool_outputs: Vec<_> = outputs
-            .iter()
-            .filter(|o| o.message.role == Role::Tool)
-            .collect();
-        assert!(
-            !tool_outputs.is_empty(),
-            "expected at least one python_repl tool call, got none"
-        );
-
-        // 2. Every tool call that returned must have exit_code 0 (success).
-        for tool_out in &tool_outputs {
-            for part in &tool_out.message.contents {
-                if let Some(v) = part.as_value() {
-                    let exit_code = v
-                        .pointer("/exit_code")
-                        .and_then(|c| c.as_integer())
-                        .unwrap_or(-1);
-                    let stdout = v.pointer("/stdout").and_then(|s| s.as_str()).unwrap_or("");
-                    let stderr = v.pointer("/stderr").and_then(|s| s.as_str()).unwrap_or("");
-                    assert_eq!(
-                        exit_code, 0,
-                        "python_repl returned non-zero exit code.\nstdout: {stdout}\nstderr: {stderr}"
-                    );
-                }
-            }
-        }
-
-        // 3. Chart file must exist.
-        assert!(
-            chart_path.exists(),
-            "chart file was not created at {:?}",
-            chart_path
-        );
-
-        // 4. File must be a valid PNG (check 8-byte magic signature).
-        const PNG_MAGIC: &[u8] = b"\x89PNG\r\n\x1a\n";
-        let header = std::fs::read(&chart_path).unwrap();
-        assert!(
-            header.starts_with(PNG_MAGIC),
-            "file at {:?} is not a valid PNG (got {:?})",
-            chart_path,
-            &header[..header.len().min(8)]
-        );
-
-        // 5. The final message must be an assistant text reply.
-        let final_msg = outputs.last().expect("expected at least one output");
-        assert_eq!(final_msg.message.role, Role::Assistant);
-        assert!(
-            final_msg.message.contents.iter().any(|p| p.is_text()),
-            "expected assistant to summarise its work in text"
         );
     }
 

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -213,8 +213,8 @@ mod tests {
     };
 
     /// Verifies that the agent calls the temperature tool and returns a final answer.
+    #[test_with::env(OPENAI_API_KEY)]
     #[tokio::test]
-    #[ignore = "requires network + OPENAI_API_KEY"]
     async fn test_run_agent() {
         dotenvy::dotenv().ok();
 
@@ -280,8 +280,8 @@ mod tests {
     /// chart with matplotlib, saves it as a PNG, and we validate the file.
     ///
     /// Requires: OPENAI_API_KEY env var, network access.
+    #[test_with::env(OPENAI_API_KEY)]
     #[tokio::test]
-    #[ignore = "requires network + OPENAI_API_KEY"]
     async fn test_python_repl_numpy_matplotlib_chart() {
         dotenvy::dotenv().ok();
 
@@ -386,6 +386,7 @@ mod tests {
     /// Sets up a math subagent and registers it as a subagent tool on a coordinator agent.
     /// Asks a math question and confirms the main agent's history contains a [`Role::Tool`]
     /// message (proof that the subagent tool was called), and that the final reply is text.
+    #[test_with::env(OPENAI_API_KEY)]
     #[tokio::test]
     async fn test_delegate_to_in_memory_subagent() {
         dotenvy::dotenv().ok();

--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -128,7 +128,7 @@ impl AgentRuntime {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, sync::Arc};
+    use std::sync::Arc;
 
     use futures::StreamExt as _;
 

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     message::{Message, Part, Role, ToolDesc},
 };
 
+mod python_repl;
 mod web_search;
 
 pub type ToolFunc = dyn Fn(Value) -> BoxFuture<'static, Value> + Send + Sync;
@@ -66,12 +67,26 @@ impl ToolSet {
         self.tools.remove(key)
     }
 
-    pub fn with_builtin(mut self, provider: &BuiltinToolProvider) -> Self {
+    pub async fn with_builtin(mut self, provider: &BuiltinToolProvider) -> anyhow::Result<Self> {
         match provider {
             BuiltinToolProvider::WebSearch {} => {
                 let tool = web_search::build_web_search_tool();
                 self.tools.insert("web_search".to_string(), tool);
-                self
+                Ok(self)
+            }
+            BuiltinToolProvider::PythonRepl {
+                python_version,
+                venv_path,
+                packages,
+            } => {
+                let config = python_repl::PythonReplConfig {
+                    python_version: python_version.clone(),
+                    venv_path: venv_path.clone(),
+                    packages: packages.clone(),
+                };
+                let tool = python_repl::build_python_repl_tool(config).await?;
+                self.tools.insert("python_repl".to_string(), tool);
+                Ok(self)
             }
         }
     }

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -15,12 +15,37 @@ pub enum InstallResult {
     Failed { stderr: String },
 }
 
+/// Maximum number of UTF-8 characters retained from stdout / stderr.
+/// Output beyond this limit is replaced with a truncation notice so that
+/// huge prints (e.g. a raw numpy array) don't flood the LLM context window.
+pub const MAX_OUTPUT_CHARS: usize = 8_000;
+
+/// Truncate `s` to at most [`MAX_OUTPUT_CHARS`] characters, preserving valid
+/// UTF-8 boundaries, and append a notice when truncation occurs.
+pub fn truncate_output(s: String) -> String {
+    if s.len() <= MAX_OUTPUT_CHARS {
+        return s;
+    }
+    // Walk backward from MAX_OUTPUT_CHARS to find a valid char boundary.
+    let mut end = MAX_OUTPUT_CHARS;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n[output truncated at {} chars]",
+        &s[..end],
+        MAX_OUTPUT_CHARS
+    )
+}
+
 /// Result of executing a Python script.
 #[derive(Debug)]
 pub struct ExecResult {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: i32,
+    /// `true` when the script was killed because it exceeded the timeout.
+    pub timed_out: bool,
 }
 
 /// A managed Python virtual environment backed by `uv`.
@@ -158,31 +183,83 @@ impl PythonEnv {
     /// the exit code.
     ///
     /// The code is written to a temporary file and passed to the venv's Python
-    /// interpreter.  The temp file is deleted after the child exits.
+    /// interpreter.  stdout and stderr are read concurrently on separate tasks
+    /// to avoid pipe-buffer deadlocks.  Output is truncated at
+    /// [`MAX_OUTPUT_CHARS`] chars to protect the LLM context window.
+    ///
+    /// On timeout the child process is killed and [`ExecResult::timed_out`] is
+    /// set to `true`; the function still returns `Ok`.
     pub async fn run_code(&self, code: &str, timeout_secs: u64) -> Result<ExecResult> {
         // Write code to a temp file.
         let script = tempfile::NamedTempFile::with_suffix(".py")
             .context("failed to create temp script file")?;
         std::fs::write(script.path(), code).context("failed to write script to temp file")?;
 
-        let child = Command::new(self.python_path())
+        let mut child = Command::new(self.python_path())
             .arg(script.path())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .context("failed to spawn Python interpreter")?;
 
-        let deadline = tokio::time::Duration::from_secs(timeout_secs);
-        let output = tokio::time::timeout(deadline, child.wait_with_output())
-            .await
-            .context("Python script timed out")?
-            .context("failed to wait for Python process")?;
+        // Drain stdout and stderr on separate tasks to prevent pipe-buffer
+        // deadlock when a process produces large output on both streams.
+        let stdout_pipe = child.stdout.take().expect("stdout was piped");
+        let stderr_pipe = child.stderr.take().expect("stderr was piped");
 
-        Ok(ExecResult {
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            exit_code: output.status.code().unwrap_or(-1),
-        })
+        let out_task = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt as _;
+            let mut buf = Vec::new();
+            tokio::io::BufReader::new(stdout_pipe)
+                .read_to_end(&mut buf)
+                .await?;
+            Ok::<_, std::io::Error>(buf)
+        });
+        let err_task = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt as _;
+            let mut buf = Vec::new();
+            tokio::io::BufReader::new(stderr_pipe)
+                .read_to_end(&mut buf)
+                .await?;
+            Ok::<_, std::io::Error>(buf)
+        });
+
+        let deadline = tokio::time::Duration::from_secs(timeout_secs);
+        match tokio::time::timeout(deadline, child.wait()).await {
+            Ok(Ok(status)) => {
+                let stdout_bytes =
+                    out_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
+                let stderr_bytes =
+                    err_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
+                Ok(ExecResult {
+                    stdout: truncate_output(
+                        String::from_utf8_lossy(&stdout_bytes).into_owned(),
+                    ),
+                    stderr: truncate_output(
+                        String::from_utf8_lossy(&stderr_bytes).into_owned(),
+                    ),
+                    exit_code: status.code().unwrap_or(-1),
+                    timed_out: false,
+                })
+            }
+            Ok(Err(e)) => {
+                out_task.abort();
+                err_task.abort();
+                Err(anyhow::anyhow!("failed to wait for Python process: {}", e))
+            }
+            Err(_) => {
+                // Timeout — kill the child and abort I/O tasks.
+                let _ = child.kill().await;
+                out_task.abort();
+                err_task.abort();
+                Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: format!("script timed out after {}s", timeout_secs),
+                    exit_code: -1,
+                    timed_out: true,
+                })
+            }
+        }
     }
 }
 
@@ -393,13 +470,106 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires uv"]
-    async fn test_run_code_timeout() {
+    async fn test_run_code_timeout_returns_timed_out_flag() {
         let uv = uv_or_skip();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         // 1-second timeout against an infinite loop.
-        let result = env.run_code("while True: pass", 1).await;
-        assert!(result.is_err(), "expected timeout error");
-        let msg = format!("{:#}", result.unwrap_err());
-        assert!(msg.contains("timed out"), "error: {}", msg);
+        let result = env.run_code("while True: pass", 1).await.unwrap();
+        assert!(result.timed_out, "expected timed_out to be true");
+        assert_eq!(result.exit_code, -1);
+        assert!(
+            result.stderr.contains("timed out"),
+            "stderr should mention timeout: {:?}",
+            result.stderr
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_success_has_timed_out_false() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env.run_code("print('ok')", 30).await.unwrap();
+        assert!(!result.timed_out, "successful run must not be timed_out");
+    }
+
+    // ── output truncation ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_truncate_output_short_string_unchanged() {
+        let s = "hello world".to_string();
+        let out = truncate_output(s.clone());
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn test_truncate_output_exact_limit_unchanged() {
+        let s = "a".repeat(MAX_OUTPUT_CHARS);
+        let out = truncate_output(s.clone());
+        assert_eq!(out, s, "string at exact limit should not be truncated");
+    }
+
+    #[test]
+    fn test_truncate_output_over_limit_is_shortened() {
+        let s = "b".repeat(MAX_OUTPUT_CHARS + 100);
+        let out = truncate_output(s);
+        assert!(
+            out.len() < MAX_OUTPUT_CHARS + 100,
+            "output should be shorter than input"
+        );
+        assert!(
+            out.contains("[output truncated"),
+            "should contain truncation marker"
+        );
+    }
+
+    #[test]
+    fn test_truncate_output_respects_utf8_boundary() {
+        // Each 'あ' is 3 bytes; MAX_OUTPUT_CHARS bytes puts the cut-point
+        // inside a multi-byte char sequence — must not panic and must produce
+        // valid UTF-8.
+        let s = "あ".repeat(MAX_OUTPUT_CHARS); // well over the char limit
+        let out = truncate_output(s);
+        // Result must be valid UTF-8 (from_utf8 / std::str invariant).
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+        // Must be shorter than the original.
+        assert!(out.len() < MAX_OUTPUT_CHARS * 3);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_large_output_is_truncated() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        // Print well over MAX_OUTPUT_CHARS bytes.
+        let code = format!("print('x' * {})", MAX_OUTPUT_CHARS * 2);
+        let result = env.run_code(&code, 30).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.len() <= MAX_OUTPUT_CHARS + 100,
+            "stdout should be truncated, got {} chars",
+            result.stdout.len()
+        );
+        assert!(
+            result.stdout.contains("[output truncated"),
+            "should contain truncation marker"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_large_stderr_is_truncated() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let code = format!(
+            "import sys; sys.stderr.write('e' * {})",
+            MAX_OUTPUT_CHARS * 2
+        );
+        let result = env.run_code(&code, 30).await.unwrap();
+        assert!(
+            result.stderr.len() <= MAX_OUTPUT_CHARS + 100,
+            "stderr should be truncated, got {} chars",
+            result.stderr.len()
+        );
     }
 }

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -227,17 +227,11 @@ impl PythonEnv {
         let deadline = tokio::time::Duration::from_secs(timeout_secs);
         match tokio::time::timeout(deadline, child.wait()).await {
             Ok(Ok(status)) => {
-                let stdout_bytes =
-                    out_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
-                let stderr_bytes =
-                    err_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
+                let stdout_bytes = out_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
+                let stderr_bytes = err_task.await.unwrap_or(Ok(vec![])).unwrap_or_default();
                 Ok(ExecResult {
-                    stdout: truncate_output(
-                        String::from_utf8_lossy(&stdout_bytes).into_owned(),
-                    ),
-                    stderr: truncate_output(
-                        String::from_utf8_lossy(&stderr_bytes).into_owned(),
-                    ),
+                    stdout: truncate_output(String::from_utf8_lossy(&stdout_bytes).into_owned()),
+                    stderr: truncate_output(String::from_utf8_lossy(&stderr_bytes).into_owned()),
                     exit_code: status.code().unwrap_or(-1),
                     timed_out: false,
                 })

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -275,6 +275,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    use crate::agent::rt::tool::python_repl::uv::resolve_uv_path;
 
     impl PythonEnv {
         /// Expose the venv directory path (useful in tests).
@@ -283,34 +284,21 @@ mod tests {
         }
     }
 
-    /// Skip the test if `uv` is not available (PATH or managed install).
-    fn uv_or_skip() -> PathBuf {
-        match crate::agent::rt::tool::python_repl::uv::resolve_uv_path() {
-            Ok(p) if p.exists() => p,
-            _ => {
-                eprintln!("SKIP: `uv` not found");
-                // Returning an obviously wrong path causes the test to be
-                // skipped via the ignore mechanism — we use `#[ignore]` below.
-                PathBuf::from("/uv-not-found")
-            }
-        }
-    }
-
     // ── venv creation ────────────────────────────────────────────────────────
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_create_temp_env_venv_dir_exists() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         assert!(env.venv_path().exists(), "venv dir should exist");
         assert!(env.python_path().exists(), "python binary should exist");
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_temp_env_is_cleaned_up_on_drop() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         // Capture venv parent (the temp dir) before dropping.
         let parent = env.venv_path().parent().unwrap().to_path_buf();
@@ -319,10 +307,10 @@ mod tests {
         assert!(!parent.exists(), "temp dir should be deleted on drop");
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_persistent_env_not_cleaned_up_on_drop() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let venv_path = dir.path().join("venv");
         let env = PythonEnv::new(uv, None, venv_path.clone(), false)
@@ -334,10 +322,10 @@ mod tests {
 
     // ── package installation ─────────────────────────────────────────────────
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_install_package_success() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env
             .install_packages(&["requests".to_string()])
@@ -346,10 +334,10 @@ mod tests {
         assert!(matches!(result, InstallResult::Success));
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_install_same_package_twice_uses_cache() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         env.install_packages(&["requests".to_string()])
             .await
@@ -362,10 +350,10 @@ mod tests {
         assert!(matches!(result, InstallResult::AlreadyInstalled));
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_install_version_specifier_change_reinstalls() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         env.install_packages(&["requests==2.31.0".to_string()])
             .await
@@ -378,10 +366,10 @@ mod tests {
         assert!(matches!(result, InstallResult::Success));
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_install_nonexistent_package_returns_failed() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env
             .install_packages(&["this-package-definitely-does-not-exist-xyzzy".to_string()])
@@ -394,10 +382,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_install_empty_list_returns_already_installed() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.install_packages(&[]).await.unwrap();
         assert!(matches!(result, InstallResult::AlreadyInstalled));
@@ -405,10 +393,10 @@ mod tests {
 
     // ── code execution ───────────────────────────────────────────────────────
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_hello_world() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.run_code("print('hello world')", 30).await.unwrap();
         assert_eq!(result.exit_code, 0);
@@ -419,10 +407,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_captures_stderr() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env
             .run_code("import sys; sys.stderr.write('err output\\n')", 30)
@@ -435,10 +423,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_runtime_error_nonzero_exit() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.run_code("raise ValueError('oops')", 30).await.unwrap();
         assert_ne!(result.exit_code, 0, "expected non-zero exit for exception");
@@ -449,10 +437,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_each_execution_is_stateless() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         // First run: define a variable.
         let first = env.run_code("x = 42", 30).await.unwrap();
@@ -462,10 +450,10 @@ mod tests {
         assert_ne!(second.exit_code, 0, "x should not exist in a fresh run");
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_timeout_returns_timed_out_flag() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         // 1-second timeout against an infinite loop.
         let result = env.run_code("while True: pass", 1).await.unwrap();
@@ -478,10 +466,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_success_has_timed_out_false() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.run_code("print('ok')", 30).await.unwrap();
         assert!(!result.timed_out, "successful run must not be timed_out");
@@ -530,10 +518,10 @@ mod tests {
         assert!(out.len() < MAX_OUTPUT_CHARS * 3);
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_large_output_is_truncated() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         // Print well over MAX_OUTPUT_CHARS bytes.
         let code = format!("print('x' * {})", MAX_OUTPUT_CHARS * 2);
@@ -550,10 +538,10 @@ mod tests {
         );
     }
 
+    #[test_with::executable(uv)]
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_code_large_stderr_is_truncated() {
-        let uv = uv_or_skip();
+        let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let code = format!(
             "import sys; sys.stderr.write('e' * {})",

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -140,9 +140,9 @@ impl PythonEnv {
     ///
     /// Specifiers that are already present in the in-memory cache are skipped;
     /// for everything else `uv pip install` is called.
-    pub async fn install_packages(&self, packages: &[String]) -> Result<InstallResult> {
+    pub async fn install_packages(&self, packages: &[String]) -> InstallResult {
         if packages.is_empty() {
-            return Ok(InstallResult::AlreadyInstalled);
+            return InstallResult::AlreadyInstalled;
         }
 
         let mut cache = self.installed.lock().await;
@@ -152,10 +152,10 @@ impl PythonEnv {
             .collect();
 
         if new.is_empty() {
-            return Ok(InstallResult::AlreadyInstalled);
+            return InstallResult::AlreadyInstalled;
         }
 
-        let output = Command::new(&self.uv)
+        let output = match Command::new(&self.uv)
             .args([
                 "pip",
                 "install",
@@ -165,17 +165,24 @@ impl PythonEnv {
             .args(new.iter().copied())
             .output()
             .await
-            .context("failed to spawn `uv pip install`")?;
+        {
+            Ok(result) => result,
+            Err(err) => {
+                return InstallResult::Failed {
+                    stderr: format!("failed to spawn `uv pip install`: {}", err),
+                };
+            }
+        };
 
         if output.status.success() {
             for spec in &new {
                 cache.insert(spec.to_string());
             }
-            Ok(InstallResult::Success)
+            InstallResult::Success
         } else {
-            Ok(InstallResult::Failed {
+            InstallResult::Failed {
                 stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            })
+            }
         }
     }
 
@@ -327,10 +334,7 @@ mod tests {
     async fn test_install_package_success() {
         let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        let result = env
-            .install_packages(&["requests".to_string()])
-            .await
-            .unwrap();
+        let result = env.install_packages(&["requests".to_string()]).await;
         assert!(matches!(result, InstallResult::Success));
     }
 
@@ -339,14 +343,9 @@ mod tests {
     async fn test_install_same_package_twice_uses_cache() {
         let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        env.install_packages(&["requests".to_string()])
-            .await
-            .unwrap();
+        env.install_packages(&["requests".to_string()]).await;
         // Second call with identical specifier must not spawn subprocess.
-        let result = env
-            .install_packages(&["requests".to_string()])
-            .await
-            .unwrap();
+        let result = env.install_packages(&["requests".to_string()]).await;
         assert!(matches!(result, InstallResult::AlreadyInstalled));
     }
 
@@ -356,13 +355,11 @@ mod tests {
         let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         env.install_packages(&["requests==2.31.0".to_string()])
-            .await
-            .unwrap();
+            .await;
         // Different specifier string → subprocess must be called.
         let result = env
             .install_packages(&["requests==2.32.0".to_string()])
-            .await
-            .unwrap();
+            .await;
         assert!(matches!(result, InstallResult::Success));
     }
 
@@ -373,8 +370,7 @@ mod tests {
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env
             .install_packages(&["this-package-definitely-does-not-exist-xyzzy".to_string()])
-            .await
-            .unwrap();
+            .await;
         assert!(
             matches!(result, InstallResult::Failed { .. }),
             "expected Failed, got {:?}",
@@ -387,7 +383,7 @@ mod tests {
     async fn test_install_empty_list_returns_already_installed() {
         let uv = resolve_uv_path().unwrap();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        let result = env.install_packages(&[]).await.unwrap();
+        let result = env.install_packages(&[]).await;
         assert!(matches!(result, InstallResult::AlreadyInstalled));
     }
 

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashSet,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashSet, path::PathBuf};
 
 use anyhow::{Context as _, Result, bail};
 use tokio::{process::Command, sync::Mutex};
@@ -83,18 +80,10 @@ impl PythonEnv {
         }
     }
 
-    /// Expose the venv directory path (useful in tests).
-    pub fn venv_path(&self) -> &Path {
-        &self.venv_path
-    }
-
     // ── private helpers ──────────────────────────────────────────────────────
 
     async fn ensure_python(&self) -> Result<()> {
-        let version_arg = self
-            .python_version
-            .as_deref()
-            .unwrap_or("3");
+        let version_arg = self.python_version.as_deref().unwrap_or("3");
         let status = Command::new(&self.uv)
             .args(["python", "install", version_arg])
             .status()
@@ -142,7 +131,12 @@ impl PythonEnv {
         }
 
         let output = Command::new(&self.uv)
-            .args(["pip", "install", "--python", self.python_path().to_str().unwrap()])
+            .args([
+                "pip",
+                "install",
+                "--python",
+                self.python_path().to_str().unwrap(),
+            ])
             .args(new.iter().copied())
             .output()
             .await
@@ -169,8 +163,7 @@ impl PythonEnv {
         // Write code to a temp file.
         let script = tempfile::NamedTempFile::with_suffix(".py")
             .context("failed to create temp script file")?;
-        std::fs::write(script.path(), code)
-            .context("failed to write script to temp file")?;
+        std::fs::write(script.path(), code).context("failed to write script to temp file")?;
 
         let child = Command::new(self.python_path())
             .arg(script.path())
@@ -208,7 +201,16 @@ impl Drop for PythonEnv {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
+
+    impl PythonEnv {
+        /// Expose the venv directory path (useful in tests).
+        pub fn venv_path(&self) -> &Path {
+            &self.venv_path
+        }
+    }
 
     /// Skip the test if `uv` is not available on PATH.
     fn uv_or_skip() -> PathBuf {
@@ -252,7 +254,9 @@ mod tests {
         let uv = uv_or_skip();
         let dir = tempfile::tempdir().unwrap();
         let venv_path = dir.path().join("venv");
-        let env = PythonEnv::new(uv, None, venv_path.clone(), false).await.unwrap();
+        let env = PythonEnv::new(uv, None, venv_path.clone(), false)
+            .await
+            .unwrap();
         drop(env);
         assert!(venv_path.exists(), "persistent venv should survive drop");
     }
@@ -264,7 +268,10 @@ mod tests {
     async fn test_install_package_success() {
         let uv = uv_or_skip();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        let result = env.install_packages(&["requests".to_string()]).await.unwrap();
+        let result = env
+            .install_packages(&["requests".to_string()])
+            .await
+            .unwrap();
         assert!(matches!(result, InstallResult::Success));
     }
 
@@ -273,9 +280,14 @@ mod tests {
     async fn test_install_same_package_twice_uses_cache() {
         let uv = uv_or_skip();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        env.install_packages(&["requests".to_string()]).await.unwrap();
+        env.install_packages(&["requests".to_string()])
+            .await
+            .unwrap();
         // Second call with identical specifier must not spawn subprocess.
-        let result = env.install_packages(&["requests".to_string()]).await.unwrap();
+        let result = env
+            .install_packages(&["requests".to_string()])
+            .await
+            .unwrap();
         assert!(matches!(result, InstallResult::AlreadyInstalled));
     }
 
@@ -284,9 +296,14 @@ mod tests {
     async fn test_install_version_specifier_change_reinstalls() {
         let uv = uv_or_skip();
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
-        env.install_packages(&["requests==2.31.0".to_string()]).await.unwrap();
+        env.install_packages(&["requests==2.31.0".to_string()])
+            .await
+            .unwrap();
         // Different specifier string → subprocess must be called.
-        let result = env.install_packages(&["requests==2.32.0".to_string()]).await.unwrap();
+        let result = env
+            .install_packages(&["requests==2.32.0".to_string()])
+            .await
+            .unwrap();
         assert!(matches!(result, InstallResult::Success));
     }
 
@@ -324,7 +341,11 @@ mod tests {
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.run_code("print('hello world')", 30).await.unwrap();
         assert_eq!(result.exit_code, 0);
-        assert!(result.stdout.contains("hello world"), "stdout: {:?}", result.stdout);
+        assert!(
+            result.stdout.contains("hello world"),
+            "stdout: {:?}",
+            result.stdout
+        );
     }
 
     #[tokio::test]
@@ -336,7 +357,11 @@ mod tests {
             .run_code("import sys; sys.stderr.write('err output\\n')", 30)
             .await
             .unwrap();
-        assert!(result.stderr.contains("err output"), "stderr: {:?}", result.stderr);
+        assert!(
+            result.stderr.contains("err output"),
+            "stderr: {:?}",
+            result.stderr
+        );
     }
 
     #[tokio::test]
@@ -346,7 +371,11 @@ mod tests {
         let env = PythonEnv::new_temp(uv, None).await.unwrap();
         let result = env.run_code("raise ValueError('oops')", 30).await.unwrap();
         assert_ne!(result.exit_code, 0, "expected non-zero exit for exception");
-        assert!(result.stderr.contains("ValueError"), "stderr: {:?}", result.stderr);
+        assert!(
+            result.stderr.contains("ValueError"),
+            "stderr: {:?}",
+            result.stderr
+        );
     }
 
     #[tokio::test]

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -1,0 +1,376 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result, bail};
+use tokio::{process::Command, sync::Mutex};
+
+/// Result of a `pip install` step.
+#[derive(Debug)]
+pub enum InstallResult {
+    /// Every requested specifier was already tracked in the in-memory cache —
+    /// no subprocess was spawned.
+    AlreadyInstalled,
+    /// All packages were installed (or upgraded) successfully.
+    Success,
+    /// `uv pip install` exited non-zero.
+    Failed { stderr: String },
+}
+
+/// Result of executing a Python script.
+#[derive(Debug)]
+pub struct ExecResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// A managed Python virtual environment backed by `uv`.
+pub struct PythonEnv {
+    /// Path to the `uv` binary.
+    uv: PathBuf,
+    /// Requested Python version string (e.g. `"3.12"`).  `None` → latest stable.
+    python_version: Option<String>,
+    /// Root directory of the virtual environment.
+    venv_path: PathBuf,
+    /// In-memory cache of specifier strings that have been successfully installed,
+    /// used to avoid redundant subprocess calls.
+    installed: Mutex<HashSet<String>>,
+    /// When `true` the venv directory is deleted on [`Drop`].
+    is_temp: bool,
+}
+
+impl PythonEnv {
+    /// Create (or reuse) a virtual environment at `venv_path`.
+    ///
+    /// If `is_temp` is `true` the directory will be deleted when this
+    /// [`PythonEnv`] is dropped.
+    pub async fn new(
+        uv: PathBuf,
+        python_version: Option<String>,
+        venv_path: PathBuf,
+        is_temp: bool,
+    ) -> Result<Self> {
+        let env = Self {
+            uv,
+            python_version,
+            venv_path,
+            installed: Mutex::new(HashSet::new()),
+            is_temp,
+        };
+        env.ensure_python().await?;
+        env.ensure_venv().await?;
+        Ok(env)
+    }
+
+    /// Create a virtual environment in a temporary directory that is
+    /// automatically cleaned up on drop.
+    pub async fn new_temp(uv: PathBuf, python_version: Option<String>) -> Result<Self> {
+        let tmp = tempfile::tempdir().context("failed to create temp dir for venv")?;
+        // `into_path` gives us the PathBuf without deleting the dir on drop —
+        // we handle cleanup ourselves in `PythonEnv::drop`.
+        let venv_path = tmp.keep().join("venv");
+        Self::new(uv, python_version, venv_path, true).await
+    }
+
+    /// Path to the Python interpreter inside the venv.
+    pub fn python_path(&self) -> PathBuf {
+        if cfg!(target_os = "windows") {
+            self.venv_path.join("Scripts").join("python.exe")
+        } else {
+            self.venv_path.join("bin").join("python")
+        }
+    }
+
+    /// Expose the venv directory path (useful in tests).
+    pub fn venv_path(&self) -> &Path {
+        &self.venv_path
+    }
+
+    // ── private helpers ──────────────────────────────────────────────────────
+
+    async fn ensure_python(&self) -> Result<()> {
+        let version_arg = self
+            .python_version
+            .as_deref()
+            .unwrap_or("3");
+        let status = Command::new(&self.uv)
+            .args(["python", "install", version_arg])
+            .status()
+            .await
+            .context("failed to spawn `uv python install`")?;
+        if !status.success() {
+            bail!("uv python install {} failed", version_arg);
+        }
+        Ok(())
+    }
+
+    async fn ensure_venv(&self) -> Result<()> {
+        if self.python_path().exists() {
+            return Ok(());
+        }
+        let mut cmd = Command::new(&self.uv);
+        cmd.args(["venv", self.venv_path.to_str().unwrap()]);
+        if let Some(ver) = &self.python_version {
+            cmd.args(["--python", ver.as_str()]);
+        }
+        let status = cmd.status().await.context("failed to spawn `uv venv`")?;
+        if !status.success() {
+            bail!("uv venv failed for {:?}", self.venv_path);
+        }
+        Ok(())
+    }
+
+    /// Install pip packages into this venv.
+    ///
+    /// Specifiers that are already present in the in-memory cache are skipped;
+    /// for everything else `uv pip install` is called.
+    pub async fn install_packages(&self, packages: &[String]) -> Result<InstallResult> {
+        if packages.is_empty() {
+            return Ok(InstallResult::AlreadyInstalled);
+        }
+
+        let mut cache = self.installed.lock().await;
+        let new: Vec<&String> = packages
+            .iter()
+            .filter(|p| !cache.contains(p.as_str()))
+            .collect();
+
+        if new.is_empty() {
+            return Ok(InstallResult::AlreadyInstalled);
+        }
+
+        let output = Command::new(&self.uv)
+            .args(["pip", "install", "--python", self.python_path().to_str().unwrap()])
+            .args(new.iter().copied())
+            .output()
+            .await
+            .context("failed to spawn `uv pip install`")?;
+
+        if output.status.success() {
+            for spec in &new {
+                cache.insert(spec.to_string());
+            }
+            Ok(InstallResult::Success)
+        } else {
+            Ok(InstallResult::Failed {
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            })
+        }
+    }
+
+    /// Execute a Python script string, returning captured stdout/stderr and
+    /// the exit code.
+    ///
+    /// The code is written to a temporary file and passed to the venv's Python
+    /// interpreter.  The temp file is deleted after the child exits.
+    pub async fn run_code(&self, code: &str, timeout_secs: u64) -> Result<ExecResult> {
+        // Write code to a temp file.
+        let script = tempfile::NamedTempFile::with_suffix(".py")
+            .context("failed to create temp script file")?;
+        std::fs::write(script.path(), code)
+            .context("failed to write script to temp file")?;
+
+        let child = Command::new(self.python_path())
+            .arg(script.path())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .context("failed to spawn Python interpreter")?;
+
+        let deadline = tokio::time::Duration::from_secs(timeout_secs);
+        let output = tokio::time::timeout(deadline, child.wait_with_output())
+            .await
+            .context("Python script timed out")?
+            .context("failed to wait for Python process")?;
+
+        Ok(ExecResult {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.status.code().unwrap_or(-1),
+        })
+    }
+}
+
+impl Drop for PythonEnv {
+    fn drop(&mut self) {
+        if self.is_temp {
+            // Best-effort: ignore errors (the process may already be exiting).
+            if let Some(parent) = self.venv_path.parent() {
+                let _ = std::fs::remove_dir_all(parent);
+            }
+        }
+    }
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Skip the test if `uv` is not available on PATH.
+    fn uv_or_skip() -> PathBuf {
+        match which::which("uv") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP: `uv` not found on PATH");
+                // Returning an obviously wrong path causes the test to be
+                // skipped via the ignore mechanism — we use `#[ignore]` below.
+                PathBuf::from("/uv-not-found")
+            }
+        }
+    }
+
+    // ── venv creation ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_create_temp_env_venv_dir_exists() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        assert!(env.venv_path().exists(), "venv dir should exist");
+        assert!(env.python_path().exists(), "python binary should exist");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_temp_env_is_cleaned_up_on_drop() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        // Capture venv parent (the temp dir) before dropping.
+        let parent = env.venv_path().parent().unwrap().to_path_buf();
+        assert!(parent.exists());
+        drop(env);
+        assert!(!parent.exists(), "temp dir should be deleted on drop");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_persistent_env_not_cleaned_up_on_drop() {
+        let uv = uv_or_skip();
+        let dir = tempfile::tempdir().unwrap();
+        let venv_path = dir.path().join("venv");
+        let env = PythonEnv::new(uv, None, venv_path.clone(), false).await.unwrap();
+        drop(env);
+        assert!(venv_path.exists(), "persistent venv should survive drop");
+    }
+
+    // ── package installation ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_install_package_success() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env.install_packages(&["requests".to_string()]).await.unwrap();
+        assert!(matches!(result, InstallResult::Success));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_install_same_package_twice_uses_cache() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        env.install_packages(&["requests".to_string()]).await.unwrap();
+        // Second call with identical specifier must not spawn subprocess.
+        let result = env.install_packages(&["requests".to_string()]).await.unwrap();
+        assert!(matches!(result, InstallResult::AlreadyInstalled));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_install_version_specifier_change_reinstalls() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        env.install_packages(&["requests==2.31.0".to_string()]).await.unwrap();
+        // Different specifier string → subprocess must be called.
+        let result = env.install_packages(&["requests==2.32.0".to_string()]).await.unwrap();
+        assert!(matches!(result, InstallResult::Success));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_install_nonexistent_package_returns_failed() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env
+            .install_packages(&["this-package-definitely-does-not-exist-xyzzy".to_string()])
+            .await
+            .unwrap();
+        assert!(
+            matches!(result, InstallResult::Failed { .. }),
+            "expected Failed, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_install_empty_list_returns_already_installed() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env.install_packages(&[]).await.unwrap();
+        assert!(matches!(result, InstallResult::AlreadyInstalled));
+    }
+
+    // ── code execution ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_hello_world() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env.run_code("print('hello world')", 30).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("hello world"), "stdout: {:?}", result.stdout);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_captures_stderr() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env
+            .run_code("import sys; sys.stderr.write('err output\\n')", 30)
+            .await
+            .unwrap();
+        assert!(result.stderr.contains("err output"), "stderr: {:?}", result.stderr);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_runtime_error_nonzero_exit() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let result = env.run_code("raise ValueError('oops')", 30).await.unwrap();
+        assert_ne!(result.exit_code, 0, "expected non-zero exit for exception");
+        assert!(result.stderr.contains("ValueError"), "stderr: {:?}", result.stderr);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_each_execution_is_stateless() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        // First run: define a variable.
+        let first = env.run_code("x = 42", 30).await.unwrap();
+        assert_eq!(first.exit_code, 0);
+        // Second run: variable must NOT be visible.
+        let second = env.run_code("print(x)", 30).await.unwrap();
+        assert_ne!(second.exit_code, 0, "x should not exist in a fresh run");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_code_timeout() {
+        let uv = uv_or_skip();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        // 1-second timeout against an infinite loop.
+        let result = env.run_code("while True: pass", 1).await;
+        assert!(result.is_err(), "expected timeout error");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(msg.contains("timed out"), "error: {}", msg);
+    }
+}

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -289,12 +289,12 @@ mod tests {
         }
     }
 
-    /// Skip the test if `uv` is not available on PATH.
+    /// Skip the test if `uv` is not available (PATH or managed install).
     fn uv_or_skip() -> PathBuf {
-        match which::which("uv") {
-            Ok(p) => p,
-            Err(_) => {
-                eprintln!("SKIP: `uv` not found on PATH");
+        match crate::agent::rt::tool::python_repl::uv::resolve_uv_path() {
+            Ok(p) if p.exists() => p,
+            _ => {
+                eprintln!("SKIP: `uv` not found");
                 // Returning an obviously wrong path causes the test to be
                 // skipped via the ignore mechanism — we use `#[ignore]` below.
                 PathBuf::from("/uv-not-found")

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -144,12 +144,14 @@ pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<
                 Ok(result) => crate::to_value!({
                     "stdout": result.stdout.as_str(),
                     "stderr": result.stderr.as_str(),
-                    "exit_code": result.exit_code as i64
+                    "exit_code": result.exit_code as i64,
+                    "timed_out": result.timed_out
                 }),
                 Err(e) => crate::to_value!({
                     "stdout": "",
                     "stderr": format!("execution error: {e}").as_str(),
                     "exit_code": -1,
+                    "timed_out": false,
                     "phase": "execution"
                 }),
             }

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -1,0 +1,277 @@
+mod env;
+mod uv;
+
+use std::sync::Arc;
+
+use env::{InstallResult, PythonEnv};
+use futures::future::BoxFuture;
+use uv::resolve_uv_path;
+
+use crate::{
+    agent::rt::tool::{ToolFunc, ToolRuntime},
+    datatype::Value,
+    message::ToolDescBuilder,
+};
+
+/// Config supplied by the user when declaring a `PythonRepl` tool provider.
+pub struct PythonReplConfig {
+    /// Python version to provision (e.g. `"3.12"`). `None` → latest stable.
+    pub python_version: Option<String>,
+    /// Persistent venv path. `None` → temp dir, cleaned up when the tool is dropped.
+    pub venv_path: Option<String>,
+    /// Packages to pre-install before the first tool call.
+    pub packages: Vec<String>,
+}
+
+/// Build the `python_repl` [`ToolRuntime`].
+///
+/// Resolves the `uv` binary, creates (or reuses) the virtual environment,
+/// and pre-installs any packages listed in `config.packages`.
+///
+/// Returns an error if:
+/// - `uv` cannot be found or downloaded
+/// - the virtual environment cannot be created
+/// - any package listed in `config.packages` fails to install
+pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<ToolRuntime> {
+    let uv = resolve_uv_path()?;
+
+    let env = match config.venv_path {
+        Some(ref path) => {
+            let expanded = shellexpand::tilde(path).into_owned();
+            PythonEnv::new(
+                uv,
+                config.python_version,
+                std::path::PathBuf::from(expanded),
+                false,
+            )
+            .await?
+        }
+        None => PythonEnv::new_temp(uv, config.python_version).await?,
+    };
+
+    // Pre-install user-specified packages.  Failure here is fatal so the
+    // user learns about misconfigured environments early.
+    if !config.packages.is_empty() {
+        match env.install_packages(&config.packages).await? {
+            InstallResult::Failed { stderr } => {
+                anyhow::bail!(
+                    "Failed to pre-install packages {:?}: {}",
+                    config.packages,
+                    stderr
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let env = Arc::new(env);
+
+    let desc = ToolDescBuilder::new("python_repl")
+        .description(
+            "Execute a Python script and return its stdout/stderr output. \
+             The script runs in a virtual environment shared across tool calls \
+             within this session. Use `pip_install` to install required packages \
+             before execution. Each execution is stateless — variables from \
+             previous calls are not available.",
+        )
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Python code to execute"
+                },
+                "pip_install": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Packages to install before running. Supports version specifiers (e.g. 'numpy>=1.24', 'pandas==2.1.0')."
+                }
+            },
+            "required": ["code"]
+        }))
+        .build();
+
+    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+        let env = env.clone();
+        Box::pin(async move {
+            let code = match args.pointer("/code").and_then(|v| v.as_str()) {
+                Some(c) => c.to_string(),
+                None => {
+                    return crate::to_value!({
+                        "stdout": "",
+                        "stderr": "missing required parameter: code",
+                        "exit_code": -1,
+                        "phase": "validation"
+                    });
+                }
+            };
+
+            let pip_packages: Vec<String> = args
+                .pointer("/pip_install")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            // Install packages if requested.
+            if !pip_packages.is_empty() {
+                match env.install_packages(&pip_packages).await {
+                    Ok(InstallResult::Failed { stderr }) => {
+                        return crate::to_value!({
+                            "stdout": "",
+                            "stderr": stderr.as_str(),
+                            "exit_code": 1,
+                            "phase": "pip_install"
+                        });
+                    }
+                    Err(e) => {
+                        return crate::to_value!({
+                            "stdout": "",
+                            "stderr": format!("pip install error: {e}").as_str(),
+                            "exit_code": -1,
+                            "phase": "pip_install"
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            // Execute the script.
+            match env.run_code(&code, 60).await {
+                Ok(result) => crate::to_value!({
+                    "stdout": result.stdout.as_str(),
+                    "stderr": result.stderr.as_str(),
+                    "exit_code": result.exit_code as i64
+                }),
+                Err(e) => crate::to_value!({
+                    "stdout": "",
+                    "stderr": format!("execution error: {e}").as_str(),
+                    "exit_code": -1,
+                    "phase": "execution"
+                }),
+            }
+        }) as BoxFuture<'static, Value>
+    });
+
+    Ok(ToolRuntime::new(desc, f))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> PythonReplConfig {
+        PythonReplConfig {
+            python_version: None,
+            venv_path: None,
+            packages: vec![],
+        }
+    }
+
+    // ── descriptor tests (no uv required) ────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_tool_name_is_python_repl() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        assert_eq!(tool.desc().name, "python_repl");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_tool_has_description() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        assert!(tool.desc().description.is_some());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_tool_schema_requires_code() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let required = tool
+            .desc()
+            .parameters
+            .pointer("/required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"code"), "code must be required");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_tool_schema_pip_install_is_array_of_strings() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let item_type = tool
+            .desc()
+            .parameters
+            .pointer("/properties/pip_install/items/type")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(item_type, "string");
+    }
+
+    // ── execution tests ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_missing_code_param_returns_validation_error() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        use crate::message::Part;
+        let call = Part::function_with_id("call-1", "python_repl", crate::to_value!({}));
+        let msg = tool.run(call).await.unwrap();
+        let phase = msg.contents[0]
+            .as_value()
+            .unwrap()
+            .pointer("/phase")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(phase, "validation");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv"]
+    async fn test_run_print_returns_stdout() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        use crate::message::Part;
+        let call = Part::function_with_id(
+            "call-1",
+            "python_repl",
+            crate::to_value!({ "code": "print('ailoy')" }),
+        );
+        let msg = tool.run(call).await.unwrap();
+        let stdout = msg.contents[0]
+            .as_value()
+            .unwrap()
+            .pointer("/stdout")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert!(stdout.contains("ailoy"), "stdout: {:?}", stdout);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires uv + network"]
+    async fn test_pip_install_failure_returns_phase_pip_install() {
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        use crate::message::Part;
+        let call = Part::function_with_id(
+            "call-1",
+            "python_repl",
+            crate::to_value!({
+                "code": "import xyzzy_nonexistent",
+                "pip_install": ["xyzzy-nonexistent-pkg-12345"]
+            }),
+        );
+        let msg = tool.run(call).await.unwrap();
+        let phase = msg.contents[0]
+            .as_value()
+            .unwrap()
+            .pointer("/phase")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(phase, "pip_install");
+    }
+}

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use env::{InstallResult, PythonEnv};
 use futures::future::BoxFuture;
-use uv::resolve_uv_path;
+use uv::ensure_uv;
 
 use crate::{
     agent::rt::tool::{ToolFunc, ToolRuntime},
@@ -33,7 +33,7 @@ pub struct PythonReplConfig {
 /// - the virtual environment cannot be created
 /// - any package listed in `config.packages` fails to install
 pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<ToolRuntime> {
-    let uv = resolve_uv_path()?;
+    let uv = ensure_uv().await?;
 
     let env = match config.venv_path {
         Some(ref path) => {

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -176,21 +176,18 @@ mod tests {
     // ── descriptor tests (no uv required) ────────────────────────────────────
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_tool_name_is_python_repl() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         assert_eq!(tool.desc().name, "python_repl");
     }
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_tool_has_description() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         assert!(tool.desc().description.is_some());
     }
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_tool_schema_requires_code() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         let required = tool
@@ -204,7 +201,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_tool_schema_pip_install_is_array_of_strings() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         let item_type = tool
@@ -219,7 +215,6 @@ mod tests {
     // ── execution tests ───────────────────────────────────────────────────────
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_missing_code_param_returns_validation_error() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         use crate::message::Part;
@@ -235,7 +230,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires uv"]
     async fn test_run_print_returns_stdout() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         use crate::message::Part;
@@ -255,7 +249,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires uv + network"]
     async fn test_pip_install_failure_returns_phase_pip_install() {
         let tool = build_python_repl_tool(default_config()).await.unwrap();
         use crate::message::Part;

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -13,6 +13,27 @@ use crate::{
     message::ToolDescBuilder,
 };
 
+/// ```text
+/// +----------------------+                   call with (`pip_install`, `code`)
+/// | PythonReplConfig     |                                 |
+/// | - python_version     |                                 v
+/// | - venv_path          |   +-----------------------------+--------------------+
+/// | - packages           |-->| "python_repl" ToolRuntime                        |
+/// +----------------------+   |                                                  |
+///                            | +-----------+     +----------------------------+ |
+///                            | | Acquire   | --> | Create PythonEnv           | |
+///                            | | `uv`      |     | - prepare venv             | |
+///                            | +-----------+     | - install initial packages | |
+///                            |                   +----------------------------+ |
+///                            +-----------------------------+--------------------+
+///                                                          |
+///                                                          v
+///                                       Install additional packages `pip_install`
+///                                                          |
+///                                                          v
+///                                                   Run python `code`
+/// ```
+
 /// Config supplied by the user when declaring a `PythonRepl` tool provider.
 pub struct PythonReplConfig {
     /// Python version to provision (e.g. `"3.12"`). `None` → latest stable.

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -52,7 +52,7 @@ pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<
     // Pre-install user-specified packages.  Failure here is fatal so the
     // user learns about misconfigured environments early.
     if !config.packages.is_empty() {
-        match env.install_packages(&config.packages).await? {
+        match env.install_packages(&config.packages).await {
             InstallResult::Failed { stderr } => {
                 anyhow::bail!(
                     "Failed to pre-install packages {:?}: {}",
@@ -119,19 +119,11 @@ pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<
             // Install packages if requested.
             if !pip_packages.is_empty() {
                 match env.install_packages(&pip_packages).await {
-                    Ok(InstallResult::Failed { stderr }) => {
+                    InstallResult::Failed { stderr } => {
                         return crate::to_value!({
                             "stdout": "",
-                            "stderr": stderr.as_str(),
+                            "stderr": format!("pip install error: {stderr}").as_str(),
                             "exit_code": 1,
-                            "phase": "pip_install"
-                        });
-                    }
-                    Err(e) => {
-                        return crate::to_value!({
-                            "stdout": "",
-                            "stderr": format!("pip install error: {e}").as_str(),
-                            "exit_code": -1,
                             "phase": "pip_install"
                         });
                     }

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -282,4 +282,66 @@ mod tests {
             .unwrap();
         assert_eq!(phase, "pip_install");
     }
+
+    /// Installs numpy + matplotlib, generates a sine-wave chart, and validates
+    /// the saved PNG — all by calling the tool directly (no LLM involved).
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_numpy_matplotlib_chart() {
+        use crate::message::Part;
+
+        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let chart_path = chart_dir.path().join("sine_chart.png");
+
+        // Install numpy and matplotlib, then generate and save the chart.
+        let code = format!(
+            "import numpy as np\n\
+             import matplotlib\n\
+             matplotlib.use('Agg')\n\
+             import matplotlib.pyplot as plt\n\
+             x = np.linspace(0, 4 * np.pi, 200)\n\
+             plt.plot(x, np.sin(x))\n\
+             plt.savefig('{}')\n\
+             print('done')",
+            chart_path.display()
+        );
+
+        let call = Part::function_with_id(
+            "call-1",
+            "python_repl",
+            crate::to_value!({
+                "code": code,
+                "pip_install": ["numpy", "matplotlib"]
+            }),
+        );
+        let msg = tool.run(call).await.unwrap();
+        let result = msg.contents[0].as_value().unwrap();
+
+        let exit_code = result
+            .pointer("/exit_code")
+            .and_then(|v| v.as_integer())
+            .unwrap_or(-1);
+        let stdout = result.pointer("/stdout").and_then(|v| v.as_str()).unwrap_or("");
+        let stderr = result.pointer("/stderr").and_then(|v| v.as_str()).unwrap_or("");
+        assert_eq!(
+            exit_code, 0,
+            "expected exit_code 0.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+
+        assert!(
+            chart_path.exists(),
+            "chart file was not created at {:?}",
+            chart_path
+        );
+
+        const PNG_MAGIC: &[u8] = b"\x89PNG\r\n\x1a\n";
+        let header = std::fs::read(&chart_path).unwrap();
+        assert!(
+            header.starts_with(PNG_MAGIC),
+            "file at {:?} is not a valid PNG (got {:?})",
+            chart_path,
+            &header[..header.len().min(8)]
+        );
+    }
 }

--- a/src/agent/rt/tool/python_repl/uv.rs
+++ b/src/agent/rt/tool/python_repl/uv.rs
@@ -143,8 +143,7 @@ fn extract_uv_binary(data: &[u8], dest: &Path) -> Result<()> {
         use std::io::Read as _;
 
         let cursor = std::io::Cursor::new(data);
-        let mut archive =
-            zip::ZipArchive::new(cursor).context("failed to open zip archive")?;
+        let mut archive = zip::ZipArchive::new(cursor).context("failed to open zip archive")?;
 
         for i in 0..archive.len() {
             let mut file = archive.by_index(i).context("failed to read zip entry")?;
@@ -156,10 +155,9 @@ fn extract_uv_binary(data: &[u8], dest: &Path) -> Result<()> {
             // Match any entry whose file-name component is exactly `uv.exe`.
             // The archive layout is typically `uv-{target}/uv.exe`.
             if path.file_name().and_then(|n| n.to_str()) == Some(want) {
-                let mut out = std::fs::File::create(dest)
-                    .context("failed to create uv binary file")?;
-                std::io::copy(&mut file, &mut out)
-                    .context("failed to write uv binary from zip")?;
+                let mut out =
+                    std::fs::File::create(dest).context("failed to create uv binary file")?;
+                std::io::copy(&mut file, &mut out).context("failed to write uv binary from zip")?;
                 return Ok(());
             }
         }

--- a/src/agent/rt/tool/python_repl/uv.rs
+++ b/src/agent/rt/tool/python_repl/uv.rs
@@ -1,6 +1,9 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
+
+/// Download URL template for uv GitHub releases.
+const UV_RELEASE_BASE: &str = "https://github.com/astral-sh/uv/releases/latest/download";
 
 /// Returns the path to the `uv` binary to use.
 ///
@@ -15,9 +18,7 @@ use anyhow::{Context as _, Result};
 /// - Windows: `%LOCALAPPDATA%\ailoy\bin\uv.exe`
 ///
 /// Steps 1 and 2 only check that the path exists; they do not verify the
-/// binary is executable or the correct version.  Step 3 returns the
-/// *expected* path regardless of whether the file is there yet — callers
-/// are responsible for downloading when it is absent.
+/// binary is executable or the correct version.
 pub fn resolve_uv_path() -> Result<PathBuf> {
     // 1. Explicit override (useful in tests and CI).
     if let Ok(path) = std::env::var("UV") {
@@ -37,6 +38,21 @@ pub fn resolve_uv_path() -> Result<PathBuf> {
     Ok(managed_uv_path()?)
 }
 
+/// Ensure `uv` is available, downloading it if necessary.
+///
+/// Calls [`resolve_uv_path`] first.  If the resolved path does not exist on
+/// disk (i.e. it fell through to the managed location and the binary has not
+/// been downloaded yet), downloads the latest `uv` release from GitHub.
+pub async fn ensure_uv() -> Result<PathBuf> {
+    let path = resolve_uv_path()?;
+    if path.exists() {
+        return Ok(path);
+    }
+    log::info!("uv not found — downloading to {}", path.display());
+    download_uv(&path).await?;
+    Ok(path)
+}
+
 /// Path where ailoy will place its own `uv` download.
 ///
 /// Returns `<cache_dir>/ailoy/bin/uv[.exe]` using the platform cache directory:
@@ -48,10 +64,161 @@ pub fn managed_uv_path() -> Result<PathBuf> {
     Ok(cache.join("ailoy").join("bin").join(uv_binary_name()))
 }
 
+// ── download logic ────────────────────────────────────────────────────────────
+
+/// Download the latest `uv` binary for the current platform and place it at
+/// `dest`.  Creates parent directories as needed.
+async fn download_uv(dest: &Path) -> Result<()> {
+    let target = platform_target()?;
+    let archive_name = archive_name(target);
+    let url = format!("{UV_RELEASE_BASE}/{archive_name}");
+
+    log::info!("Downloading {}", url);
+    let response = reqwest::get(&url).await.context("failed to download uv")?;
+
+    if !response.status().is_success() {
+        bail!(
+            "failed to download uv: HTTP {} from {}",
+            response.status(),
+            url,
+        );
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .context("failed to read uv archive body")?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).context("failed to create directory for uv binary")?;
+    }
+
+    extract_uv_binary(&bytes, dest)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
+            .context("failed to set executable permission on uv")?;
+    }
+
+    log::info!("uv installed at {}", dest.display());
+    Ok(())
+}
+
+/// Extract the `uv` binary from the downloaded archive into `dest`.
+///
+/// On Unix the archive is `.tar.gz` (extracted via flate2 + tar);
+/// on Windows it is `.zip` (extracted via the zip crate).
+fn extract_uv_binary(data: &[u8], dest: &Path) -> Result<()> {
+    let want = uv_binary_name();
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use flate2::read::GzDecoder;
+        use tar::Archive;
+
+        let decoder = GzDecoder::new(data);
+        let mut archive = Archive::new(decoder);
+
+        for entry in archive.entries().context("failed to read tar entries")? {
+            let mut entry = entry.context("failed to read tar entry")?;
+            let path = entry.path().context("failed to read entry path")?;
+
+            // Match any entry whose file-name component is exactly `uv`.
+            // The archive layout is typically `uv-{target}/uv`.
+            if path.file_name().and_then(|n| n.to_str()) == Some(want) {
+                entry
+                    .unpack(dest)
+                    .context("failed to extract uv binary from archive")?;
+                return Ok(());
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::io::Read as _;
+
+        let cursor = std::io::Cursor::new(data);
+        let mut archive =
+            zip::ZipArchive::new(cursor).context("failed to open zip archive")?;
+
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i).context("failed to read zip entry")?;
+            let path = match file.enclosed_name() {
+                Some(p) => p.to_path_buf(),
+                None => continue,
+            };
+
+            // Match any entry whose file-name component is exactly `uv.exe`.
+            // The archive layout is typically `uv-{target}/uv.exe`.
+            if path.file_name().and_then(|n| n.to_str()) == Some(want) {
+                let mut out = std::fs::File::create(dest)
+                    .context("failed to create uv binary file")?;
+                std::io::copy(&mut file, &mut out)
+                    .context("failed to write uv binary from zip")?;
+                return Ok(());
+            }
+        }
+    }
+
+    bail!(
+        "uv binary ({}) not found in archive — is the release format correct?",
+        want,
+    )
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
 /// Platform-specific binary name.
 fn uv_binary_name() -> &'static str {
-    if cfg!(target_os = "windows") { "uv.exe" } else { "uv" }
+    if cfg!(target_os = "windows") {
+        "uv.exe"
+    } else {
+        "uv"
+    }
 }
+
+/// Archive file name for the given target triple.
+fn archive_name(target: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("uv-{target}.zip")
+    } else {
+        format!("uv-{target}.tar.gz")
+    }
+}
+
+/// Determine the platform target triple used by uv release artifacts.
+///
+/// Matches ailoy's CI/supported platforms:
+///   - Linux x86_64 glibc  (ubuntu-latest)
+///   - macOS aarch64        (macos-15, Apple Silicon)
+///   - Windows x86_64       (windows-2022)
+fn platform_target() -> Result<&'static str> {
+    // macOS — ailoy CI: macos-15 (Apple Silicon)
+    if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        Ok("aarch64-apple-darwin")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        Ok("x86_64-apple-darwin")
+    }
+    // Linux — ailoy CI: ubuntu-latest (x86_64 glibc)
+    else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        Ok("x86_64-unknown-linux-gnu")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        Ok("aarch64-unknown-linux-gnu")
+    }
+    // Windows — ailoy CI: windows-2022 (x86_64)
+    else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Ok("x86_64-pc-windows-msvc")
+    } else if cfg!(target_os = "windows") && cfg!(target_arch = "aarch64") {
+        Ok("aarch64-pc-windows-msvc")
+    } else {
+        bail!("unsupported platform for uv download")
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -108,5 +275,51 @@ mod tests {
         } else {
             assert_eq!(name, "uv");
         }
+    }
+
+    #[test]
+    fn test_platform_target_is_known() {
+        let target = platform_target().unwrap();
+        assert!(
+            target.contains("apple") || target.contains("linux") || target.contains("windows"),
+            "unexpected target: {}",
+            target,
+        );
+    }
+
+    #[test]
+    fn test_archive_name_format() {
+        let target = platform_target().unwrap();
+        let name = archive_name(target);
+        if cfg!(target_os = "windows") {
+            assert!(name.ends_with(".zip"));
+        } else {
+            assert!(name.ends_with(".tar.gz"));
+        }
+        assert!(name.contains(target));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network, downloads ~25MB"]
+    async fn test_download_uv_and_verify() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("bin").join(uv_binary_name());
+
+        download_uv(&dest).await.unwrap();
+
+        assert!(dest.exists(), "uv binary should exist at {:?}", dest);
+        assert!(
+            dest.metadata().unwrap().len() > 1_000_000,
+            "uv binary should be > 1MB",
+        );
+
+        // Verify it's actually executable by running `uv --version`.
+        let output = std::process::Command::new(&dest)
+            .arg("--version")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let version = String::from_utf8_lossy(&output.stdout);
+        assert!(version.starts_with("uv "), "got: {}", version);
     }
 }

--- a/src/agent/rt/tool/python_repl/uv.rs
+++ b/src/agent/rt/tool/python_repl/uv.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
+
+/// Returns the path to the `uv` binary to use.
+///
+/// Resolution order:
+/// 1. `UV` environment variable (override for testing / CI)
+/// 2. `uv` found anywhere on `PATH`
+/// 3. `<cache_dir>/ailoy/bin/uv[.exe]` — the managed install location
+///
+/// The platform cache directory follows XDG / OS conventions via [`dirs::cache_dir`]:
+/// - Linux:   `$XDG_CACHE_HOME/ailoy/bin/uv`  (defaults to `~/.cache/ailoy/bin/uv`)
+/// - macOS:   `~/Library/Caches/ailoy/bin/uv`
+/// - Windows: `%LOCALAPPDATA%\ailoy\bin\uv.exe`
+///
+/// Steps 1 and 2 only check that the path exists; they do not verify the
+/// binary is executable or the correct version.  Step 3 returns the
+/// *expected* path regardless of whether the file is there yet — callers
+/// are responsible for downloading when it is absent.
+pub fn resolve_uv_path() -> Result<PathBuf> {
+    // 1. Explicit override (useful in tests and CI).
+    if let Ok(path) = std::env::var("UV") {
+        let p = PathBuf::from(&path);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+
+    // 2. Walk PATH.
+    let uv_name = uv_binary_name();
+    if let Ok(path) = which::which(uv_name) {
+        return Ok(path);
+    }
+
+    // 3. Managed install location.
+    Ok(managed_uv_path()?)
+}
+
+/// Path where ailoy will place its own `uv` download.
+///
+/// Returns `<cache_dir>/ailoy/bin/uv[.exe]` using the platform cache directory:
+/// - Linux:   `$XDG_CACHE_HOME`  (default `~/.cache`)
+/// - macOS:   `~/Library/Caches`
+/// - Windows: `%LOCALAPPDATA%`
+pub fn managed_uv_path() -> Result<PathBuf> {
+    let cache = dirs::cache_dir().context("cannot determine cache directory")?;
+    Ok(cache.join("ailoy").join("bin").join(uv_binary_name()))
+}
+
+/// Platform-specific binary name.
+fn uv_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") { "uv.exe" } else { "uv" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_managed_uv_path_is_under_cache_dir() {
+        let path = managed_uv_path().unwrap();
+        let cache = dirs::cache_dir().unwrap();
+        assert!(
+            path.starts_with(&cache),
+            "managed uv path {:?} should be under cache dir {:?}",
+            path,
+            cache,
+        );
+        // Must end with the platform binary name.
+        assert_eq!(path.file_name().unwrap(), uv_binary_name());
+    }
+
+    #[test]
+    fn test_managed_uv_path_structure() {
+        let path = managed_uv_path().unwrap();
+        let cache = dirs::cache_dir().unwrap();
+        // Expected: <cache_dir>/ailoy/bin/uv[.exe]
+        let expected = cache.join("ailoy").join("bin").join(uv_binary_name());
+        assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn test_resolve_uv_path_env_override() {
+        // Point UV at an existing file (use the test binary itself).
+        let current_exe = std::env::current_exe().unwrap();
+        // SAFETY: test-only env mutation — tests run in separate processes.
+        unsafe { std::env::set_var("UV", current_exe.to_str().unwrap()) };
+        let result = resolve_uv_path().unwrap();
+        assert_eq!(result, current_exe);
+        unsafe { std::env::remove_var("UV") };
+    }
+
+    #[test]
+    fn test_resolve_uv_path_env_override_missing_file_falls_through() {
+        unsafe { std::env::set_var("UV", "/this/path/definitely/does/not/exist/uv") };
+        // Should not error — must fall through to managed path.
+        let result = resolve_uv_path();
+        assert!(result.is_ok(), "should return managed path as fallback");
+        unsafe { std::env::remove_var("UV") };
+    }
+
+    #[test]
+    fn test_uv_binary_name_platform() {
+        let name = uv_binary_name();
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "uv.exe");
+        } else {
+            assert_eq!(name, "uv");
+        }
+    }
+}

--- a/src/agent/rt/tool/python_repl/uv.rs
+++ b/src/agent/rt/tool/python_repl/uv.rs
@@ -18,7 +18,9 @@ const UV_RELEASE_BASE: &str = "https://github.com/astral-sh/uv/releases/latest/d
 /// - Windows: `%LOCALAPPDATA%\ailoy\bin\uv.exe`
 ///
 /// Steps 1 and 2 only check that the path exists; they do not verify the
-/// binary is executable or the correct version.
+/// binary is executable or the correct version.  Step 3 returns the
+/// *expected* path regardless of whether the file is there yet — use
+/// [`ensure_uv`] to automatically download when absent.
 pub fn resolve_uv_path() -> Result<PathBuf> {
     // 1. Explicit override (useful in tests and CI).
     if let Ok(path) = std::env::var("UV") {

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -5,7 +6,7 @@ use url::Url;
 ///
 /// All fields are optional. When a field is `None`, provider-specific defaults apply
 /// (e.g. Anthropic defaults `max_tokens` to 8192 because it is a required API field).
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct LangModelInferConfig {
     /// Maximum number of tokens the model may generate in a single response.
     pub max_tokens: Option<u64>,
@@ -16,7 +17,7 @@ pub struct LangModelInferConfig {
 /// `AgentSpec` captures what makes an agent distinct — the language model it uses,
 /// the system instruction that shapes its behavior, and the set of tools it has access to.
 /// Changing any of these fields changes the fundamental nature of the agent.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AgentSpec {
     /// Identifier of the language model (e.g. `"claude-sonnet-4-6"`)
     pub lm: String,
@@ -49,7 +50,7 @@ impl AgentSpec {
 }
 
 /// Wire protocol used when calling a language model API.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum LangModelAPISchema {
     /// OpenAI-compatible `/v1/chat/completions` format
@@ -67,7 +68,7 @@ pub enum LangModelAPISchema {
 }
 
 /// Describes the runtime endpoint used to invoke a language model.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum LangModelProvider {
     /// Calls a remote HTTP API. Requires the wire `schema`, the `url` of the endpoint, and an optional `api_key` for authentication.
@@ -80,13 +81,14 @@ pub enum LangModelProvider {
     },
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum BuiltinToolProvider {
     WebSearch {},
 }
 
 /// Transport configuration for an MCP (Model Context Protocol) tool server.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum MCPToolProvider {
     /// Spawns a child process and communicates over its stdio
@@ -97,7 +99,7 @@ pub enum MCPToolProvider {
 }
 
 /// Identifies where a tool's implementation lives at runtime.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolProvider {
     /// A tool baked into the agent runtime, referenced by `name`
@@ -112,7 +114,7 @@ pub enum ToolProvider {
 /// `AgentProvider` is separate from [`AgentSpec`] because these settings describe *how*
 /// to run an agent, not *what* the agent is. Swapping the API endpoint or key does not
 /// change the agent's identity; swapping the model or instruction does.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AgentProvider {
     /// The concrete language model provider (API schema, endpoint URL, credentials)
     pub lm: LangModelProvider,

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -85,6 +85,16 @@ pub enum LangModelProvider {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BuiltinToolProvider {
     WebSearch {},
+    PythonRepl {
+        /// Python version to provision (e.g. `"3.12"`). `None` → latest stable.
+        python_version: Option<String>,
+        /// Persistent venv path. `None` → temp dir cleaned up when the tool is dropped.
+        /// Supports `~` expansion.
+        venv_path: Option<String>,
+        /// Packages to pre-install before the first tool call.
+        #[serde(default)]
+        packages: Vec<String>,
+    },
 }
 
 /// Transport configuration for an MCP (Model Context Protocol) tool server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod datatype;
 pub mod message;
 
 pub use agent::{
-    AgentProvider, AgentRuntime, AgentSpec, LangModelAPISchema, LangModelInferConfig,
-    LangModelProvider, ToolProvider, ToolRuntime, ToolSet,
+    AgentProvider, AgentRuntime, AgentSpec, BuiltinToolProvider, LangModelAPISchema,
+    LangModelInferConfig, LangModelProvider, MCPToolProvider, ToolProvider, ToolRuntime, ToolSet,
 };
 pub use datatype::Value;
 pub use message::{


### PR DESCRIPTION
## Summary

Implements a `python_repl` builtin tool that allows LLMs to execute Python scripts they generate. (#371)

- Works even if Python is not installed on the user's system (automatically provisions standalone Python via uv)
- Dynamically installs external libraries like `numpy`, `matplotlib` via the `pip_install` parameter
- Reuses venv within the same Agent Session for cumulative package installation
- Supports persistent venv paths that can be reused across sessions

---

## Background

LLM agents need a code execution environment to perform tasks such as data analysis, numerical computation, and chart generation. Pydantic Monty (sandboxed execution) was ruled out due to lack of external library support; [uv](https://github.com/astral-sh/uv) was adopted as the Python environment manager instead.

uv handles all of the following as a single static binary:
- Provisions the Python runtime by downloading [python-build-standalone](https://github.com/astral-sh/python-build-standalone) builds (same source as GitHub Actions `setup-python`)
- Creates venvs and installs pip packages (10–100× faster than pip)
- Cross-platform (Linux / macOS / Windows)

---

## Changes

### New: `src/agent/rt/tool/python_repl/`

#### `uv.rs` — uv binary management

```
resolve_uv_path() search order:
  1. $UV environment variable (CI/test override)
  2. uv on system PATH
  3. <XDG cache dir>/ailoy/bin/uv[.exe]  (managed location)
```

Platform-specific managed paths:
| OS | Path |
|---|---|
| Linux | `~/.cache/ailoy/bin/uv` |
| macOS | `~/Library/Caches/ailoy/bin/uv` |
| Windows | `%LOCALAPPDATA%\ailoy\bin\uv.exe` |

#### `env.rs` — `PythonEnv`

| Feature | Behavior |
|---|---|
| `new_temp()` | Creates a temporary venv; automatically deleted on Drop |
| `new(venv_path, is_temp=false)` | Persistent venv — reusable across sessions |
| `install_packages(&[String])` | In-memory cache prevents duplicate installs for the same specifier; supports version specifiers (`numpy>=1.24`, `pandas==2.1.0`) |
| `run_code(code, timeout_secs)` | Executes via a temporary `.py` file; reads stdout/stderr concurrently and asynchronously; handles timeouts |

**Key design points:**

- **Pipe deadlock prevention**: Two `tokio::spawn` tasks drain stdout/stderr concurrently
- **Output truncation**: Output exceeding `MAX_OUTPUT_CHARS = 8_000` is truncated with a `[output truncated at N chars]` marker — prevents LLM context pollution from large outputs such as full numpy array dumps
- **`timed_out: bool`**: On timeout, returns `Ok(ExecResult { timed_out: true, .. })` instead of `Err`, so the LLM can clearly distinguish between runtime errors and timeouts
- **pip install failure handling**: Failures installing pre-configured packages (`packages` config) → AgentRuntime creation fails (caught early); failures installing LLM-requested packages → returns an error result with `phase: "pip_install"` (agent execution continues)

```rust
pub struct ExecResult {
    pub stdout: String,
    pub stderr: String,
    pub exit_code: i32,
    pub timed_out: bool,
}
```

#### `mod.rs` — `build_python_repl_tool()`

Tool schema exposed to the LLM:

```json
{
  "name": "python_repl",
  "parameters": {
    "code": "string (required)",
    "pip_install": "string[] — supports version specifiers"
  }
}
```

Returned result schema:

```json
{
  "stdout": "string",
  "stderr": "string",
  "exit_code": "integer",
  "timed_out": "boolean",
  "phase": "pip_install | execution | validation  (only on failure)"
}
```

---

### Modified: `src/agent/spec.rs`

```rust
pub enum BuiltinToolProvider {
    WebSearch {},
    PythonRepl {                          // new
        python_version: Option<String>,   // None → latest stable
        venv_path: Option<String>,        // None → temp (auto-cleanup)
        packages: Vec<String>,            // pre-installed packages
    },
}
```

---

### Modified: `src/agent/rt/tool/mod.rs`

Changed `ToolSet::with_builtin()` to `async fn` and added the `PythonRepl` match arm.

---

### Modified: `src/agent/rt/agent.rs`

Changed `AgentRuntime::new()` to `async fn` to propagate the async from `with_builtin()`.

#### Breaking change

```rust
// before
let agent = AgentRuntime::new(spec, provider, tool_set);

// after
let agent = AgentRuntime::new(spec, provider, tool_set).await?;
```

---

### Modified: `Cargo.toml`

Added dependencies:

| Crate | Purpose |
|---|---|
| `tempfile` | Temporary script files / temporary venv directories |
| `dirs` | XDG cache directory lookup |
| `which` | Locate uv binary on PATH |
| `shellexpand` | Expand `~` in venv_path |

---

## Tests

### Unit tests (no uv required, always run)

| Test | Verifies |
|---|---|
| `test_managed_uv_path_is_under_cache_dir` | Path is under XDG cache directory |
| `test_managed_uv_path_structure` | Exact `<cache>/ailoy/bin/uv[.exe]` structure |
| `test_resolve_uv_path_env_override` | `$UV` environment variable takes priority |
| `test_uv_binary_name_platform` | Windows `.exe` / others `uv` |
| `test_truncate_output_short_string_unchanged` | Strings below limit are unchanged |
| `test_truncate_output_exact_limit_unchanged` | Boundary value handled correctly |
| `test_truncate_output_over_limit_is_shortened` | Truncates with marker when exceeded |
| `test_truncate_output_respects_utf8_boundary` | No panic at multibyte character boundaries |

### Integration tests (`#[ignore = "requires uv"]`)

| Test | Verifies |
|---|---|
| `test_create_temp_env_venv_dir_exists` | venv and Python binary creation |
| `test_temp_env_is_cleaned_up_on_drop` | Temporary directory deleted on Drop |
| `test_persistent_env_not_cleaned_up_on_drop` | Persistent venv survives Drop |
| `test_install_package_success` | pip install works correctly |
| `test_install_same_package_twice_uses_cache` | Same specifier uses cache, avoids subprocess |
| `test_install_version_specifier_change_reinstalls` | Version change triggers uv re-invocation |
| `test_install_nonexistent_package_returns_failed` | Non-existent package → `InstallResult::Failed` |
| `test_run_hello_world` | Basic execution and stdout capture |
| `test_run_code_captures_stderr` | stderr capture |
| `test_run_code_runtime_error_nonzero_exit` | Exception → non-zero exit code |
| `test_run_code_each_execution_is_stateless` | Variable isolation between executions |
| `test_run_code_timeout_returns_timed_out_flag` | Timeout → `timed_out: true`, returns `Ok` |
| `test_run_code_success_has_timed_out_false` | Successful execution → `timed_out: false` |
| `test_run_code_large_output_is_truncated` | Large stdout is truncated |
| `test_run_code_large_stderr_is_truncated` | Large stderr is truncated |
| `test_tool_name_is_python_repl` | Tool descriptor name |
| `test_tool_schema_requires_code` | `code` is a required parameter |
| `test_tool_schema_pip_install_is_array_of_strings` | `pip_install` schema type |
| `test_missing_code_param_returns_validation_error` | Missing `code` → `phase: validation` |
| `test_run_print_returns_stdout` | Full tool call pipeline |
| `test_pip_install_failure_returns_phase_pip_install` | pip failure → `phase: pip_install` |

### E2E integration test (`#[ignore = "requires uv + network + OPENAI_API_KEY"]`)

`test_python_repl_numpy_matplotlib_chart` (`src/agent/rt/agent.rs`):

1. Asks `gpt-4o-mini` to generate sine wave data with numpy and save a chart to a file using matplotlib
2. Verifies that the `python_repl` tool was called
3. Verifies `exit_code == 0` for all tool calls
4. Verifies the chart file exists
5. Validates PNG magic bytes (`\x89PNG\r\n\x1a\n`)
6. Verifies a final Assistant text response is present
