### PR TITLE
feat(sandbox): microsandbox 0.4→0.4.6 upgrade + SandboxConfig::home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,9 +2141,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-client"
-version = "0.25.2"
+version = "0.26.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c466cd63a4217d5b2b8e32f23f58312741ce96e3c84bf7438677d2baff0fc555"
+checksum = "25b710cd52bde69b58137785a5d2b1ec1b20980a3ca0d5f959eab8c45a72e92d"
 dependencies = [
  "cfg-if",
  "data-encoding",
@@ -2160,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.2"
+version = "0.26.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "a62d7684f766b0f96344be88c023f9b6650039aea09d526b4974cce302eb61b1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3061,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81251b9d0124a70d95e6f5f7211f4c45a71bc24d5d2f92c4aa016d464d06e0cf"
+checksum = "9d289ffd511867e5f82bbe2b577fcc78acbf8c99100c9435d515902c532f6f45"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3100,15 +3100,14 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-builder 0.23.2",
- "ureq",
  "which 8.0.2",
 ]
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f951aec163d851c3e33081d7052749a52d8f6b8168ceb5c32b941ecb2579a6"
+checksum = "8e0cf4b1e42563a39975ec111d0c5ca3b2d2648dcc445a97be6cebc1c8155308"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3119,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab50956ecc0acfe42e6122c8c77d8438d3ed59aa02a920bd82216793967e9f4"
+checksum = "efdf0dbee927e3e828860eddc6a3b234a8e793ccc23636ed9962c25b3955121e"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3129,14 +3128,13 @@ dependencies = [
  "scopeguard",
  "tempfile",
  "tracing",
- "ureq",
 ]
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778812da269394cf968194637e6f51b753e1d923f18860b66d7d9f1a5c268a51"
+checksum = "e99be592e0bf911930b31ae52864217c7d5d9b54e83cadd3b93d065ad23bed8d"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3160,19 +3158,20 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3464ec563ea8ee4413d91f83ce5afcd34bf978a89fb11a43f3a9ac74f1df92"
+checksum = "2b72e5b5b2c5bdea11a4d50b540c69d20466b828311466713ed03b2e1720718a"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c09d853c6828f36c0e951dbf4190fc850fc5d4d976ebf5fcf26301d51d2c137"
+checksum = "e51003a55eb30a25b767a1664622b7b376cbd39ecb186b982db16c120ca1abd0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "core-foundation 0.9.4",
  "crossbeam-queue",
