### PR TITLE
refactor: move max_tokens from LangModelInferConfig into LangModelPro…

### DIFF
--- a/src/agent/rt/agent.rs
+++ b/src/agent/rt/agent.rs
@@ -141,7 +141,7 @@ impl AgentRuntime {
             let tool_descs: Vec<_> = self.tools.iter().map(|t| t.desc().clone()).collect();
 
             loop {
-                let output = match self.lm.run(&self.state.history, &tool_descs, &Default::default()).await {
+                let output = match self.lm.run(&self.state.history, &tool_descs).await {
                     Ok(o) => o,
                     Err(e) => {
                         yield Err(e);

--- a/src/agent/rt/lang_model/api/anthropic.rs
+++ b/src/agent/rt/lang_model/api/anthropic.rs
@@ -18,6 +18,7 @@ impl LangModelProvider {
             schema: LangModelAPISchema::Anthropic,
             url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
             api_key: Some(api_key),
+            max_tokens: None,
         }
     }
 }
@@ -199,7 +200,7 @@ impl Marshal<LangModelRequest<'_>> for AnthropicMarshal {
         );
 
         // Anthropic requires an explicit max_tokens value, so we set it as 8192
-        let max_tokens = req.infer_config.max_tokens.unwrap_or(8192) as i64;
+        let max_tokens = req.max_tokens.unwrap_or(8192) as i64;
         let mut body = to_value!({
             "model": model,
             "max_tokens": max_tokens,
@@ -352,11 +353,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    fn with_req<F, R>(model: &str, max_tokens: Option<u64>, f: F) -> R
     where
         F: FnOnce(&LangModelRequest<'_>) -> R,
     {
@@ -370,31 +371,24 @@ mod tests {
             tools: &tools,
             url: &url,
             api_key: &api_key,
-            infer_config: &infer_config,
+            max_tokens,
         };
         f(&req)
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        with_req(
-            "claude-haiku-4-5",
-            LangModelInferConfig {
-                max_tokens: Some(512),
-                ..Default::default()
-            },
-            |req| {
-                let val = AnthropicMarshal::default().marshal(req);
-                let body = val.as_object().unwrap().get("body").unwrap();
-                let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
-                assert_eq!(max_tokens.as_integer().unwrap(), 512);
-            },
-        );
+        with_req("claude-haiku-4-5", Some(512), |req| {
+            let val = AnthropicMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
+            assert_eq!(max_tokens.as_integer().unwrap(), 512);
+        });
     }
 
     #[test]
     fn test_marshal_max_tokens_default() {
-        with_req("claude-haiku-4-5", LangModelInferConfig::default(), |req| {
+        with_req("claude-haiku-4-5", None, |req| {
             let val = AnthropicMarshal::default().marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
@@ -412,19 +406,20 @@ mod tests {
 
         let lm = LangModelRuntime::new(
             "claude-haiku-4-5".to_string(),
-            LangModelProvider::anthropic(api_key),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::Anthropic,
+                url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
+                api_key: Some(api_key),
+                max_tokens: Some(5),
+            },
         );
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("Tell me a long story about a dragon.")]),
         ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig {
-            max_tokens: Some(5),
-            ..Default::default()
-        };
 
-        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/chat_completion.rs
+++ b/src/agent/rt/lang_model/api/chat_completion.rs
@@ -17,6 +17,7 @@ impl LangModelProvider {
             schema: LangModelAPISchema::ChatCompletion,
             url: Url::parse("https://api.x.ai/v1/chat/completions").unwrap(),
             api_key: Some(api_key),
+            max_tokens: None,
         }
     }
 
@@ -25,6 +26,7 @@ impl LangModelProvider {
             schema: LangModelAPISchema::ChatCompletion,
             url: Url::parse(url)?,
             api_key,
+            max_tokens: None,
         })
     }
 }
@@ -156,7 +158,7 @@ impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
                 .unwrap()
                 .insert("tools".to_owned(), tools);
         }
-        if let Some(max_tokens) = req.infer_config.max_tokens {
+        if let Some(max_tokens) = req.max_tokens {
             body.as_object_mut().unwrap().insert(
                 "max_completion_tokens".to_owned(),
                 (max_tokens as i64).into(),
@@ -303,11 +305,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    fn with_req<F, R>(model: &str, max_tokens: Option<u64>, f: F) -> R
     where
         F: FnOnce(&LangModelRequest<'_>) -> R,
     {
@@ -321,35 +323,28 @@ mod tests {
             tools: &tools,
             url: &url,
             api_key: &api_key,
-            infer_config: &infer_config,
+            max_tokens,
         };
         f(&req)
     }
 
     #[test]
     fn test_marshal_max_tokens_set() {
-        with_req(
-            "gpt-4.1-mini",
-            LangModelInferConfig {
-                max_tokens: Some(256),
-                ..Default::default()
-            },
-            |req| {
-                let val = ChatCompletionMarshal::default().marshal(req);
-                let body = val.as_object().unwrap().get("body").unwrap();
-                let max_tokens = body
-                    .as_object()
-                    .unwrap()
-                    .get("max_completion_tokens")
-                    .unwrap();
-                assert_eq!(max_tokens.as_integer().unwrap(), 256);
-            },
-        );
+        with_req("gpt-4.1-mini", Some(256), |req| {
+            let val = ChatCompletionMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            let max_tokens = body
+                .as_object()
+                .unwrap()
+                .get("max_completion_tokens")
+                .unwrap();
+            assert_eq!(max_tokens.as_integer().unwrap(), 256);
+        });
     }
 
     #[test]
     fn test_marshal_max_tokens_absent_when_none() {
-        with_req("gpt-4.1-mini", LangModelInferConfig::default(), |req| {
+        with_req("gpt-4.1-mini", None, |req| {
             let val = ChatCompletionMarshal::default().marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(
@@ -369,23 +364,20 @@ mod tests {
 
         let lm = LangModelRuntime::new(
             "gpt-4.1-mini".to_string(),
-            LangModelProvider::chat_completion(
-                "https://api.openai.com/v1/chat/completions",
-                Some(api_key),
-            )
-            .unwrap(),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::ChatCompletion,
+                url: Url::parse("https://api.openai.com/v1/chat/completions").unwrap(),
+                api_key: Some(api_key),
+                max_tokens: Some(32),
+            },
         );
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("Tell me a long story about a dragon.")]),
         ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig {
-            max_tokens: Some(32),
-            ..Default::default()
-        };
 
-        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/gemini.rs
+++ b/src/agent/rt/lang_model/api/gemini.rs
@@ -18,6 +18,7 @@ impl LangModelProvider {
             schema: LangModelAPISchema::Gemini,
             url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap(),
             api_key: Some(api_key),
+            max_tokens: None,
         }
     }
 }
@@ -204,7 +205,7 @@ impl Marshal<LangModelRequest<'_>> for GeminiMarshal {
         if !tools.is_null() {
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
-        if let Some(max_tokens) = req.infer_config.max_tokens {
+        if let Some(max_tokens) = req.max_tokens {
             body.as_object_mut().unwrap().insert(
                 "generationConfig".into(),
                 to_value!({"maxOutputTokens": max_tokens as i64}),
@@ -348,11 +349,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    fn with_req<F, R>(model: &str, max_tokens: Option<u64>, f: F) -> R
     where
         F: FnOnce(&LangModelRequest<'_>) -> R,
     {
@@ -366,44 +367,33 @@ mod tests {
             tools: &tools,
             url: &url,
             api_key: &api_key,
-            infer_config: &infer_config,
+            max_tokens,
         };
         f(&req)
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        with_req(
-            "gemini-2.5-flash-lite",
-            LangModelInferConfig {
-                max_tokens: Some(2048),
-                ..Default::default()
-            },
-            |req| {
-                let val = GeminiMarshal::default().marshal(req);
-                let body = val.as_object().unwrap().get("body").unwrap();
-                let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
-                let max_tokens = gen_config
-                    .as_object()
-                    .unwrap()
-                    .get("maxOutputTokens")
-                    .unwrap();
-                assert_eq!(max_tokens.as_integer().unwrap(), 2048);
-            },
-        );
+        with_req("gemini-2.5-flash-lite", Some(2048), |req| {
+            let val = GeminiMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
+            let max_tokens = gen_config
+                .as_object()
+                .unwrap()
+                .get("maxOutputTokens")
+                .unwrap();
+            assert_eq!(max_tokens.as_integer().unwrap(), 2048);
+        });
     }
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        with_req(
-            "gemini-2.5-flash-lite",
-            LangModelInferConfig::default(),
-            |req| {
-                let val = GeminiMarshal::default().marshal(req);
-                let body = val.as_object().unwrap().get("body").unwrap();
-                assert!(body.as_object().unwrap().get("generationConfig").is_none());
-            },
-        );
+        with_req("gemini-2.5-flash-lite", None, |req| {
+            let val = GeminiMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            assert!(body.as_object().unwrap().get("generationConfig").is_none());
+        });
     }
 
     /// Verifies that max_tokens is respected by the Gemini API (finishReason: MAX_TOKENS).
@@ -414,19 +404,21 @@ mod tests {
 
         let lm = LangModelRuntime::new(
             "gemini-2.5-flash-lite".to_string(),
-            LangModelProvider::gemini(api_key),
+            LangModelProvider::API {
+                schema: LangModelAPISchema::Gemini,
+                url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/")
+                    .unwrap(),
+                api_key: Some(api_key),
+                max_tokens: Some(5),
+            },
         );
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("Tell me a long story about a dragon.")]),
         ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig {
-            max_tokens: Some(5),
-            ..Default::default()
-        };
 
-        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }
 }

--- a/src/agent/rt/lang_model/api/openai.rs
+++ b/src/agent/rt/lang_model/api/openai.rs
@@ -17,6 +17,7 @@ impl LangModelProvider {
             schema: LangModelAPISchema::OpenAI,
             url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
             api_key: Some(api_key),
+            max_tokens: None,
         }
     }
 }
@@ -183,7 +184,7 @@ impl Marshal<LangModelRequest<'_>> for OpenAIMarshal {
                 .insert("tool_choice".into(), to_value!("auto"));
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
-        if let Some(max_tokens) = req.infer_config.max_tokens {
+        if let Some(max_tokens) = req.max_tokens {
             body.as_object_mut()
                 .unwrap()
                 .insert("max_output_tokens".into(), (max_tokens as i64).into());
@@ -341,11 +342,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider, LangModelRuntime},
+        agent::{LangModelAPISchema, LangModelProvider, LangModelRuntime},
         message::{FinishReason, Message, Part, Role, ToolDesc},
     };
 
-    fn with_req<F, R>(model: &str, infer_config: LangModelInferConfig, f: F) -> R
+    fn with_req<F, R>(model: &str, max_tokens: Option<u64>, f: F) -> R
     where
         F: FnOnce(&LangModelRequest<'_>) -> R,
     {
@@ -359,31 +360,24 @@ mod tests {
             tools: &tools,
             url: &url,
             api_key: &api_key,
-            infer_config: &infer_config,
+            max_tokens,
         };
         f(&req)
     }
 
     #[test]
     fn test_marshal_max_output_tokens_set() {
-        with_req(
-            "gpt-5.4-mini",
-            LangModelInferConfig {
-                max_tokens: Some(1024),
-                ..Default::default()
-            },
-            |req| {
-                let val = OpenAIMarshal::default().marshal(req);
-                let body = val.as_object().unwrap().get("body").unwrap();
-                let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
-                assert_eq!(max_tokens.as_integer().unwrap(), 1024);
-            },
-        );
+        with_req("gpt-5.4-mini", Some(1024), |req| {
+            let val = OpenAIMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
+            assert_eq!(max_tokens.as_integer().unwrap(), 1024);
+        });
     }
 
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
-        with_req("gpt-5.4-mini", LangModelInferConfig::default(), |req| {
+        with_req("gpt-5.4-mini", None, |req| {
             let val = OpenAIMarshal::default().marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
@@ -397,13 +391,13 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set in .env");
 
-        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
         let lm = LangModelRuntime::new(
             "gpt-5.4-mini".to_string(),
             LangModelProvider::API {
                 schema: LangModelAPISchema::OpenAI,
-                url,
+                url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
                 api_key: Some(api_key),
+                max_tokens: Some(16),
             },
         );
         let messages = vec![
@@ -411,12 +405,8 @@ mod tests {
                 .with_contents([Part::text("Tell me a long story about a dragon.")]),
         ];
         let tools: Vec<ToolDesc> = vec![];
-        let config = LangModelInferConfig {
-            max_tokens: Some(16),
-            ..Default::default()
-        };
 
-        let resp = lm.run(&messages, &tools, &config).await.unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
         println!("{}", resp);
         assert_eq!(resp.finish_reason, FinishReason::Length {});
     }

--- a/src/agent/rt/lang_model/mod.rs
+++ b/src/agent/rt/lang_model/mod.rs
@@ -4,7 +4,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use url::Url;
 
 use crate::{
-    agent::{LangModelAPISchema, LangModelInferConfig, LangModelProvider},
+    agent::{LangModelAPISchema, LangModelProvider},
     datatype::Value,
     message::{Delta as _, Marshaled, Message, MessageOutput, ToolDesc, Unmarshal as _},
 };
@@ -21,7 +21,7 @@ struct LangModelRequest<'a> {
     pub tools: &'a [ToolDesc],
     pub url: &'a Url,
     pub api_key: &'a Option<String>,
-    pub infer_config: &'a LangModelInferConfig,
+    pub max_tokens: Option<u64>,
 }
 
 impl LangModelRuntime {
@@ -33,13 +33,13 @@ impl LangModelRuntime {
         &self,
         messages: &[Message],
         tools: &[ToolDesc],
-        infer_config: &LangModelInferConfig,
     ) -> anyhow::Result<MessageOutput> {
         match &self.provider {
             LangModelProvider::API {
                 schema,
                 url,
                 api_key,
+                max_tokens,
             } => {
                 // Create request
                 let req = LangModelRequest {
@@ -48,7 +48,7 @@ impl LangModelRuntime {
                     tools,
                     url,
                     api_key,
-                    infer_config,
+                    max_tokens: *max_tokens,
                 };
 
                 let req = match schema {
@@ -170,10 +170,7 @@ mod tests {
         let messages = vec![Message::new(Role::User).with_contents([Part::text("Hi")])];
         let tools: Vec<ToolDesc> = vec![];
 
-        let resp = lm
-            .run(&messages, &tools, &Default::default())
-            .await
-            .unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
         assert!(
             !resp.message.contents.is_empty(),
             "Expected at least one message content"
@@ -216,10 +213,7 @@ mod tests {
                 .build(),
         ];
 
-        let resp = lm
-            .run(&messages, &tools, &Default::default())
-            .await
-            .unwrap();
+        let resp = lm.run(&messages, &tools).await.unwrap();
 
         // The model should respond with a tool call
         assert_eq!(resp.finish_reason, FinishReason::ToolCall {});

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -2,16 +2,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-/// Inference-time parameters forwarded to the language model on each call.
-///
-/// All fields are optional. When a field is `None`, provider-specific defaults apply
-/// (e.g. Anthropic defaults `max_tokens` to 8192 because it is a required API field).
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct LangModelInferConfig {
-    /// Maximum number of tokens the model may generate in a single response.
-    pub max_tokens: Option<u64>,
-}
-
 /// Defines the logical identity of an agent as configured by the user.
 ///
 /// `AgentSpec` captures what makes an agent distinct — the language model it uses,
@@ -78,6 +68,11 @@ pub enum LangModelProvider {
         url: Url,
 
         api_key: Option<String>,
+
+        /// Maximum number of tokens the model may generate in a single response.
+        /// When `None`, provider-specific defaults apply (e.g. Anthropic defaults to 8192).
+        #[serde(default)]
+        max_tokens: Option<u64>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod shell;
 
 pub use agent::{
     AgentProvider, AgentRuntime, AgentSpec, BuiltinToolProvider, LangModelAPISchema,
-    LangModelInferConfig, LangModelProvider, MCPToolProvider, ToolAsyncFunc, ToolProvider,
-    ToolRuntime, ToolSet, ToolStreamingFunc, ToolSyncFunc, TurnEvent,
+    LangModelProvider, MCPToolProvider, ToolAsyncFunc, ToolProvider, ToolRuntime, ToolSet,
+    ToolStreamingFunc, ToolSyncFunc, TurnEvent,
 };
 pub use datatype::Value;
 pub use message::{


### PR DESCRIPTION
Remove the separate `LangModelInferConfig` struct and fold `max_tokens` directly into `LangModelProvider::API`. This eliminates an extra parameter from `LangModelRuntime::run()` and makes inference config part of the provider declaration rather than a per-call argument.