### PR TITLE
feat(lang_model): opt-in structured outputs across OpenAI, Anthropic, Gemini adapters

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     agent::{Agent, AgentProvider, AgentSpec, ContextManager},
+    lang_model::ResponseFormat,
     message::Message,
     runenv::RunEnv,
     tool::ToolDesc,
@@ -140,6 +141,18 @@ impl AgentBuilder {
     /// exceeds `spec.max_input_tokens`, preserving the most recent turns.
     pub fn context_manager(mut self, spec: ContextManager) -> Self {
         self.context_manager = Some(spec);
+        self
+    }
+
+    /// Constrain the model's output to a JSON schema (opt-in, strict).
+    /// `schema` is the raw JSON Schema value (e.g. `schemars::schema_for!(T)`).
+    /// When not called, the request body is unchanged.
+    pub fn response_format(mut self, name: impl Into<String>, schema: serde_json::Value) -> Self {
+        self.spec.response_format = Some(ResponseFormat::JsonSchema {
+            name: name.into(),
+            schema,
+            strict: true,
+        });
         self
     }
 

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -72,6 +72,10 @@ pub struct Agent {
     pub state: AgentState,
 
     context_manager: Option<ContextManager>,
+
+    /// Carried from [`AgentSpec::response_format`]; passed to every
+    /// `LangModel::run_with_response_format` call. `None` = unconstrained.
+    response_format: Option<crate::lang_model::ResponseFormat>,
 }
 
 impl Agent {
@@ -144,6 +148,7 @@ impl Agent {
             tool_descs,
             state,
             context_manager: None,
+            response_format: spec.response_format,
         })
     }
 
@@ -322,7 +327,14 @@ impl Agent {
                     }
                 }
 