@@ -3188,6 +3187,7 @@ dependencies = [
  "msb_krun",
  "parking_lot",
  "pem",
+ "percent-encoding",
  "rcgen",
  "resolv-conf",
  "rustls",
@@ -3205,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef509436fe7acd00f154db59b2a9d4263840849a82defe102fa9c79857be62a8"
+checksum = "d655a839bc767cadbd769a15f35b3cedd23aac8c67a53ba36188822e6af193d4"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3219,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9eb5b8015349c86daf7346d6bfb7199b809109831e5d6d5ef9f5729c627fe1"
+checksum = "e601dd7c100467e7318845df3fb8e5ab0d83866416eab1405ff3290a1ec53874"
 dependencies = [
  "bytes",
  "chrono",
@@ -3247,14 +3247,15 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c59ffa6f6e779966ead475a89c42713cb2350d02f06361ffdda4febbcf0798"
+checksum = "5d62293decc8415995915c95f45b5e2425316e518f3ff90a28c23beecf945108"
 dependencies = [
  "dirs",
  "libc",
  "reflink-copy",
  "scopeguard",
+ "ureq",
 ]
 
 [[package]]
@@ -6128,6 +6129,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots 1.0.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"
 log = "0.4"
-microsandbox = { version = "0.4", optional = true }
+microsandbox = { version = "0.4.5", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"
 log = "0.4"
-microsandbox = { version = "0.4.5", optional = true }
+microsandbox = { version = "0.4.6", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -36,7 +36,9 @@ pub enum VolumeMount {
         #[serde(default)]
         readonly: bool,
     },
-    /// Mount a microsandbox named volume (`~/.microsandbox/volumes/<name>/`).
+    /// Mount a microsandbox named volume, stored under the resolved
+    /// microsandbox home directory (e.g. `~/.microsandbox/volumes/<name>/`
+    /// or `$MSB_HOME/volumes/<name>/`).
     /// The volume persists across sandbox restarts and can be shared between sandboxes.
     Named {
         /// Name of the pre-existing microsandbox volume.
@@ -100,6 +102,13 @@ pub struct SandboxConfig {
     /// Volume mounts attached at sandbox creation time.
     #[serde(default)]
     pub volumes: Vec<VolumeMount>,
+
+    /// Override microsandbox home (binaries, db, snapshots, per-sandbox state).
+    /// Equivalent to setting `MSB_HOME`. Takes effect on the first
+    /// `Sandbox::new` only; later calls with a different value return an
+    /// error. Defaults to `$MSB_HOME` or `~/.microsandbox`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<PathBuf>,
 }
 
 impl Default for SandboxConfig {
@@ -116,6 +125,7 @@ impl Default for SandboxConfig {
             max_output_chars: 30_000,
             persist: false,
             volumes: Vec::new(),
+            home: None,
         }
     }
 }
@@ -262,10 +272,16 @@ impl Sandbox {
     pub async fn new(config: SandboxConfig) -> anyhow::Result<Self> {
         use anyhow::Context as _;
 
+        if let Some(home) = &config.home {
+            check_home_conflict(home, std::env::var_os("MSB_HOME").as_deref())?;
+            unsafe { std::env::set_var("MSB_HOME", home); }
+        }
+
         if !microsandbox::setup::is_installed() {
             log::warn!(
-                "microsandbox runtime not found — downloading to ~/.microsandbox, \
-                 this may take a moment"
+                "microsandbox runtime not found — downloading to {}, \
+                 this may take a moment",
+                microsandbox::config::config().home().display(),
             );
             microsandbox::setup::install()
                 .await
@@ -563,6 +579,22 @@ pub async fn remove_persisted(name: &str) -> anyhow::Result<()> {
     }
 }
 
+/// Return `Err` if `requested` disagrees with an already-set `MSB_HOME`.
+/// Microsandbox caches the resolved home in a `OnceLock`, so changing it
+/// mid-process is silently ignored. Surface the mismatch instead.
+fn check_home_conflict(requested: &Path, current: Option<&std::ffi::OsStr>) -> anyhow::Result<()> {
+    if let Some(prev) = current
+        && prev != requested.as_os_str()
+    {
+        anyhow::bail!(
+            "MSB_HOME already set to {:?}; cannot change to {:?} in the same process",
+            prev,
+            requested.display(),
+        );
+    }
+    Ok(())
+}
+
 /// Validate that `name` won't produce a socket path that exceeds the OS limit.
 fn validate_sandbox_name(name: &str) -> anyhow::Result<()> {
     #[cfg(target_os = "macos")]
@@ -570,20 +602,24 @@ fn validate_sandbox_name(name: &str) -> anyhow::Result<()> {
     #[cfg(not(target_os = "macos"))]
     const SUN_PATH_MAX: usize = 108;
 
-    let home =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+    let home = microsandbox::config::config().home();
     let home_str = home
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("home directory path is not valid UTF-8"))?;
 
+    const SANDBOXES_PREFIX: &str = "/sandboxes/";
+    const RUNTIME_SUFFIX: &str = "/runtime/agent.sock";
+
     let socket_path_len = home_str.len()
-        + "/.microsandbox/sandboxes/".len()
+        + SANDBOXES_PREFIX.len()
         + name.len()
-        + "/runtime/agent.sock".len()
+        + RUNTIME_SUFFIX.len()
         + 1; // null terminator
 
     if socket_path_len > SUN_PATH_MAX {
-        let max_name = SUN_PATH_MAX.saturating_sub(home_str.len() + 25 + 19 + 1);
+        let max_name = SUN_PATH_MAX.saturating_sub(
+            home_str.len() + SANDBOXES_PREFIX.len() + RUNTIME_SUFFIX.len() + 1,
+        );
         anyhow::bail!(
             "sandbox name '{}' is too long ({} chars); the resulting socket path \
              would be {} bytes but the OS limit (SUN_PATH_MAX) is {}. \
@@ -788,6 +824,46 @@ mod tests {
         assert!(
             back_anon.name.is_none(),
             "name must stay None after round-trip when originally None"
+        );
+    }
+
+    /// `check_home_conflict` accepts unset env, matching env, and rejects a mismatch.
+    #[test]
+    fn test_check_home_conflict() {
+        let requested = Path::new("/tmp/msb-a");
+        assert!(check_home_conflict(requested, None).is_ok());
+        assert!(check_home_conflict(requested, Some(requested.as_os_str())).is_ok());
+
+        let other = std::ffi::OsString::from("/tmp/msb-b");
+        let err = check_home_conflict(requested, Some(&other))
+            .expect_err("mismatched MSB_HOME must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MSB_HOME already set"),
+            "error should mention MSB_HOME conflict, got: {msg}"
+        );
+    }
+
+    /// `home` field round-trips through serde when set, and is omitted when `None`.
+    #[test]
+    fn test_sandbox_config_home_serde_roundtrip() {
+        let cfg_with = SandboxConfig {
+            home: Some(PathBuf::from("/tmp/example")),
+            ..SandboxConfig::default()
+        };
+        let json = serde_json::to_string(&cfg_with).expect("serialize");
+        assert!(
+            json.contains("\"home\":\"/tmp/example\""),
+            "expected home field in JSON, got: {json}"
+        );
+        let back: SandboxConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.home.as_deref(), Some(Path::new("/tmp/example")));
+
+        let cfg_default = SandboxConfig::default();
+        let json_default = serde_json::to_string(&cfg_default).expect("serialize default");
+        assert!(
+            !json_default.contains("\"home\""),
+            "home must be omitted when None, got: {json_default}"
         );
     }
 
@@ -1219,9 +1295,8 @@ mod tests {
             .await
             .expect("fork");
 
-        let snap_dir = dirs::home_dir()
-            .expect("home dir")
-            .join(".microsandbox")
+        let snap_dir = microsandbox::config::config()
+            .home()
             .join("snapshots")
             .join(&snap_name);
 


### PR DESCRIPTION
## Summary

Follow-up to #401. microsandbox 0.4.5 added `MSB_HOME` for relocating sandbox state (db, prebuilt binaries, snapshots, per-sandbox dirs all move under it), and 0.4.6 extended that coverage to the crate's build script so prebuilt artifacts also land under `$MSB_HOME` instead of being stranded in `~/.microsandbox`. ailoy still hard-coded `~/.microsandbox` in three places, so callers that set `MSB_HOME` saw an incorrect `SUN_PATH_MAX` check, a misleading install-warning log, and a fork-snapshot cleanup test that asserted against the wrong path.

This PR makes ailoy use that override and exposes it as a config field.

## Usage

After this PR, the home directory for sandbox state can be set in two ways:

1. **Environment variable** (set before launching ailoy):

   ```sh
   MSB_HOME=/data/msb your-ailoy-binary
   ```

   All sandbox state (db, binaries, snapshots, `sandboxes/`, `volumes/`) lives under `/data/msb`. Falls back to `~/.microsandbox` when unset.

2. **Programmatic, via `SandboxConfig::home`** (no env required):

   ```rust
   let sandbox = Sandbox::new(SandboxConfig {
       home: Some("/data/msb".into()),
       ..SandboxConfig::default()
   }).await?;
   ```

   Internally exports `MSB_HOME` for microsandbox. Must be set on the first `Sandbox::new` in the process — microsandbox caches the resolved home in a `OnceLock`. A later call with a different `home` value returns an error (via the new `check_home_conflict` helper) instead of silently being ignored.

## Changes

| File | Change |
|---|---|
| `Cargo.toml` | `microsandbox = "0.4"` → `"0.4.6"` (0.4.5 introduced `MSB_HOME`; 0.4.6 extended it to the build script) |
| `src/runenv/sandbox.rs` | `SandboxConfig::home` field; `Sandbox::new` exports `MSB_HOME` with conflict detection; `validate_sandbox_name`, install log, and `test_fork_snapshot_cleaned_up` switched to `microsandbox::config::config().home()`; two new sync tests (`test_check_home_conflict`, `test_sandbox_config_home_serde_roundtrip`) |

## Test plan

- [x] `cargo build` (no features) — pass
- [x] `cargo build --features sandbox` — pass
- [x] `cargo test --release --features sandbox` — 186 passed, 17 ignored, 2 failed. Both failures (`agent::rt::tests::test_context_manager_truncates_tool_results_when_threshold_exceeded`, `tool::r#impl::builtins::read::tests::test_read_relative_path_rejected`) reproduce on the unchanged `origin/develop` tip and are unrelated to this change.
- [x] All `runenv::sandbox::tests::*` pass, including the new `test_check_home_conflict` and `test_sandbox_config_home_serde_roundtrip`.
- [x] `MSB_HOME=/tmp/msb_isolated cargo test test_stop_and_start` passes, and runtime artifacts (`bin/msb`, `lib/libkrunfw`, `db/msb.db`, `sandboxes/`) appear under `/tmp/msb_isolated/`.

## Related

Build-time gap closed upstream: https://github.com/superradcompany/microsandbox/pull/704 made `crates/microsandbox/build.rs` resolve its target through `microsandbox_utils::resolve_home()` instead of `$HOME`, so the prebuilt `msb` / `libkrunfw` download (~42 MB) lands under `$MSB_HOME` too. Merged 2026-05-13 and shipped in microsandbox 0.4.6, which this PR pins.