### PR TITLE
fix: make `FileDyn` and `Directory` Sendable

### DIFF
--- a/src/shell/fs/filesystem.rs
+++ b/src/shell/fs/filesystem.rs
@@ -1,7 +1,9 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::io::{Read, Seek, SeekFrom, Write as IoWrite};
-use std::path::PathBuf;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    io::{Read, Seek, SeekFrom, Write as IoWrite},
+    path::PathBuf,
+};
 
 use crate::shell::fs::{DirEntry, Directory, File, FileHandle, Node, NodeKind, Stat};
 
@@ -10,11 +12,13 @@ use crate::shell::fs::{DirEntry, Directory, File, FileHandle, Node, NodeKind, St
 // ---------------------------------------------------------------------------
 
 /// A [`File`] node backed by a real file on disk.
+#[allow(unused)]
 pub struct FileSystemFile {
     path: PathBuf,
 }
 
 impl FileSystemFile {
+    #[allow(unused)]
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
@@ -130,6 +134,7 @@ impl FileHandle for FileSystemFileHandle {
 ///     Node::Directory(Box::new(FileSystemDir::new(PathBuf::from("/tmp/data")))),
 /// );
 /// ```
+#[allow(unused)]
 pub struct FileSystemDir {
     path: PathBuf,
     /// Nodes created on demand so that `get_child` can return `&Node`.
@@ -139,6 +144,7 @@ pub struct FileSystemDir {
 }
 
 impl FileSystemDir {
+    #[allow(unused)]
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
@@ -146,6 +152,7 @@ impl FileSystemDir {
         }
     }
 
+    #[allow(unused)]
     fn is_readonly(&self) -> bool {
         std::fs::metadata(&self.path)
             .map(|m| m.permissions().readonly())
@@ -153,6 +160,7 @@ impl FileSystemDir {
     }
 
     /// Build a [`Node`] for the child named `name` if it exists on disk.
+    #[allow(unused)]
     fn make_node(&self, name: &str) -> Option<Node> {
         let child_path = self.path.join(name);
         if child_path.is_dir() {

--- a/src/shell/fs/mod.rs
+++ b/src/shell/fs/mod.rs
@@ -2,6 +2,7 @@ mod filesystem;
 mod in_memory;
 mod node;
 
+#[allow(unused)]
 pub use filesystem::*;
 pub use in_memory::*;
 pub use node::*;

--- a/src/shell/fs/node.rs
+++ b/src/shell/fs/node.rs
@@ -56,7 +56,7 @@ pub trait File {
 /// blanket implementation of `FileDyn` for free.
 ///
 /// This trait is what [`Node::File`] stores.
-pub trait FileDyn {
+pub trait FileDyn: Send {
     /// Open the file and return a type-erased handle.
     ///
     /// The `'_` lifetime on the return type is tied to `&mut self`, so the
@@ -66,7 +66,7 @@ pub trait FileDyn {
     fn stat_dyn(&self) -> Stat;
 }
 
-impl<T: File> FileDyn for T {
+impl<T: File + Send> FileDyn for T {
     fn open_dyn(&mut self) -> Box<dyn FileHandle + '_> {
         Box::new(self.open())
     }
@@ -110,7 +110,7 @@ pub struct DirEntry {
 }
 
 /// POSIX-like interface for a directory node.
-pub trait Directory {
+pub trait Directory: Send {
     /// Return metadata for every direct child, analogous to `readdir(3)`.
     fn readdir(&self) -> Vec<DirEntry>;
 
@@ -139,8 +139,8 @@ pub trait Directory {
 /// same open/stat interface with the handle type erased to
 /// `Box<dyn FileHandle + '_>`.
 pub enum Node {
-    File(Box<dyn FileDyn>),
-    Directory(Box<dyn Directory>),
+    File(Box<dyn FileDyn + Send>),
+    Directory(Box<dyn Directory + Send>),
 }
 
 impl Node {

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -1,8 +1,7 @@
+use super::fs::{Directory, InMemoryDir, Node};
 use crate::shell::command::{
     ExecOutput, run_cat, run_cp, run_ls, run_mkdir, run_mv, run_pwd, run_rm, run_rmdir,
 };
-
-use super::fs::{Directory, InMemoryDir, Node};
 
 pub struct Shell {
     pub(super) cwd: Vec<String>,


### PR DESCRIPTION
Due to the lack of `Send` in `FileDyn` and `Directory`, it makes the whole `AgentRuntime` un-Sendable.
This PR adds `Send` to `FileDyn` and `Directory`, and it's safe since the members of structs implementing `FileDyn` and `Directory` are all owned data type.