-                let mut output = self.model.run(&self.state.history, &self.tool_descs).await?;
+                let mut output = self
+                    .model
+                    .run_with_response_format(
+                        &self.state.history,
+                        &self.tool_descs,
+                        self.response_format.as_ref(),
+                    )
+                    .await?;
 
                 // Capture token usage for next iteration's truncation check.
                 if let Some(u) = &output.usage {
@@ -1351,6 +1363,71 @@ To activate a skill, read its SKILL.md using the bash tool \
             result.stdout.contains("sandbox_shared_ok"),
             "sentinel file written by subagent not visible in parent's sandbox; stdout: {:?}",
             result.stdout,
+        );
+    }
+
+    /// `.response_format(...)` keeps the `agent` field inside the enum even
+    /// on an adversarial Korean meta/identity-shaped prompt that, under
+    /// instruction-only constraints, sometimes produces out-of-enum values.
+    #[test_with::env(OPENAI_API_KEY)]
+    #[tokio::test]
+    async fn test_response_format_enforces_enum() {
+        use crate::agent::AgentBuilder;
+        use serde::Deserialize;
+
+        #[derive(Debug, Deserialize)]
+        struct Decision {
+            agent: String,
+        }
+
+        // Minimal schema: one enum field over three literals.
+        let schema: serde_json::Value = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "enum": ["speedwagon", "vegapunk", "minerva"]
+                }
+            },
+            "required": ["agent"],
+            "additionalProperties": false
+        });
+
+        let instruction = "You are a router. Respond with a JSON object choosing one of: speedwagon, vegapunk, minerva. Do not invent other values.";
+
+        let provider = get_provider();
+        let mut agent = AgentBuilder::new("openai/gpt-4o-mini")
+            .provider(provider)
+            .instruction(instruction)
+            .response_format("Decision", schema)
+            .build()
+            .expect("agent build failed");
+
+        // Korean meta/identity-shaped prompt — the pattern that triggers
+        // enum escape under instruction-only constraints.
+        let query =
+            Message::new(Role::User).with_contents([Part::text("너 무슨 모델이야?")]);
+        let mut stream = agent.run(query);
+        let mut text = String::new();
+        while let Some(event) = stream.next().await {
+            let event = event.expect("agent stream error");
+            if event.message.role == Role::Assistant {
+                for p in &event.message.contents {
+                    if let Some(t) = p.as_text() {
+                        text.push_str(t);
+                    }
+                }
+            }
+        }
+        assert!(!text.is_empty(), "expected an assistant text response");
+
+        // Must parse and the agent must be one of the three literals.
+        let decision: Decision = serde_json::from_str(text.trim())
+            .unwrap_or_else(|e| panic!("response was not a valid Decision JSON: {e}\nraw: {text}"));
+        assert!(
+            matches!(decision.agent.as_str(), "speedwagon" | "vegapunk" | "minerva"),
+            "agent field violated the enum: got {:?}",
+            decision.agent
         );
     }
 }

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     agent::AgentCard,
+    lang_model::ResponseFormat,
     tool::{
         ToolDesc,
         r#impl::{
@@ -58,6 +59,13 @@ pub struct AgentSpec {
     /// `None` for top-level agents.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card: Option<AgentCard>,
+
+    /// Opt-in structured-output enforcement. `None` (default) leaves the
+    /// request body unchanged; `Some` is translated by each adapter into the
+    /// provider's schema-enforcement field.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub response_format: Option<ResponseFormat>,
 }
 
 impl AgentSpec {
@@ -68,7 +76,14 @@ impl AgentSpec {
             tools: Vec::new(),
             subagents: Vec::new(),
             card: None,
+            response_format: None,
         }
+    }
+
+    /// Set the structured-output constraint. See [`ResponseFormat`].
+    pub fn response_format(mut self, rf: ResponseFormat) -> Self {
+        self.response_format = Some(rf);
+        self
     }
 
     pub fn instruction(mut self, inst: impl Into<String>) -> Self {

--- a/src/lang_model/impl/api/anthropic.rs
+++ b/src/lang_model/impl/api/anthropic.rs
@@ -224,6 +224,27 @@ impl Marshal<LangModelRequest<'_>> for AnthropicMarshal {
                 .unwrap()
                 .insert("tools".to_owned(), tools);
         }
+        if let Some(rf) = req.response_format {
+            // Anthropic Messages: response_format.json_schema.{name,schema,strict}.
+            // Newer models accept this field directly; older models return 400.
+            let crate::lang_model::ResponseFormat::JsonSchema {
+                name,
+                schema,
+                strict,
+            } = rf;
+            let rf_val: Value = serde_json::json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": name,
+                    "schema": schema,
+                    "strict": strict,
+                }
+            })
+            .into();
+            body.as_object_mut()
+                .unwrap()
+                .insert("response_format".to_owned(), rf_val);
+        }
 
         to_value!({
             "url": url,
@@ -403,6 +424,7 @@ mod tests {
             url: &url,
             api_key: &api_key,
             max_tokens,
+            response_format: None,
         };
         f(&req)
     }

--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -182,6 +182,26 @@ impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
                 (max_tokens as i64).into(),
             );
         }
+        if let Some(rf) = req.response_format {
+            // OpenAI Chat Completions: response_format.json_schema.{name,schema,strict}
+            let crate::lang_model::ResponseFormat::JsonSchema {
+                name,
+                schema,
+                strict,
+            } = rf;
+            let rf_val: Value = serde_json::json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": name,
+                    "schema": schema,
+                    "strict": strict,
+                }
+            })
+            .into();
+            body.as_object_mut()
+                .unwrap()
+                .insert("response_format".to_owned(), rf_val);
+        }
         body.as_object_mut()
             .unwrap()
             .retain(|_key, value| !value.is_null());
@@ -363,6 +383,7 @@ mod tests {
             url: &url,
             api_key: &api_key,
             max_tokens,
+            response_format: None,
         };
         f(&req)
     }

