### PR TITLE
feat(web_search): allow selecting specific engines at tool creation

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     agent::{Agent, AgentProvider, AgentSpec, ContextManager},
     message::Message,
     runenv::{FileEntry, RunEnv},
-    tool::ToolDesc,
+    tool::{ToolDesc, WebSearchEngineKind},
 };
 
 /// Fluent builder over [`AgentSpec`] for [`Agent`].
@@ -105,8 +105,8 @@ impl AgentBuilder {
         self
     }
 
-    pub fn web_search_tool(mut self) -> Self {
-        self.spec = self.spec.web_search_tool();
+    pub fn web_search_tool(mut self, engines: Vec<WebSearchEngineKind>) -> Self {
+        self.spec = self.spec.web_search_tool(engines);
         self
     }
 

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -10,7 +10,7 @@ use crate::{
     skill::{render_skills_table, scan_declared_skills},
     tool::{
         ToolDesc, ToolFunc,
-        r#impl::{get_subagent_tool_desc, get_subagent_tool_func},
+        r#impl::{get_subagent_tool_desc, get_subagent_tool_func, get_web_search_tool_factory},
     },
 };
 
@@ -154,8 +154,15 @@ impl Agent {
 
         let model_options = spec.model_options.clone().unwrap_or_default();
 
-        // Collect tools required by the spec; error if any tool is missing
-        let mut tools = provider.tools.provide(&spec.tools)?;
+        // Collect tools required by the spec; error if any tool is missing.
+        // When the spec requests specific web_search engines, override the default factory.
+        let mut tools = if let Some(engines) = spec.web_search_engines.as_ref() {
+            let mut tp = provider.tools.clone();
+            tp.insert_func_factory("web_search", get_web_search_tool_factory(engines.clone()));
+            tp.provide(&spec.tools)?
+        } else {
+            provider.tools.provide(&spec.tools)?
+        };
         let mut tool_descs = spec.tools.clone();
 
         // Sub-agents become regular tool entries: each is a one-shot ToolFunc

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -8,7 +8,7 @@ use crate::{
     lang_model::LangModelOptions,
     runenv::FileEntry,
     tool::{
-        ToolDesc,
+        ToolDesc, WebSearchEngineKind,
         r#impl::{
             get_apply_patch_tool_desc, get_edit_tool_desc, get_glob_tool_desc, get_grep_tool_desc,
             get_python_repl_tool_desc, get_read_tool_desc, get_shell_tool_desc,
@@ -78,6 +78,11 @@ pub struct AgentSpec {
     /// can live anywhere on the runenv — they do not need to share a parent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<PathBuf>,
+
+    /// Engines used by the `web_search` tool. `None` (or not provided) means
+    /// all available engines. Only meaningful when `web_search` is listed in `tools`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search_engines: Option<Vec<WebSearchEngineKind>>,
 }
 
 impl AgentSpec {
@@ -91,6 +96,7 @@ impl AgentSpec {
             files: Vec::new(),
             skills: Vec::new(),
             model_options: None,
+            web_search_engines: None,
         }
     }
 
@@ -139,8 +145,15 @@ impl AgentSpec {
         self
     }
 
-    pub fn web_search_tool(mut self) -> Self {
+    /// Add the `web_search` tool to the spec.
+    ///
+    /// Pass a non-empty `engines` vec to restrict which engines are used;
+    /// an empty vec (or `vec![]`) uses all available engines.
+    pub fn web_search_tool(mut self, engines: Vec<WebSearchEngineKind>) -> Self {
         self.tools.push(get_web_search_tool_desc());
+        if !engines.is_empty() {
+            self.web_search_engines = Some(engines);
+        }
         self
     }
 
@@ -357,5 +370,53 @@ mod tests {
         assert_eq!(back.files.len(), 1);
         assert_eq!(back.subagents.len(), 1);
         assert_eq!(back.subagents[0].files.len(), 1);
+    }
+
+    #[test]
+    fn test_web_search_tool_empty_engines_keeps_field_none() {
+        let spec = AgentSpec::new("openai/gpt-4o-mini").web_search_tool(vec![]);
+        assert!(
+            spec.web_search_engines.is_none(),
+            "empty engines should leave web_search_engines as None"
+        );
+        assert_eq!(spec.tools.len(), 1);
+        assert_eq!(spec.tools[0].name, "web_search");
+    }
+
+    #[test]
+    fn test_web_search_tool_with_engines_stores_field() {
+        let spec = AgentSpec::new("openai/gpt-4o-mini").web_search_tool(vec![
+            WebSearchEngineKind::Google,
+            WebSearchEngineKind::Brave,
+        ]);
+        assert_eq!(
+            spec.web_search_engines.as_deref(),
+            Some(vec![WebSearchEngineKind::Google, WebSearchEngineKind::Brave].as_slice())
+        );
+        assert_eq!(spec.tools.len(), 1);
+    }
+
+    #[test]
+    fn test_web_search_engines_omitted_from_serialisation_when_none() {
+        let spec = AgentSpec::new("openai/gpt-4o-mini").web_search_tool(vec![]);
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(
+            !json.contains("web_search_engines"),
+            "web_search_engines should be absent when None: {json}"
+        );
+    }
+
+    #[test]
+    fn test_web_search_engines_roundtrip() {
+        let spec = AgentSpec::new("openai/gpt-4o-mini").web_search_tool(vec![
+            WebSearchEngineKind::Google,
+            WebSearchEngineKind::Yahoo,
+        ]);
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: AgentSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.web_search_engines.as_deref(),
+            Some(vec![WebSearchEngineKind::Google, WebSearchEngineKind::Yahoo].as_slice())
+        );
     }
 }

--- a/src/tool/impl/builtins/mod.rs
+++ b/src/tool/impl/builtins/mod.rs
@@ -45,6 +45,6 @@ pub fn get_builtin_tool_factories() -> Vec<(&'static str, BuiltinFactory)> {
         ("apply_patch", Arc::new(move |_| apply_patch.clone())),
         ("glob", Arc::new(move |_| glob.clone())),
         ("grep", Arc::new(move |_| grep.clone())),
-        ("web_search", Arc::new(get_web_search_tool_factory())),
+        ("web_search", Arc::new(get_web_search_tool_factory(vec![]))),
     ]
 }

--- a/src/tool/impl/builtins/web_search/aggregator.rs
+++ b/src/tool/impl/builtins/web_search/aggregator.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 
 use super::{
     engine::{SearchEngine, SearchError},
-    engines::{Bing, Brave, DuckDuckGo, Google, LibreX, Mojeek, Startpage, Yahoo, Yandex},
+    engines::WebSearchEngineKind,
 };
 
 /// A search result aggregated from multiple engines.
@@ -102,24 +102,23 @@ pub struct MetaSearcher {
 }
 
 impl MetaSearcher {
-    pub fn new() -> Self {
+    /// Constructs a `MetaSearcher` using the given engine selection.
+    ///
+    /// An empty `engines` slice uses all available engines (default meta-search behaviour).
+    pub fn new(engines: Vec<WebSearchEngineKind>) -> Self {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .user_agent(super::engine::USER_AGENT)
             .build()
             .expect("Failed to build HTTP client");
 
-        let engines: Vec<Box<dyn SearchEngine>> = vec![
-            Box::new(Bing::new().expect("Bing init failed")),
-            Box::new(Brave::new().expect("Brave init failed")),
-            Box::new(DuckDuckGo::new().expect("DuckDuckGo init failed")),
-            Box::new(Google::new().expect("Google init failed")),
-            Box::new(LibreX::new().expect("LibreX init failed")),
-            Box::new(Mojeek::new().expect("Mojeek init failed")),
-            Box::new(Startpage::new().expect("Startpage init failed")),
-            Box::new(Yahoo::new().expect("Yahoo init failed")),
-            Box::new(Yandex::new().expect("Yandex init failed")),
-        ];
+        let kinds = if engines.is_empty() {
+            WebSearchEngineKind::ALL.to_vec()
+        } else {
+            engines
+        };
+        let engines: Vec<Box<dyn SearchEngine>> =
+            kinds.into_iter().map(|k| k.instantiate()).collect();
 
         Self { engines, client }
     }
@@ -362,5 +361,44 @@ mod tests {
 
         let results = searcher.search("test", 5).await;
         assert_eq!(results.len(), 5);
+    }
+
+    // --- WebSearchEngineKind / MetaSearcher::new engine selection tests ---
+
+    #[test]
+    fn test_empty_engines_uses_all() {
+        let searcher = MetaSearcher::new(vec![]);
+        assert_eq!(
+            searcher.engines.len(),
+            WebSearchEngineKind::ALL.len(),
+            "empty engines vec should use all available engines"
+        );
+        let names: Vec<&str> = searcher.engines.iter().map(|e| e.name()).collect();
+        for kind in WebSearchEngineKind::ALL {
+            assert!(
+                names.contains(&kind.name()),
+                "engine {:?} should be present",
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn test_specific_engines_subset() {
+        let kinds = vec![WebSearchEngineKind::Google, WebSearchEngineKind::Brave];
+        let searcher = MetaSearcher::new(kinds.clone());
+        assert_eq!(searcher.engines.len(), 2);
+        let names: Vec<&str> = searcher.engines.iter().map(|e| e.name()).collect();
+        for kind in &kinds {
+            assert!(
+                names.contains(&kind.name()),
+                "engine {:?} should be present",
+                kind
+            );
+        }
+        assert!(
+            !names.contains(&WebSearchEngineKind::Bing.name()),
+            "Bing should not be present"
+        );
     }
 }

--- a/src/tool/impl/builtins/web_search/engines/mod.rs
+++ b/src/tool/impl/builtins/web_search/engines/mod.rs
@@ -14,6 +14,75 @@ pub use duckduckgo::DuckDuckGo;
 pub use google::Google;
 pub use librex::LibreX;
 pub use mojeek::Mojeek;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 pub use startpage::Startpage;
 pub use yahoo::Yahoo;
 pub use yandex::Yandex;
+
+use super::engine::SearchEngine;
+
+/// Identifies a specific web search engine available to [`MetaSearcher`](super::aggregator::MetaSearcher).
+///
+/// Pass a subset to [`MetaSearcher::new`](super::aggregator::MetaSearcher::new) to restrict
+/// which engines are used. An empty slice falls back to all engines.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub enum WebSearchEngineKind {
+    Bing,
+    Brave,
+    DuckDuckGo,
+    Google,
+    LibreX,
+    Mojeek,
+    Startpage,
+    Yahoo,
+    Yandex,
+}
+
+impl WebSearchEngineKind {
+    pub const ALL: &'static [WebSearchEngineKind] = &[
+        WebSearchEngineKind::Bing,
+        WebSearchEngineKind::Brave,
+        WebSearchEngineKind::DuckDuckGo,
+        WebSearchEngineKind::Google,
+        WebSearchEngineKind::LibreX,
+        WebSearchEngineKind::Mojeek,
+        WebSearchEngineKind::Startpage,
+        WebSearchEngineKind::Yahoo,
+        WebSearchEngineKind::Yandex,
+    ];
+
+    /// Returns the engine's canonical name string, matching `SearchEngine::name()`.
+    pub fn name(&self) -> &'static str {
+        match self {
+            WebSearchEngineKind::Bing => "Bing",
+            WebSearchEngineKind::Brave => "Brave",
+            WebSearchEngineKind::DuckDuckGo => "DuckDuckGo",
+            WebSearchEngineKind::Google => "Google",
+            WebSearchEngineKind::LibreX => "LibreX",
+            WebSearchEngineKind::Mojeek => "Mojeek",
+            WebSearchEngineKind::Startpage => "Startpage",
+            WebSearchEngineKind::Yahoo => "Yahoo",
+            WebSearchEngineKind::Yandex => "Yandex",
+        }
+    }
+
+    /// Constructs a boxed [`SearchEngine`] for this kind.
+    pub fn instantiate(&self) -> Box<dyn SearchEngine> {
+        match self {
+            WebSearchEngineKind::Bing => Box::new(Bing::new().expect("Bing init failed")),
+            WebSearchEngineKind::Brave => Box::new(Brave::new().expect("Brave init failed")),
+            WebSearchEngineKind::DuckDuckGo => {
+                Box::new(DuckDuckGo::new().expect("DuckDuckGo init failed"))
+            }
+            WebSearchEngineKind::Google => Box::new(Google::new().expect("Google init failed")),
+            WebSearchEngineKind::LibreX => Box::new(LibreX::new().expect("LibreX init failed")),
+            WebSearchEngineKind::Mojeek => Box::new(Mojeek::new().expect("Mojeek init failed")),
+            WebSearchEngineKind::Startpage => {
+                Box::new(Startpage::new().expect("Startpage init failed"))
+            }
+            WebSearchEngineKind::Yahoo => Box::new(Yahoo::new().expect("Yahoo init failed")),
+            WebSearchEngineKind::Yandex => Box::new(Yandex::new().expect("Yandex init failed")),
+        }
+    }
+}

--- a/src/tool/impl/builtins/web_search/mod.rs
+++ b/src/tool/impl/builtins/web_search/mod.rs
@@ -5,6 +5,7 @@ mod engines;
 use std::sync::Arc;
 
 use aggregator::MetaSearcher;
+pub use engines::WebSearchEngineKind;
 
 use crate::{
     datatype::Value,
@@ -38,9 +39,14 @@ pub fn get_web_search_tool_desc() -> ToolDesc {
         .build()
 }
 
-pub fn get_web_search_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
-    |_| {
-        let searcher = Arc::new(MetaSearcher::new());
+/// Returns a factory for the `web_search` tool that fans out to the given engines.
+///
+/// An empty `engines` vec falls back to all available engines.
+pub fn get_web_search_tool_factory(
+    engines: Vec<WebSearchEngineKind>,
+) -> impl Fn(&ToolDesc) -> ToolFunc {
+    move |_| {
+        let searcher = Arc::new(MetaSearcher::new(engines.clone()));
         tool_func!(async |args: Value| -> Value
             with [searcher = searcher.clone()]
             {
@@ -119,7 +125,7 @@ mod tests {
     #[ignore = "requires network"]
     async fn test_web_search_tool_aggregation() {
         // Call the underlying searcher directly so we can inspect AggregatedResult fields.
-        let searcher = MetaSearcher::new();
+        let searcher = MetaSearcher::new(vec![]);
         let results = searcher.search("ailoy", 20).await;
 
         println!("Total aggregated results: {}", results.len());
@@ -189,5 +195,23 @@ mod tests {
             "Expected results from at least 3 distinct engines, got {:?}",
             all_sources
         );
+    }
+
+    #[test]
+    fn test_engine_kind_all_count() {
+        assert_eq!(WebSearchEngineKind::ALL.len(), 9);
+    }
+
+    #[test]
+    fn test_engine_kind_name_matches_engine_name() {
+        for kind in WebSearchEngineKind::ALL {
+            let engine = kind.instantiate();
+            assert_eq!(
+                kind.name(),
+                engine.name(),
+                "WebSearchEngineKind::{:?} name() must match engine.name()",
+                kind
+            );
+        }
     }
 }

--- a/src/tool/impl/mod.rs
+++ b/src/tool/impl/mod.rs
@@ -3,5 +3,6 @@ mod builtins;
 mod subagent;
 
 // pub(crate) use a2a::{get_a2a_tool_desc, get_a2a_tool_func};
+pub use builtins::WebSearchEngineKind;
 pub(crate) use builtins::*;
 pub(crate) use subagent::{get_subagent_tool_desc, get_subagent_tool_func};

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -34,5 +34,6 @@ mod provider;
 
 pub use desc::*;
 pub use func::*;
+pub use r#impl::WebSearchEngineKind;
 pub use provider::*;
 // pub use r#impl::builtin::{};


### PR DESCRIPTION
## Summary

The `web_search` builtin tool previously always fanned out to all 9 search engines (Bing, Brave, DuckDuckGo, Google, LibreX, Mojeek, Startpage, Yahoo, Yandex). This PR adds the ability to restrict which engines are used, configured at tool creation time rather than per-call.

- Introduces `WebSearchEngineKind` enum that identifies each engine with a type-safe handle. Supports `serde` serialization and `schemars::JsonSchema` so it can be stored in `AgentSpec` without breaking serialization roundtrips.
- `MetaSearcher::new(engines: Vec<WebSearchEngineKind>)` accepts a subset of engines; an empty vec falls back to all 9 (preserving existing behavior).
- `get_web_search_tool_factory(engines)` captures the engine list at factory construction time — not exposed through the LLM-visible JSON Schema.
- `AgentSpec::web_search_tool(engines)` and `AgentBuilder::web_search_tool(engines)` updated accordingly. The selected engines are stored in a new `AgentSpec::web_search_engines` field (`None` = all engines, serialized only when set).
- At `Agent::try_with_provider_and_runenv`, if `spec.web_search_engines` is set, the default factory registered in `ToolProvider` is overridden before tool resolution — no changes to `ToolProvider`'s public API.

**Usage example:**
```rust
// Use only Google and Brave for this agent's web searches
let agent = AgentBuilder::new("anthropic/claude-sonnet-4-6")
    .web_search_tool(vec![WebSearchEngineKind::Google, WebSearchEngineKind::Brave])
    .build()?;

// Empty vec (or no-arg equivalent) = all engines (unchanged behavior)
let agent = AgentBuilder::new("anthropic/claude-sonnet-4-6")
    .web_search_tool(vec![])
    .build()?;
```

## Test plan

- [x] `test_engine_kind_all_count` — `WebSearchEngineKind::ALL` has exactly 9 entries
- [x] `test_engine_kind_name_matches_engine_name` — each enum variant's `name()` matches the underlying engine's `SearchEngine::name()`
- [x] `test_empty_engines_uses_all` — `MetaSearcher::new(vec![])` instantiates all 9 engines
- [x] `test_specific_engines_subset` — `MetaSearcher::new(vec![Google, Brave])` instantiates exactly those two
- [x] `test_web_search_tool_empty_engines_keeps_field_none` — `web_search_tool(vec![])` leaves `web_search_engines` as `None`
- [x] `test_web_search_tool_with_engines_stores_field` — `web_search_tool(vec![Google, Brave])` stores the field correctly and adds the `web_search` `ToolDesc`
- [x] `test_web_search_engines_omitted_from_serialisation_when_none` — `web_search_engines` is absent from JSON when `None`
- [x] `test_web_search_engines_roundtrip` — serde JSON roundtrip preserves engine selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)