### PR TITLE
fix: use rustls-tls for reqwest to avoid OpenSSL/BoringSSL linker conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ log = "0.4"
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 rmcp = { version = "0.11.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 scraper = "0.24"
 schemars = { version = "0.8", features = ["preserve_order", "url"] }


### PR DESCRIPTION
## Summary
- Disable default features on `reqwest` and switch TLS backend to `rustls-tls`
- Fixes linker errors (`undefined symbol: SSL_CTX_ctrl`, etc.) caused by `openssl-sys` (from `reqwest` default `native-tls`) conflicting with `boring-sys2` (from `wreq`)
