### PR TITLE
Add base for `python_source_tool` & builtin tool `convert_pdf_to_md`

### DIFF
--- a/src/agent/rt/tool/convert_pdf_to_md.rs
+++ b/src/agent/rt/tool/convert_pdf_to_md.rs
@@ -8,7 +8,7 @@ use anyhow::Context as _;
 
 use crate::{
     agent::rt::tool::{
-        ToolFunc, ToolKind, ToolRuntime,
+        ToolAsyncFunc, ToolKind, ToolRuntime,
         python_repl::{PythonReplConfig, PythonSourceToolConfig, build_python_source_tool},
     },
     datatype::Value,
@@ -97,7 +97,7 @@ pub async fn build_convert_pdf_to_md_tool() -> anyhow::Result<ToolRuntime> {
     let python_tool = Arc::new(build_convert_pdf_to_md_python_tool().await?);
     let desc = convert_pdf_to_md_tool_desc();
 
-    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+    let f: Arc<ToolAsyncFunc> = Arc::new(move |args: Value| {
         let python_tool = python_tool.clone();
         Box::pin(async move {
             let pdf_path = match validate_pdf_path(&args) {
@@ -145,7 +145,7 @@ pub async fn build_convert_pdf_to_md_tool() -> anyhow::Result<ToolRuntime> {
         })
     });
 
-    Ok(ToolRuntime::new_with_kind(desc, f, ToolKind::Builtin))
+    Ok(ToolRuntime::new_async_with_kind(desc, f, ToolKind::Builtin))
 }
 
 async fn build_convert_pdf_to_md_python_tool() -> anyhow::Result<ToolRuntime> {

--- a/src/agent/rt/tool/convert_pdf_to_md.rs
+++ b/src/agent/rt/tool/convert_pdf_to_md.rs
@@ -1,0 +1,537 @@
+use std::{
+    io::Read as _,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Context as _;
+
+use crate::{
+    agent::rt::tool::{
+        ToolFunc, ToolKind, ToolRuntime,
+        python_repl::{PythonReplConfig, PythonSourceToolConfig, build_python_source_tool},
+    },
+    datatype::Value,
+    message::{Part, ToolDesc, ToolDescBuilder},
+};
+
+const TOOL_NAME: &str = "convert_pdf_to_md";
+const DOCLING_PACKAGE: &str = "docling>=2,<3";
+const PYTHON_VERSION: &str = "3.12";
+const CONVERSION_TIMEOUT_SECS: u64 = 600;
+const DOCLING_SOURCE: &str = r#"
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+logging.getLogger("docling").setLevel(logging.CRITICAL)
+
+
+def build_converter():
+    from docling.datamodel.base_models import InputFormat
+    from docling.datamodel.pipeline_options import (
+        PdfPipelineOptions,
+        TableStructureOptions,
+    )
+    from docling.document_converter import DocumentConverter, PdfFormatOption
+
+    pipeline_options = PdfPipelineOptions(
+        do_ocr=False,
+        do_table_structure=True,
+        table_structure_options=TableStructureOptions(
+            do_cell_matching=True,
+            mode="accurate",
+        ),
+        accelerator_options={"num_threads": 4, "device": "auto"},
+        do_picture_classification=False,
+        do_picture_description=False,
+        do_chart_extraction=False,
+        do_code_enrichment=False,
+        do_formula_enrichment=False,
+        generate_page_images=False,
+        generate_picture_images=False,
+    )
+    return DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+        }
+    )
+
+
+def load_args():
+    args_path = os.environ.get("AILOY_ARGS_JSON_PATH", "")
+    if not args_path:
+        raise ValueError("missing AILOY_ARGS_JSON_PATH")
+    return json.loads(Path(args_path).read_text(encoding="utf-8"))
+
+
+def main():
+    args = load_args()
+    raw_pdf_path = args.get("pdf_path")
+    if not isinstance(raw_pdf_path, str) or not raw_pdf_path.strip():
+        raise ValueError("`pdf_path` must be a non-empty string")
+
+    pdf_path = Path(raw_pdf_path)
+    markdown = build_converter().convert(pdf_path).document.export_to_markdown()
+    size_chars = len(markdown)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".md",
+        prefix="convert_pdf_to_md-",
+        delete=False,
+        encoding="utf-8",
+    ) as fp:
+        fp.write(markdown)
+        md_path = str(Path(fp.name).resolve())
+    print(json.dumps({"md_path": md_path, "size_chars": size_chars}, ensure_ascii=False), end="")
+
+
+if __name__ == "__main__":
+    main()
+"#;
+
+pub async fn build_convert_pdf_to_md_tool() -> anyhow::Result<ToolRuntime> {
+    let python_tool = Arc::new(build_convert_pdf_to_md_python_tool().await?);
+    let desc = convert_pdf_to_md_tool_desc();
+
+    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+        let python_tool = python_tool.clone();
+        Box::pin(async move {
+            let pdf_path = match validate_pdf_path(&args) {
+                Ok(path) => path,
+                Err(err) => return err,
+            };
+
+            let tool_call = Part::function_with_id(
+                "convert-pdf-to-md-internal",
+                TOOL_NAME,
+                crate::to_value!({
+                    "pdf_path": pdf_path.to_string_lossy().to_string()
+                }),
+            );
+
+            match python_tool.run(tool_call).await {
+                Ok(msg) => {
+                    let value = match msg.contents.first().and_then(|part| part.as_value()) {
+                        Some(value) => value,
+                        None => {
+                            return error_value(
+                                &pdf_path.to_string_lossy(),
+                                "execution",
+                                "python source tool returned no value payload",
+                            );
+                        }
+                    };
+
+                    if value.is_object() {
+                        return value.clone();
+                    }
+
+                    error_value(
+                        &pdf_path.to_string_lossy(),
+                        "execution",
+                        "python source tool returned unexpected payload type",
+                    )
+                }
+                Err(err) => error_value(
+                    &pdf_path.to_string_lossy(),
+                    "execution",
+                    &format!("failed to run python source tool: {err}"),
+                ),
+            }
+        })
+    });
+
+    Ok(ToolRuntime::new_with_kind(desc, f, ToolKind::Builtin))
+}
+
+async fn build_convert_pdf_to_md_python_tool() -> anyhow::Result<ToolRuntime> {
+    build_python_source_tool(
+        convert_pdf_to_md_tool_desc(),
+        convert_pdf_to_md_tool_config()?,
+    )
+    .await
+}
+
+fn convert_pdf_to_md_tool_config() -> anyhow::Result<PythonSourceToolConfig> {
+    Ok(PythonSourceToolConfig::new(DOCLING_SOURCE)
+        .python(PythonReplConfig {
+            python_version: Some(PYTHON_VERSION.to_string()),
+            venv_path: Some(docling_venv_path()?.to_string_lossy().into_owned()),
+            packages: vec![DOCLING_PACKAGE.to_string()],
+        })
+        .timeout_secs(CONVERSION_TIMEOUT_SECS))
+}
+
+fn convert_pdf_to_md_tool_desc() -> ToolDesc {
+    let mut desc = ToolDescBuilder::new(TOOL_NAME)
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "pdf_path": {
+                    "type": "string",
+                    "description": "Path to the PDF file to convert"
+                }
+            },
+            "required": ["pdf_path"]
+        }))
+        .build();
+    desc.description = Some("Convert a local PDF file to Markdown using Docling.".to_string());
+    desc.returns = Some(crate::to_value!({
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "md_path": { "type": "string" },
+                    "size_chars": { "type": "integer", "minimum": 0 }
+                },
+                "required": ["md_path", "size_chars"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "pdf_path": { "type": "string" },
+                    "error": { "type": "string" },
+                    "phase": { "type": "string" }
+                },
+                "required": ["error", "phase"]
+            }
+        ]
+    }));
+    desc
+}
+
+fn docling_venv_path() -> anyhow::Result<PathBuf> {
+    Ok(dirs::cache_dir()
+        .context("cannot determine cache directory")?
+        .join("ailoy")
+        .join("venvs")
+        .join("docling"))
+}
+
+fn validate_pdf_path(args: &Value) -> Result<PathBuf, Value> {
+    let raw_path = args
+        .pointer("/pdf_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if raw_path.is_empty() {
+        return Err(error_value(
+            "",
+            "validation",
+            "missing required parameter: pdf_path",
+        ));
+    }
+
+    let resolved = match resolve_input_path(&raw_path) {
+        Ok(path) => path,
+        Err(err) => {
+            return Err(error_value(&raw_path, "validation", &err.to_string()));
+        }
+    };
+    let resolved_string = resolved.to_string_lossy().into_owned();
+
+    if !resolved.exists() {
+        return Err(error_value(
+            &resolved_string,
+            "validation",
+            "input path does not exist",
+        ));
+    }
+    if !resolved.is_file() {
+        return Err(error_value(
+            &resolved_string,
+            "validation",
+            "input path must be a file",
+        ));
+    }
+
+    let canonical = match resolved.canonicalize() {
+        Ok(path) => path,
+        Err(err) => {
+            return Err(error_value(
+                &resolved_string,
+                "validation",
+                &format!("failed to canonicalize input path: {err}"),
+            ));
+        }
+    };
+    let canonical_string = canonical.to_string_lossy().into_owned();
+
+    match is_pdf_file(&canonical) {
+        Ok(true) => Ok(canonical),
+        Ok(false) => Err(error_value(
+            &canonical_string,
+            "validation",
+            "input path must be a PDF file",
+        )),
+        Err(err) => Err(error_value(
+            &canonical_string,
+            "validation",
+            &format!("failed to read input file: {err}"),
+        )),
+    }
+}
+
+fn resolve_input_path(raw_path: &str) -> anyhow::Result<PathBuf> {
+    let expanded = shellexpand::tilde(raw_path).into_owned();
+    let path = PathBuf::from(expanded);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(std::env::current_dir()
+            .context("failed to get current working directory")?
+            .join(path))
+    }
+}
+
+fn is_pdf_file(path: &Path) -> std::io::Result<bool> {
+    let mut file = std::fs::File::open(path)?;
+    let mut header = [0_u8; 5];
+    match file.read_exact(&mut header) {
+        Ok(()) => Ok(&header == b"%PDF-"),
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn error_value(pdf_path: &str, phase: &str, error: &str) -> Value {
+    crate::to_value!({
+        "pdf_path": pdf_path,
+        "error": error,
+        "phase": phase
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::{BuiltinToolProvider, ToolSet},
+        message::Part,
+    };
+
+    fn write_minimal_pdf(path: &Path, text: &str) {
+        let text = escape_pdf_string(text);
+        let stream = format!("BT\n/F1 24 Tf\n72 100 Td\n({text}) Tj\nET");
+        let objects = vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>".to_string(),
+            format!("<< /Length {} >>\nstream\n{stream}\nendstream", stream.len()),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        ];
+
+        let mut pdf = Vec::from("%PDF-1.4\n".as_bytes());
+        let mut offsets = Vec::with_capacity(objects.len());
+
+        for (index, object) in objects.iter().enumerate() {
+            offsets.push(pdf.len());
+            pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", index + 1, object).as_bytes());
+        }
+
+        let xref_offset = pdf.len();
+        pdf.extend_from_slice(
+            format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+        );
+        for offset in offsets {
+            pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        pdf.extend_from_slice(
+            format!(
+                "trailer\n<< /Root 1 0 R /Size {} >>\nstartxref\n{}\n%%EOF\n",
+                objects.len() + 1,
+                xref_offset
+            )
+            .as_bytes(),
+        );
+
+        std::fs::write(path, pdf).expect("failed to write test pdf");
+    }
+
+    fn escape_pdf_string(text: &str) -> String {
+        text.replace('\\', "\\\\")
+            .replace('(', "\\(")
+            .replace(')', "\\)")
+    }
+
+    #[test]
+    fn test_convert_pdf_to_md_tool_desc_sets_name_schema_and_returns() {
+        let desc = convert_pdf_to_md_tool_desc();
+
+        assert_eq!(desc.name, TOOL_NAME);
+        assert_eq!(
+            desc.parameters
+                .pointer("/required/0")
+                .and_then(|v| v.as_str()),
+            Some("pdf_path")
+        );
+        assert_eq!(
+            desc.description.as_deref(),
+            Some("Convert a local PDF file to Markdown using Docling.")
+        );
+        assert_eq!(
+            desc.returns
+                .as_ref()
+                .and_then(|v| v.pointer("/oneOf/0/required/0"))
+                .and_then(|v| v.as_str()),
+            Some("md_path")
+        );
+    }
+
+    #[test]
+    fn test_convert_pdf_to_md_tool_config_sets_runtime_and_docling() {
+        let config = convert_pdf_to_md_tool_config().expect("failed to build config");
+
+        assert_eq!(config.timeout_secs, CONVERSION_TIMEOUT_SECS);
+        assert_eq!(
+            config.python.python_version.as_deref(),
+            Some(PYTHON_VERSION)
+        );
+        assert_eq!(
+            config.python.packages.as_slice(),
+            &[DOCLING_PACKAGE.to_string()]
+        );
+        assert_eq!(
+            config.python.venv_path.as_deref(),
+            Some(docling_venv_path().unwrap().to_string_lossy().as_ref())
+        );
+        assert!(config.source.contains("DocumentConverter"));
+        assert!(config.source.contains("export_to_markdown"));
+        assert!(config.source.contains("NamedTemporaryFile"));
+        assert!(config.source.contains("\"md_path\""));
+    }
+
+    #[test]
+    fn test_missing_pdf_path_returns_validation_error() {
+        let err = validate_pdf_path(&crate::to_value!({})).unwrap_err();
+        assert_eq!(
+            err.pointer("/phase").and_then(|v| v.as_str()),
+            Some("validation")
+        );
+        assert_eq!(
+            err.pointer("/error").and_then(|v| v.as_str()),
+            Some("missing required parameter: pdf_path")
+        );
+    }
+
+    #[test]
+    fn test_nonexistent_pdf_path_returns_validation_error() {
+        let err = validate_pdf_path(&crate::to_value!({
+            "pdf_path": "definitely-missing-file.pdf"
+        }))
+        .unwrap_err();
+        assert_eq!(
+            err.pointer("/phase").and_then(|v| v.as_str()),
+            Some("validation")
+        );
+        assert_eq!(
+            err.pointer("/error").and_then(|v| v.as_str()),
+            Some("input path does not exist")
+        );
+    }
+
+    #[test]
+    fn test_directory_path_returns_validation_error() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let err = validate_pdf_path(&crate::to_value!({
+            "pdf_path": dir.path().to_string_lossy().to_string()
+        }))
+        .unwrap_err();
+        assert_eq!(
+            err.pointer("/phase").and_then(|v| v.as_str()),
+            Some("validation")
+        );
+        assert_eq!(
+            err.pointer("/error").and_then(|v| v.as_str()),
+            Some("input path must be a file")
+        );
+    }
+
+    #[test]
+    fn test_non_pdf_file_returns_validation_error() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("note.txt");
+        std::fs::write(&path, "not a pdf").expect("failed to write test file");
+
+        let err = validate_pdf_path(&crate::to_value!({
+            "pdf_path": path.to_string_lossy().to_string()
+        }))
+        .unwrap_err();
+
+        assert_eq!(
+            err.pointer("/phase").and_then(|v| v.as_str()),
+            Some("validation")
+        );
+        assert_eq!(
+            err.pointer("/error").and_then(|v| v.as_str()),
+            Some("input path must be a PDF file")
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    #[ignore = "requires real uv + docling installation"]
+    async fn test_builtin_provider_registers_convert_pdf_to_md() {
+        let tool_set = ToolSet::new()
+            .with_builtin(&BuiltinToolProvider::ConvertPdfToMd {})
+            .await
+            .expect("failed to build builtin tool");
+
+        assert!(tool_set.get(TOOL_NAME).is_some());
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    #[ignore = "requires docling installation and model artifacts"]
+    async fn test_convert_pdf_to_md_smoke() {
+        let tool = build_convert_pdf_to_md_tool()
+            .await
+            .expect("failed to build convert_pdf_to_md tool");
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let pdf_path = dir.path().join("hello.pdf");
+        write_minimal_pdf(&pdf_path, "Hello Docling");
+
+        let call = Part::function_with_id(
+            "call-1",
+            TOOL_NAME,
+            crate::to_value!({
+                "pdf_path": pdf_path.to_string_lossy().to_string()
+            }),
+        );
+        let msg = tool.run(call).await.expect("tool call failed");
+        let value = msg.contents[0].as_value().expect("expected value response");
+
+        assert!(
+            value.is_object(),
+            "expected object response, got: {value:?}"
+        );
+        let md_path = value
+            .pointer("/md_path")
+            .and_then(|v| v.as_str())
+            .expect("expected md_path in success result");
+        let markdown = std::fs::read_to_string(md_path).expect("failed to read markdown file");
+        let size_chars = value
+            .pointer("/size_chars")
+            .and_then(|v| v.as_integer())
+            .expect("expected size_chars in success result");
+        assert_eq!(
+            size_chars,
+            markdown.chars().count() as i64,
+            "size_chars should match markdown character count",
+        );
+
+        assert!(!markdown.trim().is_empty(), "markdown should not be empty");
+        assert!(
+            markdown.to_lowercase().contains("hello")
+                || markdown.to_lowercase().contains("docling"),
+            "markdown should contain extracted text, got: {markdown:?}"
+        );
+    }
+}

--- a/src/agent/rt/tool/mod.rs
+++ b/src/agent/rt/tool/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     message::{Message, Part, Role, ToolDesc},
 };
 
+mod convert_pdf_to_md;
 mod python_repl;
 mod subagent;
 mod web_search;
@@ -98,6 +99,11 @@ impl ToolSet {
             BuiltinToolProvider::WebSearch {} => {
                 let tool = web_search::build_web_search_tool();
                 self.tools.insert("web_search".to_string(), tool);
+                Ok(self)
+            }
+            BuiltinToolProvider::ConvertPdfToMd {} => {
+                let tool = convert_pdf_to_md::build_convert_pdf_to_md_tool().await?;
+                self.tools.insert("convert_pdf_to_md".to_string(), tool);
                 Ok(self)
             }
             BuiltinToolProvider::PythonRepl {

--- a/src/agent/rt/tool/python_repl/env.rs
+++ b/src/agent/rt/tool/python_repl/env.rs
@@ -197,17 +197,31 @@ impl PythonEnv {
     /// On timeout the child process is killed and [`ExecResult::timed_out`] is
     /// set to `true`; the function still returns `Ok`.
     pub async fn run_code(&self, code: &str, timeout_secs: u64) -> Result<ExecResult> {
+        self.run_code_with_env(code, timeout_secs, &[]).await
+    }
+
+    /// Execute Python code with additional environment variables.
+    ///
+    /// Output truncation follows the same policy as [`Self::run_code`].
+    pub async fn run_code_with_env(
+        &self,
+        code: &str,
+        timeout_secs: u64,
+        extra_env: &[(&str, &str)],
+    ) -> Result<ExecResult> {
         // Write code to a temp file.
         let script = tempfile::NamedTempFile::with_suffix(".py")
             .context("failed to create temp script file")?;
         std::fs::write(script.path(), code).context("failed to write script to temp file")?;
 
-        let mut child = Command::new(self.python_path())
-            .arg(script.path())
+        let mut cmd = Command::new(self.python_path());
+        cmd.arg(script.path())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .context("failed to spawn Python interpreter")?;
+            .stderr(std::process::Stdio::piped());
+        for (key, value) in extra_env {
+            cmd.env(key, value);
+        }
+        let mut child = cmd.spawn().context("failed to spawn Python interpreter")?;
 
         // Drain stdout and stderr on separate tasks to prevent pipe-buffer
         // deadlock when a process produces large output on both streams.
@@ -548,6 +562,28 @@ mod tests {
             result.stderr.len() <= MAX_OUTPUT_CHARS + 100,
             "stderr should be truncated, got {} chars",
             result.stderr.len()
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_run_code_with_env_large_output_is_truncated() {
+        let uv = resolve_uv_path().unwrap();
+        let env = PythonEnv::new_temp(uv, None).await.unwrap();
+        let code = "import os\nprint((os.environ.get('TOKEN') or '') + ('x' * 20000))";
+        let result = env
+            .run_code_with_env(code, 30, &[("TOKEN", "abc")])
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.len() <= MAX_OUTPUT_CHARS + 100,
+            "stdout should be truncated, got {} chars",
+            result.stdout.len()
+        );
+        assert!(
+            result.stdout.contains("[output truncated"),
+            "should contain truncation marker"
         );
     }
 }

--- a/src/agent/rt/tool/python_repl/mod.rs
+++ b/src/agent/rt/tool/python_repl/mod.rs
@@ -1,11 +1,13 @@
-mod env;
-mod uv;
+pub(crate) mod env;
+mod source_tool;
+pub(crate) mod uv;
 
 use std::sync::Arc;
 
-use env::{InstallResult, PythonEnv};
+pub(crate) use env::{InstallResult, PythonEnv};
 use futures::future::BoxFuture;
-use uv::ensure_uv;
+pub(crate) use source_tool::{PythonSourceToolConfig, build_python_source_tool};
+pub(crate) use uv::ensure_uv;
 
 use crate::{
     agent::rt::tool::{ToolFunc, ToolRuntime},
@@ -35,6 +37,7 @@ use crate::{
 /// ```
 
 /// Config supplied by the user when declaring a `PythonRepl` tool provider.
+#[derive(Clone, Debug, Default)]
 pub struct PythonReplConfig {
     /// Python version to provision (e.g. `"3.12"`). `None` → latest stable.
     pub python_version: Option<String>,
@@ -54,36 +57,8 @@ pub struct PythonReplConfig {
 /// - the virtual environment cannot be created
 /// - any package listed in `config.packages` fails to install
 pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<ToolRuntime> {
-    let uv = ensure_uv().await?;
-
-    let env = match config.venv_path {
-        Some(ref path) => {
-            let expanded = shellexpand::tilde(path).into_owned();
-            PythonEnv::new(
-                uv,
-                config.python_version,
-                std::path::PathBuf::from(expanded),
-                false,
-            )
-            .await?
-        }
-        None => PythonEnv::new_temp(uv, config.python_version).await?,
-    };
-
-    // Pre-install user-specified packages.  Failure here is fatal so the
-    // user learns about misconfigured environments early.
-    if !config.packages.is_empty() {
-        match env.install_packages(&config.packages).await {
-            InstallResult::Failed { stderr } => {
-                anyhow::bail!(
-                    "Failed to pre-install packages {:?}: {}",
-                    config.packages,
-                    stderr
-                );
-            }
-            _ => {}
-        }
-    }
+    let env = prepare_python_env(&config).await?;
+    install_python_packages(&env, &config.packages).await?;
 
     let env = Arc::new(env);
 
@@ -174,35 +149,67 @@ pub async fn build_python_repl_tool(config: PythonReplConfig) -> anyhow::Result<
     Ok(ToolRuntime::new(desc, f))
 }
 
+pub(crate) async fn prepare_python_env(config: &PythonReplConfig) -> anyhow::Result<PythonEnv> {
+    let uv = ensure_uv().await?;
+
+    match config.venv_path.as_deref() {
+        Some(path) => {
+            let expanded = shellexpand::tilde(path).into_owned();
+            PythonEnv::new(
+                uv,
+                config.python_version.clone(),
+                std::path::PathBuf::from(expanded),
+                false,
+            )
+            .await
+        }
+        None => PythonEnv::new_temp(uv, config.python_version.clone()).await,
+    }
+}
+
+pub(crate) async fn install_python_packages(
+    env: &PythonEnv,
+    packages: &[String],
+) -> anyhow::Result<()> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    match env.install_packages(packages).await {
+        InstallResult::Failed { stderr } => {
+            anyhow::bail!("Failed to pre-install packages {:?}: {}", packages, stderr);
+        }
+        InstallResult::AlreadyInstalled | InstallResult::Success => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn default_config() -> PythonReplConfig {
-        PythonReplConfig {
-            python_version: None,
-            venv_path: None,
-            packages: vec![],
-        }
-    }
 
     // ── descriptor tests (no uv required) ────────────────────────────────────
 
     #[tokio::test]
     async fn test_tool_name_is_python_repl() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         assert_eq!(tool.desc().name, "python_repl");
     }
 
     #[tokio::test]
     async fn test_tool_has_description() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         assert!(tool.desc().description.is_some());
     }
 
     #[tokio::test]
     async fn test_tool_schema_requires_code() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         let required = tool
             .desc()
             .parameters
@@ -215,7 +222,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_schema_pip_install_is_array_of_strings() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         let item_type = tool
             .desc()
             .parameters
@@ -229,7 +238,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_code_param_returns_validation_error() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         use crate::message::Part;
         let call = Part::function_with_id("call-1", "python_repl", crate::to_value!({}));
         let msg = tool.run(call).await.unwrap();
@@ -244,7 +255,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_print_returns_stdout() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         use crate::message::Part;
         let call = Part::function_with_id(
             "call-1",
@@ -263,7 +276,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_pip_install_failure_returns_phase_pip_install() {
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         use crate::message::Part;
         let call = Part::function_with_id(
             "call-1",
@@ -290,7 +305,9 @@ mod tests {
     async fn test_numpy_matplotlib_chart() {
         use crate::message::Part;
 
-        let tool = build_python_repl_tool(default_config()).await.unwrap();
+        let tool = build_python_repl_tool(PythonReplConfig::default())
+            .await
+            .unwrap();
         let chart_dir = tempfile::tempdir().expect("failed to create temp dir");
         let chart_path = chart_dir.path().join("sine_chart.png");
 

--- a/src/agent/rt/tool/python_repl/source_tool.rs
+++ b/src/agent/rt/tool/python_repl/source_tool.rs
@@ -1,0 +1,403 @@
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+
+use super::{PythonReplConfig, install_python_packages, prepare_python_env};
+use crate::{
+    agent::rt::tool::{ToolFunc, ToolKind, ToolRuntime},
+    datatype::Value,
+    message::ToolDesc,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+pub(crate) struct PythonSourceToolConfig {
+    pub(crate) source: String,
+    pub(crate) python: PythonReplConfig,
+    pub(crate) timeout_secs: u64,
+}
+
+impl PythonSourceToolConfig {
+    pub(crate) fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            python: PythonReplConfig::default(),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+        }
+    }
+
+    pub(crate) fn python(mut self, python: PythonReplConfig) -> Self {
+        self.python = python;
+        self
+    }
+
+    pub(crate) fn timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.timeout_secs = timeout_secs;
+        self
+    }
+}
+
+pub(crate) async fn build_python_source_tool(
+    desc: ToolDesc,
+    config: PythonSourceToolConfig,
+) -> anyhow::Result<ToolRuntime> {
+    let env = Arc::new(prepare_python_env(&config.python).await?);
+    install_python_packages(env.as_ref(), &config.python.packages).await?;
+
+    let source = std::sync::Arc::new(config.source);
+    let timeout_secs = config.timeout_secs;
+
+    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+        let env = env.clone();
+        let source = source.clone();
+
+        Box::pin(async move {
+            let args_dir = match tempfile::tempdir() {
+                Ok(dir) => dir,
+                Err(err) => {
+                    return python_source_error_value(
+                        &args,
+                        "initialization",
+                        &format!("failed to create temp args directory: {err}"),
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
+                }
+            };
+            let args_path = args_dir.path().join("args.json");
+            let args_json = match serde_json::to_string(&args) {
+                Ok(json) => json,
+                Err(err) => {
+                    return python_source_error_value(
+                        &args,
+                        "initialization",
+                        &format!("failed to serialize args to JSON: {err}"),
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
+                }
+            };
+            if let Err(err) = std::fs::write(&args_path, args_json) {
+                return python_source_error_value(
+                    &args,
+                    "initialization",
+                    &format!("failed to write args JSON file: {err}"),
+                    None,
+                    None,
+                    None,
+                    None,
+                );
+            }
+            let args_path_str = args_path.to_string_lossy().to_string();
+            let result = env
+                .run_code_with_env(
+                    &source,
+                    timeout_secs,
+                    &[("AILOY_ARGS_JSON_PATH", args_path_str.as_str())],
+                )
+                .await;
+
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    return python_source_error_value(
+                        &args,
+                        "execution",
+                        &format!("execution error: {err}"),
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
+                }
+            };
+
+            if result.exit_code != 0 {
+                return python_source_error_value(
+                    &args,
+                    "execution",
+                    &python_execution_error_message(&result, timeout_secs),
+                    Some(result.stdout.as_str()),
+                    Some(result.stderr.as_str()),
+                    Some(result.exit_code as i64),
+                    Some(result.timed_out),
+                );
+            }
+
+            parse_python_source_json(&args, &result, &result.stdout)
+        }) as BoxFuture<'static, Value>
+    });
+
+    Ok(ToolRuntime::new_with_kind(desc, f, ToolKind::Builtin))
+}
+
+fn python_execution_error_message(result: &super::env::ExecResult, timeout_secs: u64) -> String {
+    let stderr = result.stderr.trim();
+    let stdout = result.stdout.trim();
+
+    if !stderr.is_empty() {
+        format!("python source execution failed: {stderr}")
+    } else if !stdout.is_empty() {
+        format!("python source execution failed: {stdout}")
+    } else if result.timed_out {
+        format!("python source timed out after {timeout_secs}s")
+    } else {
+        format!("python source exited with code {}", result.exit_code)
+    }
+}
+
+fn parse_python_source_json(
+    processed_args: &Value,
+    result: &super::env::ExecResult,
+    payload: &str,
+) -> Value {
+    match serde_json::from_str::<Value>(payload) {
+        Ok(value) => value,
+        Err(err) => python_source_parsing_error(
+            processed_args,
+            result,
+            &format!("failed to parse python result as JSON: {err}"),
+        ),
+    }
+}
+
+fn python_source_parsing_error(
+    processed_args: &Value,
+    result: &super::env::ExecResult,
+    error: &str,
+) -> Value {
+    python_source_error_value(
+        processed_args,
+        "parsing",
+        error,
+        Some(result.stdout.as_str()),
+        Some(result.stderr.as_str()),
+        Some(result.exit_code as i64),
+        Some(result.timed_out),
+    )
+}
+
+fn python_source_error_value(
+    base_args: &Value,
+    phase: &str,
+    error: &str,
+    stdout: Option<&str>,
+    stderr: Option<&str>,
+    exit_code: Option<i64>,
+    timed_out: Option<bool>,
+) -> Value {
+    let mut value = match base_args.clone() {
+        Value::Object(map) => Value::Object(map),
+        other => Value::object([("input", other)]),
+    };
+
+    let object = value
+        .as_object_mut()
+        .expect("python source error payload must be object");
+    object.insert("error".to_string(), Value::string(error));
+    object.insert("phase".to_string(), Value::string(phase));
+
+    if let Some(stdout) = stdout.filter(|stdout| !stdout.is_empty()) {
+        object.insert("stdout".to_string(), Value::string(stdout));
+    }
+    if let Some(stderr) = stderr.filter(|stderr| !stderr.is_empty()) {
+        object.insert("stderr".to_string(), Value::string(stderr));
+    }
+    if let Some(exit_code) = exit_code {
+        object.insert("exit_code".to_string(), Value::integer(exit_code));
+    }
+    if let Some(timed_out) = timed_out {
+        object.insert("timed_out".to_string(), Value::bool(timed_out));
+    }
+
+    value
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        message::{Part, ToolDescBuilder},
+        to_value,
+    };
+
+    fn test_tool_desc(name: &str) -> ToolDesc {
+        ToolDescBuilder::new(name).build()
+    }
+
+    #[test]
+    fn test_python_source_tool_config_defaults() {
+        let config = PythonSourceToolConfig::new("print('ok')");
+        assert_eq!(config.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_build_python_source_tool_descriptor_reflects_config() {
+        let mut desc = ToolDescBuilder::new("echo_json")
+            .parameters(to_value!({
+                "type": "object",
+                "properties": { "value": { "type": "integer" } },
+                "required": ["value"]
+            }))
+            .build();
+        desc.description = Some("Echo args".to_string());
+        desc.returns = Some(to_value!({
+            "type": "object",
+            "properties": { "value": { "type": "integer" } },
+            "required": ["value"]
+        }));
+
+        let tool = build_python_source_tool(
+            desc,
+            PythonSourceToolConfig::new(
+                "import json, os\nwith open(os.environ['AILOY_ARGS_JSON_PATH'], encoding='utf-8') as f:\n    args = json.load(f)\nprint(json.dumps(args), end='')",
+            ),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let desc = tool.desc();
+        assert_eq!(desc.name, "echo_json");
+        assert_eq!(desc.description.as_deref(), Some("Echo args"));
+        assert_eq!(
+            desc.parameters
+                .pointer("/required/0")
+                .and_then(|value| value.as_str()),
+            Some("value")
+        );
+        assert_eq!(
+            desc.returns
+                .as_ref()
+                .and_then(|value| value.pointer("/required/0"))
+                .and_then(|value| value.as_str()),
+            Some("value")
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_stdout_json_transport_parses_result() {
+        let tool = build_python_source_tool(
+            test_tool_desc("echo_json"),
+            PythonSourceToolConfig::new(
+                "import json, os\nwith open(os.environ['AILOY_ARGS_JSON_PATH'], encoding='utf-8') as f:\n    args = json.load(f)\nprint(json.dumps({'value': args['value']}), end='')",
+            ),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let call = Part::function_with_id("call-1", "echo_json", to_value!({ "value": 7 }));
+        let msg = tool.run(call).await.expect("tool execution failed");
+        let value = msg.contents[0].as_value().unwrap();
+
+        assert_eq!(
+            value.pointer("/value").and_then(|value| value.as_integer()),
+            Some(7),
+            "unexpected value: {value:?}"
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_source_receives_args_via_env_json_path() {
+        let tool = build_python_source_tool(
+            test_tool_desc("args_from_env"),
+            PythonSourceToolConfig::new(
+                "import json, os\nwith open(os.environ['AILOY_ARGS_JSON_PATH'], encoding='utf-8') as f:\n    args = json.load(f)\nprint(json.dumps({'value': args.get('value')}), end='')",
+            ),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let call = Part::function_with_id("call-1", "args_from_env", to_value!({ "value": 11 }));
+        let msg = tool.run(call).await.expect("tool execution failed");
+        let value = msg.contents[0].as_value().unwrap();
+
+        assert_eq!(
+            value.pointer("/value").and_then(|value| value.as_integer()),
+            Some(11),
+            "unexpected value: {value:?}"
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_large_json_payload_is_truncated_and_returns_parsing_error() {
+        let tool = build_python_source_tool(
+            test_tool_desc("big_payload"),
+            PythonSourceToolConfig::new(
+                "import json\nprint(json.dumps({'payload': 'x' * 9001}), end='')",
+            ),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let call = Part::function_with_id("call-1", "big_payload", to_value!({}));
+        let msg = tool.run(call).await.expect("tool execution failed");
+        let value = msg.contents[0].as_value().unwrap();
+        assert_eq!(
+            value.pointer("/phase").and_then(|value| value.as_str()),
+            Some("parsing"),
+            "unexpected value: {value:?}"
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_python_exception_returns_execution_error() {
+        let tool = build_python_source_tool(
+            ToolDescBuilder::new("raise_error")
+                .parameters(to_value!({
+                    "type": "object",
+                    "properties": { "value": { "type": "string" } }
+                }))
+                .build(),
+            PythonSourceToolConfig::new("raise RuntimeError('boom')"),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let call = Part::function_with_id("call-1", "raise_error", to_value!({ "value": "x" }));
+        let msg = tool.run(call).await.expect("tool execution failed");
+        let value = msg.contents[0].as_value().unwrap();
+
+        assert_eq!(
+            value.pointer("/phase").and_then(|value| value.as_str()),
+            Some("execution"),
+            "unexpected value: {value:?}"
+        );
+        assert!(
+            value
+                .pointer("/error")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .contains("boom"),
+            "unexpected value: {value:?}"
+        );
+    }
+
+    #[test_with::executable(uv)]
+    #[tokio::test]
+    async fn test_invalid_json_stdout_returns_parsing_error() {
+        let tool = build_python_source_tool(
+            test_tool_desc("invalid_stdout"),
+            PythonSourceToolConfig::new("print('oops', end='')"),
+        )
+        .await
+        .expect("failed to build source tool");
+
+        let call = Part::function_with_id("call-1", "invalid_stdout", to_value!({}));
+        let msg = tool.run(call).await.expect("tool execution failed");
+        let value = msg.contents[0].as_value().unwrap();
+
+        assert_eq!(
+            value.pointer("/phase").and_then(|value| value.as_str()),
+            Some("parsing"),
+            "unexpected value: {value:?}"
+        );
+    }
+}

--- a/src/agent/rt/tool/python_repl/source_tool.rs
+++ b/src/agent/rt/tool/python_repl/source_tool.rs
@@ -4,7 +4,7 @@ use futures::future::BoxFuture;
 
 use super::{PythonReplConfig, install_python_packages, prepare_python_env};
 use crate::{
-    agent::rt::tool::{ToolFunc, ToolKind, ToolRuntime},
+    agent::rt::tool::{ToolAsyncFunc, ToolKind, ToolRuntime},
     datatype::Value,
     message::ToolDesc,
 };
@@ -47,7 +47,7 @@ pub(crate) async fn build_python_source_tool(
     let source = std::sync::Arc::new(config.source);
     let timeout_secs = config.timeout_secs;
 
-    let f: Arc<ToolFunc> = Arc::new(move |args: Value| {
+    let f: Arc<ToolAsyncFunc> = Arc::new(move |args: Value| {
         let env = env.clone();
         let source = source.clone();
 
@@ -132,7 +132,7 @@ pub(crate) async fn build_python_source_tool(
         }) as BoxFuture<'static, Value>
     });
 
-    Ok(ToolRuntime::new_with_kind(desc, f, ToolKind::Builtin))
+    Ok(ToolRuntime::new_async_with_kind(desc, f, ToolKind::Builtin))
 }
 
 fn python_execution_error_message(result: &super::env::ExecResult, timeout_secs: u64) -> String {

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -85,6 +85,7 @@ pub enum LangModelProvider {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BuiltinToolProvider {
     WebSearch {},
+    ConvertPdfToMd {},
     PythonRepl {
         /// Python version to provision (e.g. `"3.12"`). `None` → latest stable.
         python_version: Option<String>,


### PR DESCRIPTION
## Description
resolves #385 

### What's in this
- `python_source_tool`: A feature that allows creating new tools by pre-defining Python `env` and code snippets based on Python REPL tools
- `convert_pdf_to_md` tool: A tool that uses the Python tool `docling` to convert a local PDF file to Markdown, saves it locally, and returns the path, as the first example of `python_source_tool`

## Related Issues
- #372 : This PR is based on this feature.
- https://github.com/brekkylab/agent-k/issues/21
- https://github.com/brekkylab/agent-k/issues/22