--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -258,10 +258,28 @@ impl Marshal<LangModelRequest<'_>> for GeminiMarshal {
         if !tools.is_null() {
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
+        // maxOutputTokens, responseSchema, responseMimeType all live under
+        // the same `generationConfig` object.
+        let mut generation_config = serde_json::Map::new();
         if let Some(max_tokens) = req.max_tokens {
+            generation_config.insert(
+                "maxOutputTokens".to_owned(),
+                serde_json::Value::from(max_tokens as i64),
+            );
+        }
+        if let Some(rf) = req.response_format {
+            // Gemini: generationConfig.responseMimeType + responseSchema
+            let crate::lang_model::ResponseFormat::JsonSchema { schema, .. } = rf;
+            generation_config.insert(
+                "responseMimeType".to_owned(),
+                serde_json::Value::String("application/json".to_owned()),
+            );
+            generation_config.insert("responseSchema".to_owned(), schema.clone());
+        }
+        if !generation_config.is_empty() {
             body.as_object_mut().unwrap().insert(
                 "generationConfig".into(),
-                to_value!({"maxOutputTokens": max_tokens as i64}),
+                serde_json::Value::Object(generation_config).into(),
             );
         }
 
@@ -449,6 +467,7 @@ mod tests {
             url: &url,
             api_key: &api_key,
             max_tokens,
+            response_format: None,
         };
         f(&req)
     }

--- a/src/lang_model/impl/api/openai.rs
+++ b/src/lang_model/impl/api/openai.rs
@@ -200,6 +200,26 @@ impl Marshal<LangModelRequest<'_>> for OpenAIMarshal {
                 .unwrap()
                 .insert("max_output_tokens".into(), (max_tokens as i64).into());
         }
