### PR TITLE
Message with schemars

### DIFF
--- a/src/datatype/bytes.rs
+++ b/src/datatype/bytes.rs
@@ -1,8 +1,28 @@
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, Schema, SchemaObject},
+};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Bytes(ByteBuf);
+
+impl JsonSchema for Bytes {
+    fn schema_name() -> String {
+        "Bytes".into()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("base64".into()),
+            ..Default::default()
+        }
+        .into()
+    }
+}
 
 impl Bytes {
     pub fn base64(&self) -> String {

--- a/src/datatype/value.rs
+++ b/src/datatype/value.rs
@@ -41,6 +41,19 @@ pub enum Value {
     Array(Vec<Value>),
 }
 
+impl schemars::JsonSchema for Value {
+    fn schema_name() -> String {
+        "Value".into()
+    }
+
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        // Empty SchemaObject produces `{}`, which in JSON Schema accepts any value.
+        // This is intentional: `Value` is a free-form type that can hold any JSON-
+        // compatible value (null, bool, number, string, array, or object).
+        schemars::schema::SchemaObject::default().into()
+    }
+}
+
 impl Value {
     pub fn null() -> Self {
         Self::Null

--- a/src/message/message.rs
+++ b/src/message/message.rs
@@ -6,7 +6,15 @@ use crate::message::Part;
 
 /// The author of a message (or streaming delta) in a chat.
 #[derive(
-    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, strum::Display, strum::EnumString,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+    schemars::JsonSchema,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
@@ -41,7 +49,7 @@ pub enum Role {
 /// assert_eq!(msg.role, Role::User);
 /// assert_eq!(msg.contents.len(), 1);
 /// ```
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Message {
     /// Author of the message.
     pub role: Role,
@@ -122,7 +130,7 @@ impl fmt::Display for Message {
 }
 
 /// Explains why a language model's streamed generation finished.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FinishReason {
     /// The model stopped naturally (e.g., EOS token or stop sequence).
@@ -151,7 +159,7 @@ impl fmt::Display for FinishReason {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct MessageOutput {
     /// Nesting level of this message relative to the top-level agent turn.
     ///

--- a/src/message/message_delta.rs
+++ b/src/message/message_delta.rs
@@ -30,7 +30,7 @@ use crate::message::{Delta, FinishReason, Message, MessageOutput, PartDelta, Rol
 /// let msg = merged.finish().unwrap();
 /// assert_eq!(msg.contents[0].as_text().unwrap(), "Hello");
 /// ```
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct MessageDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<Role>,

--- a/src/message/part.rs
+++ b/src/message/part.rs
@@ -6,7 +6,7 @@ use url::Url;
 use crate::datatype::{Bytes, Value};
 
 /// Represents a function call contained within a message part.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PartFunction {
     /// The name of the function
     pub name: String,
@@ -26,7 +26,7 @@ pub struct PartFunction {
 /// let part = Part::image_url("https://example.com/image.png".to_string()).unwrap();
 /// assert!(part.is_image());
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum PartImage {
     Embedded { mime_type: String, data: Bytes },
@@ -54,7 +54,7 @@ pub enum PartImage {
 /// assert!(part.is_text());
 /// ```
 ///
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Part {
     /// Plain utf-8 encoded text.

--- a/src/message/part_delta.rs
+++ b/src/message/part_delta.rs
@@ -29,7 +29,7 @@ use crate::{
 ///     arguments: r#"{"text":"hi"}"#.into(),
 /// };
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PartDeltaFunction {
     Verbatim { text: String },
@@ -57,7 +57,7 @@ pub enum PartDeltaFunction {
 /// # Error Handling
 /// Accumulation or finalization may return an error if incompatible deltas
 /// (e.g. mismatched function IDs) are combined or invalid JSON arguments are given.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PartDelta {
     /// Incremental text fragment.

--- a/src/message/tool_desc.rs
+++ b/src/message/tool_desc.rs
@@ -48,7 +48,7 @@ use crate::datatype::Value;
 ///
 /// assert_eq!(desc.name, "temperature");
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct ToolDesc {
     /// The unique name of the tool or function.
     pub name: String,


### PR DESCRIPTION
- Derives `schemars::JsonSchema` on all public message types: `Role`, `Message`, `FinishReason`, `MessageOutput`, `MessageDelta`, `Part`, `PartImage`, `PartFunction`, `PartDelta`, `PartDeltaFunction`, and `ToolDesc`
- Implements manual `JsonSchema` for `Bytes` (maps to `{ type: string, format: base64 }`)
- Implements manual `JsonSchema` for `Value` (maps to `{}`, accepting any JSON value)