+        if let Some(rf) = req.response_format {
+            // OpenAI Responses API: text.format.{name,schema,strict}
+            // (differs from Chat Completions, which nests under response_format.json_schema)
+            let crate::lang_model::ResponseFormat::JsonSchema {
+                name,
+                schema,
+                strict,
+            } = rf;
+            let format_val: Value = serde_json::json!({
+                "type": "json_schema",
+                "name": name,
+                "schema": schema,
+                "strict": strict,
+            })
+            .into();
+            body.as_object_mut().unwrap().insert(
+                "text".into(),
+                serde_json::json!({"format": format_val}).into(),
+            );
+        }
 
         to_value!({
             "url": url,
@@ -393,6 +413,7 @@ mod tests {
             url: &url,
             api_key: &api_key,
             max_tokens,
+            response_format: None,
         };
         f(&req)
     }

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -15,6 +15,21 @@ pub struct LangModel {
     provider: LangModelProviderElem,
 }
 
+/// Opt-in structured-output enforcement. Each adapter translates this into
+/// its provider's schema-enforcement field (OpenAI `response_format` /
+/// `text.format`, Anthropic `response_format`, Gemini
+/// `generationConfig.responseSchema`).
+#[derive(Clone, Debug)]
+pub enum ResponseFormat {
+    /// `schema` is the raw JSON Schema value (e.g. `schemars::schema_for!(T)`).
+    /// `strict = true` requests strict conformance where the provider supports it.
+    JsonSchema {
+        name: String,
+        schema: serde_json::Value,
+        strict: bool,
+    },
+}
+
 pub(crate) struct LangModelRequest<'a> {
     pub model: &'a str,
     pub messages: &'a [Message],
@@ -22,6 +37,9 @@ pub(crate) struct LangModelRequest<'a> {
     pub url: &'a Url,
     pub api_key: &'a Option<String>,
     pub max_tokens: Option<u64>,
+    /// Structured-output enforcement, if any. `None` keeps the request
+    /// shape identical to before this field existed (backward-compatible).
+    pub response_format: Option<&'a ResponseFormat>,
 }
 
 impl LangModel {
@@ -38,6 +56,21 @@ impl LangModel {
         messages: &[Message],
         tools: &[ToolDesc],
     ) -> anyhow::Result<MessageOutput> {
+        self.run_with_response_format(messages, tools, None).await
+    }
+
+    /// Like [`run`](Self::run), but optionally enforces a JSON-schema-shaped
+    /// response via the provider's structured-outputs API. Each adapter
+    /// translates `response_format` into its provider-specific body field
+    /// (OpenAI `response_format`, Anthropic `response_format`, Gemini
+    /// `generationConfig.responseSchema`). When `None`, the request body
+    /// is unchanged from before this method existed.
+    pub async fn run_with_response_format(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDesc],
+        response_format: Option<&ResponseFormat>,
+    ) -> anyhow::Result<MessageOutput> {
         match &self.provider {
             LangModelProviderElem::API {
                 schema,
@@ -53,6 +86,7 @@ impl LangModel {
                     url,
                     api_key,
                     max_tokens: *max_tokens,
+                    response_format,
                 };
 
                 let req = match schema {


### PR DESCRIPTION
## Summary

Add opt-in JSON-schema-shaped output enforcement across all four provider adapters (OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, Gemini generateContent). When the caller does nothing, request bodies are byte-identical to before this change.

- `ResponseFormat::JsonSchema { name, schema, strict }` is a new enum exposed from `lang_model::rt`. The single shape covers all four adapters; each adapter translates it into its provider-specific body field.
- `AgentSpec.response_format: Option<ResponseFormat>` (`#[serde(skip)]` + `#[schemars(skip)]`) carries the choice through the spec. `AgentBuilder::response_format(name, schema_value)` is the convenience setter (`strict = true` by default).
- `LangModel::run` is preserved as a wrapper over a new `run_with_response_format` so existing call sites and external users of the public `LangModel` API are not affected.
- `Agent` stores the option once at construction and forwards it on every `run_with_response_format` call from the agent runtime.

## Why

Instruction-only "respond in this JSON shape" prompts are not enforced at decode time, so models occasionally output values outside the declared enum (e.g. `"agent":"fallback"` instead of one of the declared agent names). Provider Structured Outputs APIs constrain the decoder and eliminate those escapes — but only if the adapter actually passes the schema through, which ailoy did not.

This PR adds the pass-through. agent-k will use it in a follow-up to remove the ~2% enum escape we measured on the router; other ailoy users get the same lever for any agent that needs structured output.

## Per-provider mapping

- **OpenAI Chat Completions** — `response_format.json_schema.{name,schema,strict}`.
- **OpenAI Responses API** — `text.format.{name,schema,strict}` (different field path from Chat Completions; both are handled).
- **Anthropic Messages** — `response_format.json_schema.{name,schema,strict}` on the request body. Newer Claude models accept this directly; older models return 400 and callers should target a supported model or omit `response_format`.
- **Gemini generateContent** — `generationConfig.responseMimeType = "application/json"` plus `generationConfig.responseSchema = <schema>`, coexisting with `maxOutputTokens` in the same `generationConfig` object.

## Backward compatibility

- `LangModelRequest` is `pub(crate)`; the added field is invisible to external users.
- `AgentSpec` field is `#[serde(skip)]` and `#[schemars(skip)]`, so saved/restored specs round-trip unchanged.
- `LangModel::run(...)` retains the same signature and behaviour; `run_with_response_format` is additive.
- When `response_format` is `None` (the default), every adapter takes the existing code path and produces the same body bytes as before.

## Test plan

- [x] `cargo build` — no warnings (including dead-code).
- [x] `cargo test --lib` — 165 existing tests pass with the change applied. (Two pre-existing failures on `develop` HEAD — `test_context_manager_truncates_tool_results_when_threshold_exceeded` and `test_read_relative_path_rejected` — reproduce on a clean checkout and are unrelated to this PR.)
- [x] New `test_response_format_enforces_enum` (gated by `OPENAI_API_KEY`): feeds a Korean meta/identity-shaped adversarial prompt with an enum-constrained schema and asserts the response parses as the expected struct with a value inside the enum set. Passes.

## Out of scope (follow-up)

- Anthropic older-model fallback via the tool-use route (the workaround that worked before `response_format` shipped). Callers targeting those models can keep using instruction-only schemas for now.
- A `strict = false` lax mode setter. The current setter defaults to `strict = true`; adding the lax variant is a one-method addition if a real use case appears.
- Streaming responses with schema enforcement (the integration test exercises the non-streaming path).