### PR TITLE
feat(tool): add web_fetch builtin (single)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -61,6 +62,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "hex",
+ "html-to-markdown-rs",
  "image",
  "indexmap 2.14.0",
  "infer",
@@ -248,6 +250,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "astral-tl"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1006,6 +1017,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,7 +1231,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -2163,6 +2194,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2282,14 +2318,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
+name = "html-to-markdown-rs"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f856d5f5daa55ea8b81bd746f1e49170fe589eccd2f5020d9ea888417983ab"
+dependencies = [
+ "ahash",
+ "astral-tl",
+ "base64 0.22.1",
+ "html-escape",
+ "html5ever 0.39.0",
+ "lru 0.18.0",
+ "memchr",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.35.0",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -3051,6 +3126,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,8 +3180,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "tendril",
- "web_atoms",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.4",
 ]
 
 [[package]]
@@ -3952,7 +4047,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3961,8 +4066,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3971,8 +4086,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3981,8 +4106,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -3993,6 +4118,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4867,10 +5001,10 @@ dependencies = [
  "cssparser",
  "ego-tree",
  "getopts",
- "html5ever",
+ "html5ever 0.35.0",
  "precomputed-hash",
  "selectors",
- "tendril",
+ "tendril 0.4.3",
 ]
 
 [[package]]
@@ -5084,8 +5218,8 @@ dependencies = [
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -5610,9 +5744,21 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -5621,8 +5767,20 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -5776,6 +5934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "test-with"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5877,6 +6045,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6282,6 +6459,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6577,10 +6760,22 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ fancy-regex = "0.16"
 futures = "0.3"
 getrandom = "0.3"
 hex = "0.4"
+html-to-markdown-rs = { version = "3.4", features = ["metadata"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -110,6 +110,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn web_fetch_tool(mut self) -> Self {
+        self.spec = self.spec.web_fetch_tool();
+        self
+    }
+
     /// Append a sub-agent spec.  At [`build`](Self::build) time the sub-agent is
     /// materialised and registered as a callable tool, sharing the parent's [`RunEnv`].
     /// The sub-spec must carry an [`AgentCard`](crate::agent::AgentCard).

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -12,7 +12,7 @@ use crate::{
         r#impl::{
             get_apply_patch_tool_desc, get_edit_tool_desc, get_glob_tool_desc, get_grep_tool_desc,
             get_python_repl_tool_desc, get_read_tool_desc, get_shell_tool_desc,
-            get_web_search_tool_desc, get_write_tool_desc,
+            get_web_fetch_tool_desc, get_web_search_tool_desc, get_write_tool_desc,
         },
     },
 };
@@ -154,6 +154,17 @@ impl AgentSpec {
         if !engines.is_empty() {
             self.web_search_engines = Some(engines);
         }
+        self
+    }
+
+    /// Add the `web_fetch` tool to the spec.
+    ///
+    /// Like `web_search_tool`, this is opt-in and is not included in
+    /// `system_tools()`. The tool accepts either a single `url` or a `urls`
+    /// array (up to five) for parallel fetches, honors robots.txt, and
+    /// rate-limits one request per second per host.
+    pub fn web_fetch_tool(mut self) -> Self {
+        self.tools.push(get_web_fetch_tool_desc());
         self
     }
 

--- a/src/tool/impl/builtins/mod.rs
+++ b/src/tool/impl/builtins/mod.rs
@@ -5,6 +5,7 @@ mod grep;
 mod python_repl;
 mod read;
 mod shell;
+mod web_fetch;
 mod web_search;
 mod write;
 
@@ -17,6 +18,7 @@ pub use grep::*;
 pub use python_repl::*;
 pub use read::*;
 pub use shell::*;
+pub use web_fetch::*;
 pub use web_search::*;
 pub use write::*;
 
@@ -46,5 +48,6 @@ pub fn get_builtin_tool_factories() -> Vec<(&'static str, BuiltinFactory)> {
         ("glob", Arc::new(move |_| glob.clone())),
         ("grep", Arc::new(move |_| grep.clone())),
         ("web_search", Arc::new(get_web_search_tool_factory(vec![]))),
+        ("web_fetch", Arc::new(get_web_fetch_tool_factory())),
     ]
 }

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -143,14 +143,7 @@ fn convert_with_crate(html: &str, output_format: OutputFormat) -> Converted {
                 .document
                 .title
                 .clone()
-                .or_else(|| {
-                    result
-                        .metadata
-                        .document
-                        .open_graph
-                        .get("title")
-                        .cloned()
-                })
+                .or_else(|| result.metadata.document.open_graph.get("title").cloned())
                 .unwrap_or_default()
                 .trim()
                 .to_string();
@@ -224,11 +217,7 @@ fn slice_body(text: &str, offset: usize, len: usize) -> (String, usize, Option<u
     };
     let e = end_byte.unwrap_or(text.len());
     let slice = text[s..e].to_string();
-    let next_offset = if e < text.len() {
-        Some(end_char)
-    } else {
-        None
-    };
+    let next_offset = if e < text.len() { Some(end_char) } else { None };
     (slice, total_chars, next_offset)
 }
 
@@ -335,7 +324,10 @@ async fn fetch_one(
         Ok(t) => t,
         Err(e) => return crate::to_value!({"url": url_str, "error": e}),
     };
-    let Converted { body: readable, title } = convert(&body, &content_type, format);
+    let Converted {
+        body: readable,
+        title,
+    } = convert(&body, &content_type, format);
     let (slice, total_chars, next_offset) = slice_body(&readable, offset, length);
     let complete = next_offset.is_none();
     let next_offset = match next_offset {
@@ -483,16 +475,11 @@ mod tests {
 
     #[test]
     fn convert_markdown_preserves_structure() {
-        let html =
-            "<html><body><h1>Title</h1><p>See <a href=\"https://example.com/x\">docs</a></p></body></html>";
+        let html = "<html><body><h1>Title</h1><p>See <a href=\"https://example.com/x\">docs</a></p></body></html>";
         let out = convert(html, "text/html", BodyFormat::Markdown);
         // Markdown should keep the heading sigil and the anchor URL.
         assert!(out.body.contains("# Title"), "{}", out.body);
-        assert!(
-            out.body.contains("(https://example.com/x)"),
-            "{}",
-            out.body
-        );
+        assert!(out.body.contains("(https://example.com/x)"), "{}", out.body);
     }
 
     #[test]
@@ -595,5 +582,4 @@ mod tests {
             &body.chars().take(200).collect::<String>()
         );
     }
-
 }

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -1,0 +1,698 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use reqwest::Client;
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::{
+    datatype::Value,
+    tool::{ToolDesc, ToolDescBuilder, ToolFunc},
+    tool_func,
+};
+
+const DEFAULT_BODY_CHARS: usize = 30 * 1024;
+const MAX_BODY_CHARS: usize = 60 * 1024;
+const MAX_DOWNLOAD_BYTES: usize = 2 * 1024 * 1024;
+const MAX_URL_CHARS: usize = 2048;
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+const PER_HOST_MIN_INTERVAL: Duration = Duration::from_millis(1000);
+const MAX_BATCH_URLS: usize = 5;
+const USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; ailoy/web_fetch; +https://github.com/brekkylab/ailoy)";
+
+#[derive(Clone)]
+struct WebFetchState {
+    client: Client,
+    last_hit: Arc<Mutex<HashMap<String, Instant>>>,
+    robots: Arc<Mutex<HashMap<String, RobotsRules>>>,
+}
+
+impl WebFetchState {
+    fn new() -> Self {
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .expect("reqwest::Client builder cannot fail with these settings");
+        Self {
+            client,
+            last_hit: Arc::new(Mutex::new(HashMap::new())),
+            robots: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+struct RobotsRules {
+    disallow: Vec<String>,
+    allow: Vec<String>,
+    // Per RFC 9309 §2.3.1.4: when robots.txt cannot be fetched, allow all.
+    fetch_failed: bool,
+}
+
+impl RobotsRules {
+    fn permits(&self, path: &str) -> bool {
+        if self.fetch_failed {
+            return true;
+        }
+        let mut best_len = 0usize;
+        let mut best_allow = true;
+        for d in &self.disallow {
+            if !d.is_empty() && path.starts_with(d.as_str()) && d.len() >= best_len {
+                best_len = d.len();
+                best_allow = false;
+            }
+        }
+        for a in &self.allow {
+            if !a.is_empty() && path.starts_with(a.as_str()) && a.len() >= best_len {
+                best_len = a.len();
+                best_allow = true;
+            }
+        }
+        best_allow
+    }
+}
+
+fn parse_robots(body: &str) -> RobotsRules {
+    let mut rules = RobotsRules::default();
+    let mut applies_to_us = false;
+    for raw in body.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let (key, value) = match line.split_once(':') {
+            Some((k, v)) => (k.trim().to_ascii_lowercase(), v.trim().to_string()),
+            None => continue,
+        };
+        match key.as_str() {
+            "user-agent" => applies_to_us = value == "*",
+            "disallow" if applies_to_us => rules.disallow.push(value),
+            "allow" if applies_to_us => rules.allow.push(value),
+            _ => {}
+        }
+    }
+    rules
+}
+
+async fn robots_rules_for(state: &WebFetchState, host_origin: &str) -> RobotsRules {
+    if let Some(cached) = state.robots.lock().get(host_origin).cloned() {
+        return cached;
+    }
+    let robots_url = format!("{host_origin}/robots.txt");
+    let rules = match state.client.get(&robots_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body = resp.text().await.unwrap_or_default();
+            parse_robots(&body)
+        }
+        _ => RobotsRules {
+            fetch_failed: true,
+            ..Default::default()
+        },
+    };
+    state
+        .robots
+        .lock()
+        .insert(host_origin.to_string(), rules.clone());
+    rules
+}
+
+async fn rate_limit_for(state: &WebFetchState, host: &str) {
+    let wait = {
+        let mut m = state.last_hit.lock();
+        let now = Instant::now();
+        let wait = m
+            .get(host)
+            .and_then(|when| PER_HOST_MIN_INTERVAL.checked_sub(now.duration_since(*when)))
+            .unwrap_or(Duration::ZERO);
+        m.insert(host.to_string(), now + wait);
+        wait
+    };
+    if !wait.is_zero() {
+        tokio::time::sleep(wait).await;
+    }
+}
+
+async fn download(
+    state: &WebFetchState,
+    url: &str,
+) -> Result<(String, String, u16, String), String> {
+    let resp = state
+        .client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+    let status = resp.status().as_u16();
+    let final_url = resp.url().to_string();
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    // Stream chunks instead of buffering the full body, capped at MAX_DOWNLOAD_BYTES.
+    use futures::StreamExt;
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::with_capacity(64 * 1024);
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("read body chunk: {e}"))?;
+        let remaining = MAX_DOWNLOAD_BYTES.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        if chunk.len() <= remaining {
+            buf.extend_from_slice(&chunk);
+        } else {
+            buf.extend_from_slice(&chunk[..remaining]);
+            break;
+        }
+    }
+    let body = String::from_utf8_lossy(&buf).into_owned();
+    Ok((body, content_type, status, final_url))
+}
+
+fn html_to_text(body: &str) -> String {
+    let doc = Html::parse_document(body);
+    let mut out = String::new();
+    walk(doc.root_element(), &mut out);
+
+    // Collapse 3+ newlines to 2 and trim.
+    let mut collapsed = String::with_capacity(out.len());
+    let mut newline_run = 0;
+    for ch in out.chars() {
+        if ch == '\n' {
+            newline_run += 1;
+            if newline_run <= 2 {
+                collapsed.push('\n');
+            }
+        } else {
+            newline_run = 0;
+            collapsed.push(ch);
+        }
+    }
+    collapsed.trim().to_string()
+}
+
+fn walk(el: scraper::ElementRef, out: &mut String) {
+    let tag = el.value().name();
+    if matches!(tag, "script" | "style" | "noscript" | "svg" | "template") {
+        return;
+    }
+    let is_block = matches!(
+        tag,
+        "p" | "div"
+            | "section"
+            | "article"
+            | "header"
+            | "footer"
+            | "nav"
+            | "main"
+            | "aside"
+            | "li"
+            | "tr"
+            | "h1"
+            | "h2"
+            | "h3"
+            | "h4"
+            | "h5"
+            | "h6"
+            | "blockquote"
+            | "pre"
+            | "ul"
+            | "ol"
+            | "table"
+            | "br"
+            | "hr"
+    );
+    if is_block && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if tag == "a" {
+        let text = el.text().collect::<String>();
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            out.push_str(trimmed);
+            if let Some(href) = el.value().attr("href") {
+                let h = href.trim();
+                if !h.is_empty() && !h.starts_with('#') {
+                    out.push_str(" [");
+                    out.push_str(h);
+                    out.push(']');
+                }
+            }
+        }
+    } else {
+        for child in el.children() {
+            if let Some(child_el) = scraper::ElementRef::wrap(child) {
+                walk(child_el, out);
+            } else if let Some(text) = child.value().as_text() {
+                out.push_str(text);
+            }
+        }
+    }
+    if is_block && !out.ends_with('\n') {
+        out.push('\n');
+    }
+}
+
+fn extract_title(content_type: &str, body: &str) -> String {
+    if !content_type.to_ascii_lowercase().contains("html") {
+        return String::new();
+    }
+    let doc = Html::parse_document(body);
+    let sel = Selector::parse("title").expect("static selector");
+    let raw = doc
+        .select(&sel)
+        .next()
+        .map(|el| el.text().collect::<String>())
+        .unwrap_or_default();
+    // HTML parsers treat <title> as RAWTEXT, so inline tags like <b>...</b>
+    // come through as literal text. Strip them with a simple manual pass.
+    let mut out = String::with_capacity(raw.len());
+    let mut in_tag = false;
+    for ch in raw.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' if in_tag => in_tag = false,
+            c if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.trim().to_string()
+}
+
+fn extract_readable(body: &str, content_type: &str) -> String {
+    if content_type.to_ascii_lowercase().contains("html") {
+        html_to_text(body)
+    } else {
+        body.to_string()
+    }
+}
+
+fn slice_body(text: &str, offset: usize, len: usize) -> (String, usize, bool) {
+    let total: Vec<char> = text.chars().collect();
+    let total_chars = total.len();
+    if offset >= total_chars {
+        return (String::new(), total_chars, true);
+    }
+    let end = offset.saturating_add(len).min(total_chars);
+    let slice: String = total[offset..end].iter().collect();
+    let truncated = end < total_chars;
+    (slice, total_chars, !truncated)
+}
+
+fn now_iso_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400);
+    let (y, m, d) = civil_from_days(days);
+    let hh = sod / 3600;
+    let mm = (sod % 3600) / 60;
+    let ss = sod % 60;
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+// Howard Hinnant's `civil_from_days`. days since 1970-01-01 -> (y, m, d).
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+pub fn get_web_fetch_tool_desc() -> ToolDesc {
+    ToolDescBuilder::new("web_fetch")
+        .description(concat!(
+            "Fetch one or more URLs and return readable bodies. HTML is reduced ",
+            "to plain text: script/style/svg/template/noscript subtrees are ",
+            "removed and <a href> anchors render as `text [url]` so outbound ",
+            "links survive. Use this after `web_search` to read the full body ",
+            "of a result instead of relying on the snippet.\n\n",
+            "Two call shapes:\n",
+            "  - single: pass `url` (string), get one result back.\n",
+            "  - batch: pass `urls` (array of strings) to fetch up to 5 URLs in ",
+            "parallel. The response is `{\"results\": [...]}` with one entry ",
+            "per input URL, in the same order. Independent fetches (e.g. ",
+            "URLs returned by one `web_search` call) should be batched.\n\n",
+            "Each body is clamped to 30 KiB by default; for more, call again ",
+            "with `offset` set to the previous `next_offset`. Respects ",
+            "robots.txt and rate-limits 1 request/second per host."
+        ))
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Single URL to fetch. Use this OR `urls`, not both."
+                },
+                "urls": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Batch of URLs to fetch in parallel (max 5). Use this OR `url`. Returns `{results: [...]}` matching input order."
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Character offset into each readable body. Use 0 for the first call; on subsequent calls pass the `next_offset` returned previously.",
+                    "default": 0,
+                    "minimum": 0
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "Maximum number of characters per body returned in this call. Default 30720 (30 KiB). Hard cap 61440.",
+                    "default": 30720,
+                    "minimum": 256,
+                    "maximum": 61440
+                }
+            }
+        }))
+        .build()
+}
+
+async fn fetch_one(state: WebFetchState, url_str: String, offset: usize, length: usize) -> Value {
+    if url_str.len() > MAX_URL_CHARS {
+        let msg = format!("url exceeds {MAX_URL_CHARS} characters");
+        return crate::to_value!({"url": url_str, "error": msg});
+    }
+    let parsed = match Url::parse(&url_str) {
+        Ok(u) => u,
+        Err(e) => {
+            let msg = format!("invalid url: {e}");
+            return crate::to_value!({"url": url_str, "error": msg});
+        }
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        let msg = format!("unsupported scheme: {}", parsed.scheme());
+        return crate::to_value!({"url": url_str, "error": msg});
+    }
+    let host = match parsed.host_str() {
+        Some(h) => h.to_string(),
+        None => return crate::to_value!({"url": url_str, "error": "url has no host"}),
+    };
+    let host_origin = format!("{}://{}", parsed.scheme(), host);
+
+    let rules = robots_rules_for(&state, &host_origin).await;
+    if !rules.permits(parsed.path()) {
+        let msg = format!("robots.txt disallows fetching {url_str}");
+        return crate::to_value!({"url": url_str, "error": msg});
+    }
+
+    rate_limit_for(&state, &host).await;
+
+    let (body, content_type, status, final_url) = match download(&state, &url_str).await {
+        Ok(t) => t,
+        Err(e) => return crate::to_value!({"url": url_str, "error": e}),
+    };
+    let title = extract_title(&content_type, &body);
+    let readable = extract_readable(&body, &content_type);
+    let (slice, total_chars, complete) = slice_body(&readable, offset, length);
+    let next_offset = if complete {
+        Value::Null
+    } else {
+        Value::from((offset + slice.chars().count()) as i64)
+    };
+
+    crate::to_value!({
+        "url": final_url,
+        "status": status as i64,
+        "title": title,
+        "content_type": content_type,
+        "body": slice,
+        "body_length_total": total_chars as i64,
+        "next_offset": next_offset,
+        "complete": complete,
+        "retrieved_at": now_iso_utc()
+    })
+}
+
+/// Factory closes over a process-wide [`WebFetchState`] so the rate limiter
+/// and robots cache are shared across calls, matching `web_search`.
+pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
+    let state = WebFetchState::new();
+    move |_| {
+        let state = state.clone();
+        tool_func!(async |args: Value| -> Value with [state = state.clone()] {
+            let offset = args
+                .pointer("/offset")
+                .and_then(|v| v.as_integer())
+                .unwrap_or(0)
+                .max(0) as usize;
+            let length = args
+                .pointer("/length")
+                .and_then(|v| v.as_integer())
+                .map(|n| n.max(256).min(MAX_BODY_CHARS as i64) as usize)
+                .unwrap_or(DEFAULT_BODY_CHARS);
+
+            // `urls` (array) takes precedence over `url` when both are sent.
+            let urls_array = args.pointer("/urls").and_then(|v| v.as_array()).cloned();
+
+            if let Some(urls) = urls_array {
+                let urls: Vec<String> = urls
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                if urls.is_empty() {
+                    return crate::to_value!({
+                        "error": "`urls` array is empty or contains no strings"
+                    });
+                }
+                if urls.len() > MAX_BATCH_URLS {
+                    let msg = format!(
+                        "batch size {} exceeds max {MAX_BATCH_URLS} — split into multiple calls",
+                        urls.len()
+                    );
+                    return crate::to_value!({"error": msg});
+                }
+
+                let mut handles = Vec::with_capacity(urls.len());
+                for u in urls {
+                    handles.push(tokio::spawn(fetch_one(state.clone(), u, offset, length)));
+                }
+                let mut results: Vec<Value> = Vec::with_capacity(handles.len());
+                for h in handles {
+                    match h.await {
+                        Ok(v) => results.push(v),
+                        Err(e) => {
+                            let msg = format!("fetch task panicked: {e}");
+                            results.push(crate::to_value!({"error": msg}));
+                        }
+                    }
+                }
+                return crate::to_value!({"results": Value::array(results)});
+            }
+
+            let url_str = match args.pointer("/url").and_then(|v| v.as_str()) {
+                Some(u) => u.to_string(),
+                None => {
+                    return crate::to_value!({
+                        "error": "missing required parameter: either `url` (string) or `urls` (array)"
+                    });
+                }
+            };
+            fetch_one(state, url_str, offset, length).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slice_body_basic() {
+        let s = "abcdefghij";
+        let (out, total, complete) = slice_body(s, 0, 5);
+        assert_eq!(out, "abcde");
+        assert_eq!(total, 10);
+        assert!(!complete);
+        let (out2, _, complete2) = slice_body(s, 5, 5);
+        assert_eq!(out2, "fghij");
+        assert!(complete2);
+        let (out3, _, complete3) = slice_body(s, 100, 5);
+        assert_eq!(out3, "");
+        assert!(complete3);
+    }
+
+    #[test]
+    fn slice_body_unicode_is_char_based() {
+        let s = "한국어테스트";
+        let (out, total, _) = slice_body(s, 0, 3);
+        assert_eq!(out, "한국어");
+        assert_eq!(total, 6);
+    }
+
+    #[test]
+    fn robots_longest_match_wins() {
+        let body = "User-agent: *\nDisallow: /private\nAllow: /private/public\n";
+        let rules = parse_robots(body);
+        assert!(!rules.permits("/private/secret.html"));
+        assert!(rules.permits("/private/public/file.html"));
+        assert!(rules.permits("/about"));
+    }
+
+    #[test]
+    fn robots_other_user_agents_are_ignored() {
+        let body = "User-agent: GoogleBot\nDisallow: /\n";
+        let rules = parse_robots(body);
+        assert!(rules.permits("/anything"));
+    }
+
+    #[test]
+    fn robots_fetch_failed_allows_all() {
+        let rules = RobotsRules {
+            fetch_failed: true,
+            disallow: vec!["/".into()],
+            ..Default::default()
+        };
+        assert!(rules.permits("/anything"));
+    }
+
+    #[test]
+    fn html_to_text_strips_script_and_style() {
+        let html = "<html><body>\
+                    <script>var x = 1;</script>\
+                    <style>body { color: red; }</style>\
+                    <h1>Hello</h1>\
+                    <p>World</p>\
+                    </body></html>";
+        let out = html_to_text(html);
+        assert!(!out.contains("var x"), "{out}");
+        assert!(!out.contains("color: red"), "{out}");
+        assert!(out.contains("Hello"), "{out}");
+        assert!(out.contains("World"), "{out}");
+    }
+
+    #[test]
+    fn html_to_text_preserves_anchor_href() {
+        let html =
+            "<html><body><p>See <a href=\"https://example.com/x\">the docs</a></p></body></html>";
+        let out = html_to_text(html);
+        assert!(
+            out.contains("the docs [https://example.com/x]"),
+            "anchor href should survive flattening, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn html_to_text_skips_pure_fragment_links() {
+        let html = "<a href=\"#top\">jump</a>";
+        let out = html_to_text(html);
+        assert!(out.contains("jump"), "{out}");
+        assert!(!out.contains("[#top]"), "{out}");
+    }
+
+    #[test]
+    fn extract_title_pulls_title_element() {
+        let html = "<html><head><title>Hello <b>World</b></title></head><body></body></html>";
+        let title = extract_title("text/html", html);
+        assert_eq!(title, "Hello World");
+    }
+
+    #[test]
+    fn extract_title_empty_for_non_html_content_type() {
+        let html = "<title>Foo</title>";
+        assert_eq!(extract_title("application/json", html), "");
+    }
+
+    #[test]
+    fn descriptor_shape() {
+        let desc = get_web_fetch_tool_desc();
+        assert_eq!(desc.name, "web_fetch");
+        assert!(desc.description.is_some());
+    }
+
+    /// Single-URL fetch against a stable public endpoint.
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn network_single_fetch_returns_200_and_body() {
+        let state = WebFetchState::new();
+        let result = fetch_one(
+            state,
+            "https://example.com/".to_string(),
+            0,
+            DEFAULT_BODY_CHARS,
+        )
+        .await;
+        let status = result
+            .pointer("/status")
+            .and_then(|v| v.as_integer())
+            .unwrap_or(0);
+        let body = result
+            .pointer("/body")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let retrieved_at = result
+            .pointer("/retrieved_at")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert_eq!(status, 200, "result: {result:?}");
+        assert!(
+            body.to_ascii_lowercase().contains("example domain"),
+            "body should mention `Example Domain`, got first 200 chars: {:?}",
+            &body.chars().take(200).collect::<String>()
+        );
+        assert!(retrieved_at.ends_with('Z'), "retrieved_at: {retrieved_at}");
+    }
+
+    /// Batch fetch across multiple distinct hosts. Verifies the response
+    /// shape (`{"results": [...]}`), input-order preservation, and that all
+    /// five fetches return a non-empty body.
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn network_batch_fetch_returns_results_in_order() {
+        let state = WebFetchState::new();
+        let urls = vec![
+            "https://example.com/".to_string(),
+            "https://example.org/".to_string(),
+            "https://example.net/".to_string(),
+        ];
+        let mut handles = Vec::with_capacity(urls.len());
+        for u in urls.iter() {
+            handles.push(tokio::spawn(fetch_one(
+                state.clone(),
+                u.clone(),
+                0,
+                DEFAULT_BODY_CHARS,
+            )));
+        }
+        let mut results = Vec::with_capacity(handles.len());
+        for h in handles {
+            results.push(h.await.unwrap());
+        }
+        assert_eq!(results.len(), urls.len());
+        for (i, r) in results.iter().enumerate() {
+            let url = r
+                .pointer("/url")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let status = r
+                .pointer("/status")
+                .and_then(|v| v.as_integer())
+                .unwrap_or(0);
+            let body = r
+                .pointer("/body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            assert!(
+                url.starts_with(&urls[i].trim_end_matches('/')),
+                "result {i} url mismatch: input={} got={url}",
+                urls[i]
+            );
+            assert_eq!(status, 200, "result {i}: {r:?}");
+            assert!(!body.is_empty(), "result {i} body empty");
+        }
+    }
+}

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use html_to_markdown_rs::{ConversionOptions, OutputFormat};
 use parking_lot::Mutex;
 use reqwest::Client;
-use scraper::{Html, Selector};
 use url::Url;
 
 use crate::{
@@ -27,7 +27,6 @@ const USER_AGENT: &str =
 struct WebFetchState {
     client: Client,
     last_hit: Arc<Mutex<HashMap<String, Instant>>>,
-    robots: Arc<Mutex<HashMap<String, RobotsRules>>>,
 }
 
 impl WebFetchState {
@@ -40,84 +39,8 @@ impl WebFetchState {
         Self {
             client,
             last_hit: Arc::new(Mutex::new(HashMap::new())),
-            robots: Arc::new(Mutex::new(HashMap::new())),
         }
     }
-}
-
-#[derive(Default, Clone)]
-struct RobotsRules {
-    disallow: Vec<String>,
-    allow: Vec<String>,
-    // Per RFC 9309 §2.3.1.4: when robots.txt cannot be fetched, allow all.
-    fetch_failed: bool,
-}
-
-impl RobotsRules {
-    fn permits(&self, path: &str) -> bool {
-        if self.fetch_failed {
-            return true;
-        }
-        let mut best_len = 0usize;
-        let mut best_allow = true;
-        for d in &self.disallow {
-            if !d.is_empty() && path.starts_with(d.as_str()) && d.len() >= best_len {
-                best_len = d.len();
-                best_allow = false;
-            }
-        }
-        for a in &self.allow {
-            if !a.is_empty() && path.starts_with(a.as_str()) && a.len() >= best_len {
-                best_len = a.len();
-                best_allow = true;
-            }
-        }
-        best_allow
-    }
-}
-
-fn parse_robots(body: &str) -> RobotsRules {
-    let mut rules = RobotsRules::default();
-    let mut applies_to_us = false;
-    for raw in body.lines() {
-        let line = raw.split('#').next().unwrap_or("").trim();
-        if line.is_empty() {
-            continue;
-        }
-        let (key, value) = match line.split_once(':') {
-            Some((k, v)) => (k.trim().to_ascii_lowercase(), v.trim().to_string()),
-            None => continue,
-        };
-        match key.as_str() {
-            "user-agent" => applies_to_us = value == "*",
-            "disallow" if applies_to_us => rules.disallow.push(value),
-            "allow" if applies_to_us => rules.allow.push(value),
-            _ => {}
-        }
-    }
-    rules
-}
-
-async fn robots_rules_for(state: &WebFetchState, host_origin: &str) -> RobotsRules {
-    if let Some(cached) = state.robots.lock().get(host_origin).cloned() {
-        return cached;
-    }
-    let robots_url = format!("{host_origin}/robots.txt");
-    let rules = match state.client.get(&robots_url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            let body = resp.text().await.unwrap_or_default();
-            parse_robots(&body)
-        }
-        _ => RobotsRules {
-            fetch_failed: true,
-            ..Default::default()
-        },
-    };
-    state
-        .robots
-        .lock()
-        .insert(host_origin.to_string(), rules.clone());
-    rules
 }
 
 async fn rate_limit_for(state: &WebFetchState, host: &str) {
@@ -175,134 +98,135 @@ async fn download(
     Ok((body, content_type, status, final_url))
 }
 
-fn html_to_text(body: &str) -> String {
-    let doc = Html::parse_document(body);
-    let mut out = String::new();
-    walk(doc.root_element(), &mut out);
-
-    // Collapse 3+ newlines to 2 and trim.
-    let mut collapsed = String::with_capacity(out.len());
-    let mut newline_run = 0;
-    for ch in out.chars() {
-        if ch == '\n' {
-            newline_run += 1;
-            if newline_run <= 2 {
-                collapsed.push('\n');
-            }
-        } else {
-            newline_run = 0;
-            collapsed.push(ch);
-        }
-    }
-    collapsed.trim().to_string()
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum BodyFormat {
+    Text,
+    Markdown,
+    Html,
 }
 
-fn walk(el: scraper::ElementRef, out: &mut String) {
-    let tag = el.value().name();
-    if matches!(tag, "script" | "style" | "noscript" | "svg" | "template") {
-        return;
+impl BodyFormat {
+    fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "text" | "plain" | "plaintext" => Some(Self::Text),
+            "markdown" | "md" => Some(Self::Markdown),
+            "html" | "raw" => Some(Self::Html),
+            _ => None,
+        }
     }
-    let is_block = matches!(
-        tag,
-        "p" | "div"
-            | "section"
-            | "article"
-            | "header"
-            | "footer"
-            | "nav"
-            | "main"
-            | "aside"
-            | "li"
-            | "tr"
-            | "h1"
-            | "h2"
-            | "h3"
-            | "h4"
-            | "h5"
-            | "h6"
-            | "blockquote"
-            | "pre"
-            | "ul"
-            | "ol"
-            | "table"
-            | "br"
-            | "hr"
-    );
-    if is_block && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    if tag == "a" {
-        let text = el.text().collect::<String>();
-        let trimmed = text.trim();
-        if !trimmed.is_empty() {
-            out.push_str(trimmed);
-            if let Some(href) = el.value().attr("href") {
-                let h = href.trim();
-                if !h.is_empty() && !h.starts_with('#') {
-                    out.push_str(" [");
-                    out.push_str(h);
-                    out.push(']');
-                }
+}
+
+// Output of the HTML→{text,markdown} conversion path. We return both the
+// readable body and the document title because `html_to_markdown_rs` already
+// extracts both in one pass — no point parsing twice.
+struct Converted {
+    body: String,
+    title: String,
+}
+
+fn convert_with_crate(html: &str, output_format: OutputFormat) -> Converted {
+    let opts = ConversionOptions::builder()
+        .output_format(output_format)
+        // Inline base64 data-URI images blow up the byte budget for no
+        // benefit to an LLM caller; skip them.
+        .skip_images(true)
+        .build();
+    match html_to_markdown_rs::convert(html, Some(opts)) {
+        Ok(result) => {
+            // Prefer the `<title>` element; fall back to `og:title` so SPAs
+            // that set only the OG tag still surface something useful.
+            let title = result
+                .metadata
+                .document
+                .title
+                .clone()
+                .or_else(|| {
+                    result
+                        .metadata
+                        .document
+                        .open_graph
+                        .get("title")
+                        .cloned()
+                })
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            Converted {
+                body: result.content.unwrap_or_default(),
+                title,
             }
         }
+        // On conversion error (malformed input, etc.), return the raw input
+        // and an empty title rather than surfacing an error — `web_fetch` is
+        // best-effort.
+        Err(_) => Converted {
+            body: html.to_string(),
+            title: String::new(),
+        },
+    }
+}
+
+// Pick the conversion path for the requested format and content-type.
+//
+// - `format=html`: raw passthrough, regardless of content type.
+// - `format={text,markdown}`: route HTML through `html_to_markdown_rs`;
+//   non-HTML content (JSON, plain text, etc.) passes through verbatim so a
+//   caller asking for a JSON body gets a JSON body, not an empty conversion.
+fn convert(body: &str, content_type: &str, format: BodyFormat) -> Converted {
+    if matches!(format, BodyFormat::Html) {
+        return Converted {
+            body: body.to_string(),
+            title: String::new(),
+        };
+    }
+    let is_html = content_type.to_ascii_lowercase().contains("html");
+    if !is_html {
+        return Converted {
+            body: body.to_string(),
+            title: String::new(),
+        };
+    }
+    let output_format = match format {
+        BodyFormat::Text => OutputFormat::Plain,
+        BodyFormat::Markdown => OutputFormat::Markdown,
+        BodyFormat::Html => unreachable!(),
+    };
+    convert_with_crate(body, output_format)
+}
+
+// Returns `(slice, total_chars, next_offset)`. `next_offset = None` means the
+// slice reaches the end of `text` (caller treats this as `complete`).
+//
+// Single `char_indices()` pass: locates the start/end byte boundaries for the
+// requested char window, counts total chars, and computes `next_offset` without
+// re-iterating the slice or copying into a `Vec<char>`. Byte-indexing into
+// `text` is safe because `char_indices()` yields char-boundary offsets.
+fn slice_body(text: &str, offset: usize, len: usize) -> (String, usize, Option<usize>) {
+    let end_char = offset.saturating_add(len);
+    let mut start_byte: Option<usize> = None;
+    let mut end_byte: Option<usize> = None;
+    let mut total_chars: usize = 0;
+    for (char_idx, (byte_idx, _)) in text.char_indices().enumerate() {
+        if char_idx == offset {
+            start_byte = Some(byte_idx);
+        }
+        if char_idx == end_char {
+            end_byte = Some(byte_idx);
+        }
+        total_chars = char_idx + 1;
+    }
+    let Some(s) = start_byte else {
+        // `offset >= total_chars`: nothing to return, and we are complete.
+        return (String::new(), total_chars, None);
+    };
+    let e = end_byte.unwrap_or(text.len());
+    let slice = text[s..e].to_string();
+    let next_offset = if e < text.len() {
+        Some(end_char)
     } else {
-        for child in el.children() {
-            if let Some(child_el) = scraper::ElementRef::wrap(child) {
-                walk(child_el, out);
-            } else if let Some(text) = child.value().as_text() {
-                out.push_str(text);
-            }
-        }
-    }
-    if is_block && !out.ends_with('\n') {
-        out.push('\n');
-    }
-}
-
-fn extract_title(content_type: &str, body: &str) -> String {
-    if !content_type.to_ascii_lowercase().contains("html") {
-        return String::new();
-    }
-    let doc = Html::parse_document(body);
-    let sel = Selector::parse("title").expect("static selector");
-    let raw = doc
-        .select(&sel)
-        .next()
-        .map(|el| el.text().collect::<String>())
-        .unwrap_or_default();
-    // HTML parsers treat <title> as RAWTEXT, so inline tags like <b>...</b>
-    // come through as literal text. Strip them with a simple manual pass.
-    let mut out = String::with_capacity(raw.len());
-    let mut in_tag = false;
-    for ch in raw.chars() {
-        match ch {
-            '<' => in_tag = true,
-            '>' if in_tag => in_tag = false,
-            c if !in_tag => out.push(c),
-            _ => {}
-        }
-    }
-    out.trim().to_string()
-}
-
-fn extract_readable(body: &str, content_type: &str) -> String {
-    if content_type.to_ascii_lowercase().contains("html") {
-        html_to_text(body)
-    } else {
-        body.to_string()
-    }
-}
-
-fn slice_body(text: &str, offset: usize, len: usize) -> (String, usize, bool) {
-    let total: Vec<char> = text.chars().collect();
-    let total_chars = total.len();
-    if offset >= total_chars {
-        return (String::new(), total_chars, true);
-    }
-    let end = offset.saturating_add(len).min(total_chars);
-    let slice: String = total[offset..end].iter().collect();
-    let truncated = end < total_chars;
-    (slice, total_chars, !truncated)
+        None
+    };
+    (slice, total_chars, next_offset)
 }
 
 fn now_iso_utc() -> String {
@@ -337,11 +261,12 @@ fn civil_from_days(days: i64) -> (i64, u32, u32) {
 pub fn get_web_fetch_tool_desc() -> ToolDesc {
     ToolDescBuilder::new("web_fetch")
         .description(concat!(
-            "Fetch one or more URLs and return readable bodies. HTML is reduced ",
-            "to plain text: script/style/svg/template/noscript subtrees are ",
-            "removed and <a href> anchors render as `text [url]` so outbound ",
-            "links survive. Use this after `web_search` to read the full body ",
-            "of a result instead of relying on the snippet.\n\n",
+            "Fetch one or more URLs and return their bodies. HTML responses ",
+            "are converted via `html-to-markdown-rs`, which uses `html5ever` ",
+            "to parse, drops script/style/nav noise, and emits the requested ",
+            "format. Non-HTML responses (JSON, plain text, etc.) pass through ",
+            "unchanged. Use this after `web_search` to read a result's full ",
+            "body instead of relying on the snippet.\n\n",
             "Two call shapes:\n",
             "  - single: pass `url` (string), get one result back.\n",
             "  - batch: pass `urls` (array of strings) to fetch up to 5 URLs in ",
@@ -349,8 +274,8 @@ pub fn get_web_fetch_tool_desc() -> ToolDesc {
             "per input URL, in the same order. Independent fetches (e.g. ",
             "URLs returned by one `web_search` call) should be batched.\n\n",
             "Each body is clamped to 30 KiB by default; for more, call again ",
-            "with `offset` set to the previous `next_offset`. Respects ",
-            "robots.txt and rate-limits 1 request/second per host."
+            "with `offset` set to the previous `next_offset`. Rate-limited to ",
+            "1 request/second per host."
         ))
         .parameters(crate::to_value!({
             "type": "object",
@@ -364,9 +289,15 @@ pub fn get_web_fetch_tool_desc() -> ToolDesc {
                     "items": { "type": "string" },
                     "description": "Batch of URLs to fetch in parallel (max 5). Use this OR `url`. Returns `{results: [...]}` matching input order."
                 },
+                "format": {
+                    "type": "string",
+                    "enum": ["text", "markdown", "html"],
+                    "description": "Body format. `text` (default) returns visible text only — smallest token cost, no document structure. `markdown` returns CommonMark — preserves headings, lists, tables, and link targets. `html` returns the response body unchanged.",
+                    "default": "text"
+                },
                 "offset": {
                     "type": "integer",
-                    "description": "Character offset into each readable body. Use 0 for the first call; on subsequent calls pass the `next_offset` returned previously.",
+                    "description": "Character offset into each body. Use 0 for the first call; on subsequent calls pass the `next_offset` returned previously.",
                     "default": 0,
                     "minimum": 0
                 },
@@ -382,7 +313,13 @@ pub fn get_web_fetch_tool_desc() -> ToolDesc {
         .build()
 }
 
-async fn fetch_one(state: WebFetchState, url_str: String, offset: usize, length: usize) -> Value {
+async fn fetch_one(
+    state: WebFetchState,
+    url_str: String,
+    offset: usize,
+    length: usize,
+    format: BodyFormat,
+) -> Value {
     if url_str.len() > MAX_URL_CHARS {
         let msg = format!("url exceeds {MAX_URL_CHARS} characters");
         return crate::to_value!({"url": url_str, "error": msg});
@@ -402,13 +339,6 @@ async fn fetch_one(state: WebFetchState, url_str: String, offset: usize, length:
         Some(h) => h.to_string(),
         None => return crate::to_value!({"url": url_str, "error": "url has no host"}),
     };
-    let host_origin = format!("{}://{}", parsed.scheme(), host);
-
-    let rules = robots_rules_for(&state, &host_origin).await;
-    if !rules.permits(parsed.path()) {
-        let msg = format!("robots.txt disallows fetching {url_str}");
-        return crate::to_value!({"url": url_str, "error": msg});
-    }
 
     rate_limit_for(&state, &host).await;
 
@@ -416,13 +346,12 @@ async fn fetch_one(state: WebFetchState, url_str: String, offset: usize, length:
         Ok(t) => t,
         Err(e) => return crate::to_value!({"url": url_str, "error": e}),
     };
-    let title = extract_title(&content_type, &body);
-    let readable = extract_readable(&body, &content_type);
-    let (slice, total_chars, complete) = slice_body(&readable, offset, length);
-    let next_offset = if complete {
-        Value::Null
-    } else {
-        Value::from((offset + slice.chars().count()) as i64)
+    let Converted { body: readable, title } = convert(&body, &content_type, format);
+    let (slice, total_chars, next_offset) = slice_body(&readable, offset, length);
+    let complete = next_offset.is_none();
+    let next_offset = match next_offset {
+        Some(n) => Value::from(n as i64),
+        None => Value::Null,
     };
 
     crate::to_value!({
@@ -439,7 +368,7 @@ async fn fetch_one(state: WebFetchState, url_str: String, offset: usize, length:
 }
 
 /// Factory closes over a process-wide [`WebFetchState`] so the rate limiter
-/// and robots cache are shared across calls, matching `web_search`.
+/// is shared across calls, matching `web_search`.
 pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
     let state = WebFetchState::new();
     move |_| {
@@ -455,6 +384,13 @@ pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
                 .and_then(|v| v.as_integer())
                 .map(|n| n.max(256).min(MAX_BODY_CHARS as i64) as usize)
                 .unwrap_or(DEFAULT_BODY_CHARS);
+            // Unknown `format` values silently fall back to "text" so a
+            // mistyped value still returns something useful.
+            let format = args
+                .pointer("/format")
+                .and_then(|v| v.as_str())
+                .and_then(BodyFormat::parse)
+                .unwrap_or(BodyFormat::Text);
 
             // Accept `urls` only when it is a non-empty array of strings.
             // An empty/missing `urls` (some LLMs send `"urls": []` next to a
@@ -482,7 +418,13 @@ pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
 
                 let mut handles = Vec::with_capacity(urls.len());
                 for u in urls {
-                    handles.push(tokio::spawn(fetch_one(state.clone(), u, offset, length)));
+                    handles.push(tokio::spawn(fetch_one(
+                        state.clone(),
+                        u,
+                        offset,
+                        length,
+                        format,
+                    )));
                 }
                 let mut results: Vec<Value> = Vec::with_capacity(handles.len());
                 for h in handles {
@@ -505,7 +447,7 @@ pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
                     });
                 }
             };
-            fetch_one(state, url_str, offset, length).await
+            fetch_one(state, url_str, offset, length, format).await
         })
     }
 }
@@ -517,97 +459,113 @@ mod tests {
     #[test]
     fn slice_body_basic() {
         let s = "abcdefghij";
-        let (out, total, complete) = slice_body(s, 0, 5);
+        let (out, total, next) = slice_body(s, 0, 5);
         assert_eq!(out, "abcde");
         assert_eq!(total, 10);
-        assert!(!complete);
-        let (out2, _, complete2) = slice_body(s, 5, 5);
+        assert_eq!(next, Some(5));
+        let (out2, _, next2) = slice_body(s, 5, 5);
         assert_eq!(out2, "fghij");
-        assert!(complete2);
-        let (out3, _, complete3) = slice_body(s, 100, 5);
+        assert_eq!(next2, None);
+        let (out3, _, next3) = slice_body(s, 100, 5);
         assert_eq!(out3, "");
-        assert!(complete3);
+        assert_eq!(next3, None);
     }
 
     #[test]
     fn slice_body_unicode_is_char_based() {
         let s = "한국어테스트";
-        let (out, total, _) = slice_body(s, 0, 3);
+        let (out, total, next) = slice_body(s, 0, 3);
         assert_eq!(out, "한국어");
         assert_eq!(total, 6);
+        assert_eq!(next, Some(3));
+        let (out2, _, next2) = slice_body(s, 3, 3);
+        assert_eq!(out2, "테스트");
+        assert_eq!(next2, None);
     }
 
     #[test]
-    fn robots_longest_match_wins() {
-        let body = "User-agent: *\nDisallow: /private\nAllow: /private/public\n";
-        let rules = parse_robots(body);
-        assert!(!rules.permits("/private/secret.html"));
-        assert!(rules.permits("/private/public/file.html"));
-        assert!(rules.permits("/about"));
+    fn slice_body_next_offset_matches_chars_count() {
+        // Freezes the contract that callers can rely on `next_offset` instead
+        // of calling `.chars().count()` themselves. If this ever drifts,
+        // `fetch_one` would emit a wrong pagination cursor.
+        let s = "한국어테스트0123456789";
+        let (slice, _, next) = slice_body(s, 2, 4);
+        assert_eq!(next, Some(2 + slice.chars().count()));
     }
 
     #[test]
-    fn robots_other_user_agents_are_ignored() {
-        let body = "User-agent: GoogleBot\nDisallow: /\n";
-        let rules = parse_robots(body);
-        assert!(rules.permits("/anything"));
+    fn body_format_parse_accepts_known_values() {
+        assert_eq!(BodyFormat::parse("text"), Some(BodyFormat::Text));
+        assert_eq!(BodyFormat::parse("plain"), Some(BodyFormat::Text));
+        assert_eq!(BodyFormat::parse("Markdown"), Some(BodyFormat::Markdown));
+        assert_eq!(BodyFormat::parse("md"), Some(BodyFormat::Markdown));
+        assert_eq!(BodyFormat::parse("HTML"), Some(BodyFormat::Html));
+        assert_eq!(BodyFormat::parse("raw"), Some(BodyFormat::Html));
+        assert_eq!(BodyFormat::parse("xml"), None);
     }
 
     #[test]
-    fn robots_fetch_failed_allows_all() {
-        let rules = RobotsRules {
-            fetch_failed: true,
-            disallow: vec!["/".into()],
-            ..Default::default()
-        };
-        assert!(rules.permits("/anything"));
-    }
-
-    #[test]
-    fn html_to_text_strips_script_and_style() {
-        let html = "<html><body>\
+    fn convert_text_strips_script_and_style() {
+        let html = "<html><head><title>T</title></head><body>\
                     <script>var x = 1;</script>\
                     <style>body { color: red; }</style>\
                     <h1>Hello</h1>\
                     <p>World</p>\
                     </body></html>";
-        let out = html_to_text(html);
-        assert!(!out.contains("var x"), "{out}");
-        assert!(!out.contains("color: red"), "{out}");
-        assert!(out.contains("Hello"), "{out}");
-        assert!(out.contains("World"), "{out}");
+        let out = convert(html, "text/html", BodyFormat::Text);
+        assert!(!out.body.contains("var x"), "{}", out.body);
+        assert!(!out.body.contains("color: red"), "{}", out.body);
+        assert!(out.body.contains("Hello"), "{}", out.body);
+        assert!(out.body.contains("World"), "{}", out.body);
     }
 
     #[test]
-    fn html_to_text_preserves_anchor_href() {
+    fn convert_markdown_preserves_structure() {
         let html =
-            "<html><body><p>See <a href=\"https://example.com/x\">the docs</a></p></body></html>";
-        let out = html_to_text(html);
+            "<html><body><h1>Title</h1><p>See <a href=\"https://example.com/x\">docs</a></p></body></html>";
+        let out = convert(html, "text/html", BodyFormat::Markdown);
+        // Markdown should keep the heading sigil and the anchor URL.
+        assert!(out.body.contains("# Title"), "{}", out.body);
         assert!(
-            out.contains("the docs [https://example.com/x]"),
-            "anchor href should survive flattening, got: {out:?}"
+            out.body.contains("(https://example.com/x)"),
+            "{}",
+            out.body
         );
     }
 
     #[test]
-    fn html_to_text_skips_pure_fragment_links() {
-        let html = "<a href=\"#top\">jump</a>";
-        let out = html_to_text(html);
-        assert!(out.contains("jump"), "{out}");
-        assert!(!out.contains("[#top]"), "{out}");
+    fn convert_html_returns_body_verbatim() {
+        let html = "<html><body><script>var x = 1;</script>\
+                    <a href=\"https://example.com\">link</a></body></html>";
+        let out = convert(html, "text/html", BodyFormat::Html);
+        assert_eq!(out.body, html);
+        // `format=html` skips conversion entirely, so no title is extracted.
+        assert_eq!(out.title, "");
     }
 
     #[test]
-    fn extract_title_pulls_title_element() {
-        let html = "<html><head><title>Hello <b>World</b></title></head><body></body></html>";
-        let title = extract_title("text/html", html);
-        assert_eq!(title, "Hello World");
+    fn convert_non_html_passes_through() {
+        let body = "{\"key\":\"value\"}";
+        let out_text = convert(body, "application/json", BodyFormat::Text);
+        assert_eq!(out_text.body, body);
+        assert_eq!(out_text.title, "");
+        let out_md = convert(body, "application/json", BodyFormat::Markdown);
+        assert_eq!(out_md.body, body);
     }
 
     #[test]
-    fn extract_title_empty_for_non_html_content_type() {
-        let html = "<title>Foo</title>";
-        assert_eq!(extract_title("application/json", html), "");
+    fn convert_extracts_title_from_title_tag() {
+        let html = "<html><head><title>Hello World</title></head><body><p>x</p></body></html>";
+        let out = convert(html, "text/html", BodyFormat::Text);
+        assert_eq!(out.title, "Hello World");
+    }
+
+    #[test]
+    fn convert_falls_back_to_og_title() {
+        let html = "<html><head><meta property=\"og:title\" content=\"OG Title\"></head>\
+                    <body><p>x</p></body></html>";
+        let out = convert(html, "text/html", BodyFormat::Text);
+        assert_eq!(out.title, "OG Title");
     }
 
     #[test]
@@ -627,6 +585,7 @@ mod tests {
             "https://example.com/".to_string(),
             0,
             DEFAULT_BODY_CHARS,
+            BodyFormat::Text,
         )
         .await;
         let status = result
@@ -650,9 +609,34 @@ mod tests {
         assert!(retrieved_at.ends_with('Z'), "retrieved_at: {retrieved_at}");
     }
 
+    /// `format="html"` against the same endpoint should return raw markup —
+    /// `<html`, `<title>`, etc. — not the converted text form.
+    #[tokio::test]
+    #[ignore = "requires network"]
+    async fn network_single_fetch_html_returns_raw_markup() {
+        let state = WebFetchState::new();
+        let result = fetch_one(
+            state,
+            "https://example.com/".to_string(),
+            0,
+            DEFAULT_BODY_CHARS,
+            BodyFormat::Html,
+        )
+        .await;
+        let body = result
+            .pointer("/body")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            body.contains("<html") || body.contains("<HTML"),
+            "html format should preserve markup, got first 200 chars: {:?}",
+            &body.chars().take(200).collect::<String>()
+        );
+    }
+
     /// Batch fetch across multiple distinct hosts. Verifies the response
     /// shape (`{"results": [...]}`), input-order preservation, and that all
-    /// five fetches return a non-empty body.
+    /// fetches return a non-empty body.
     #[tokio::test]
     #[ignore = "requires network"]
     async fn network_batch_fetch_returns_results_in_order() {
@@ -669,6 +653,7 @@ mod tests {
                 u.clone(),
                 0,
                 DEFAULT_BODY_CHARS,
+                BodyFormat::Text,
             )));
         }
         let mut results = Vec::with_capacity(handles.len());

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -19,7 +19,6 @@ const MAX_DOWNLOAD_BYTES: usize = 2 * 1024 * 1024;
 const MAX_URL_CHARS: usize = 2048;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 const PER_HOST_MIN_INTERVAL: Duration = Duration::from_millis(1000);
-const MAX_BATCH_URLS: usize = 5;
 const USER_AGENT: &str =
     "Mozilla/5.0 (compatible; ailoy/web_fetch; +https://github.com/brekkylab/ailoy)";
 
@@ -261,54 +260,40 @@ fn civil_from_days(days: i64) -> (i64, u32, u32) {
 pub fn get_web_fetch_tool_desc() -> ToolDesc {
     ToolDescBuilder::new("web_fetch")
         .description(concat!(
-            "Fetch one or more URLs and return their bodies. HTML responses ",
-            "are converted via `html-to-markdown-rs`, which uses `html5ever` ",
-            "to parse, drops script/style/nav noise, and emits the requested ",
-            "format. Non-HTML responses (JSON, plain text, etc.) pass through ",
-            "unchanged. Use this after `web_search` to read a result's full ",
-            "body instead of relying on the snippet.\n\n",
-            "Two call shapes:\n",
-            "  - single: pass `url` (string), get one result back.\n",
-            "  - batch: pass `urls` (array of strings) to fetch up to 5 URLs in ",
-            "parallel. The response is `{\"results\": [...]}` with one entry ",
-            "per input URL, in the same order. Independent fetches (e.g. ",
-            "URLs returned by one `web_search` call) should be batched.\n\n",
-            "Each body is clamped to 30 KiB by default; for more, call again ",
-            "with `offset` set to the previous `next_offset`. Rate-limited to ",
-            "1 request/second per host."
+            "Fetch a URL and return its body. HTML responses are converted to ",
+            "the requested format; non-HTML responses (JSON, plain text, etc.) ",
+            "pass through unchanged. Bodies are clamped to 30 KiB by default; ",
+            "for more, call again with `offset` set to the previous ",
+            "`next_offset`. Rate-limited to 1 request/second per host."
         ))
         .parameters(crate::to_value!({
             "type": "object",
             "properties": {
                 "url": {
                     "type": "string",
-                    "description": "Single URL to fetch. Use this OR `urls`, not both."
-                },
-                "urls": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Batch of URLs to fetch in parallel (max 5). Use this OR `url`. Returns `{results: [...]}` matching input order."
+                    "description": "URL to fetch."
                 },
                 "format": {
                     "type": "string",
                     "enum": ["text", "markdown", "html"],
-                    "description": "Body format. `text` (default) returns visible text only — smallest token cost, no document structure. `markdown` returns CommonMark — preserves headings, lists, tables, and link targets. `html` returns the response body unchanged.",
+                    "description": "Body format. `text` (default) is visible text only — smallest token cost, no document structure. `markdown` keeps headings, lists, tables, and link targets. `html` returns the response body unchanged.",
                     "default": "text"
                 },
                 "offset": {
                     "type": "integer",
-                    "description": "Character offset into each body. Use 0 for the first call; on subsequent calls pass the `next_offset` returned previously.",
+                    "description": "Character offset into the body. Use 0 for the first call; on subsequent calls pass the `next_offset` returned previously.",
                     "default": 0,
                     "minimum": 0
                 },
                 "length": {
                     "type": "integer",
-                    "description": "Maximum number of characters per body returned in this call. Default 30720 (30 KiB). Hard cap 61440.",
+                    "description": "Maximum number of characters returned in this call. Default 30720 (30 KiB). Hard cap 61440.",
                     "default": 30720,
                     "minimum": 256,
                     "maximum": 61440
                 }
-            }
+            },
+            "required": ["url"]
         }))
         .build()
 }
@@ -392,58 +377,11 @@ pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
                 .and_then(BodyFormat::parse)
                 .unwrap_or(BodyFormat::Text);
 
-            // Accept `urls` only when it is a non-empty array of strings.
-            // An empty/missing `urls` (some LLMs send `"urls": []` next to a
-            // single `url`) falls through to the single-URL path so callers
-            // get a result instead of a validation error.
-            let urls_array: Option<Vec<String>> = args
-                .pointer("/urls")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect::<Vec<String>>()
-                })
-                .filter(|v| !v.is_empty());
-
-            if let Some(urls) = urls_array {
-                if urls.len() > MAX_BATCH_URLS {
-                    let msg = format!(
-                        "batch size {} exceeds max {MAX_BATCH_URLS} — split into multiple calls",
-                        urls.len()
-                    );
-                    return crate::to_value!({"error": msg});
-                }
-
-                let mut handles = Vec::with_capacity(urls.len());
-                for u in urls {
-                    handles.push(tokio::spawn(fetch_one(
-                        state.clone(),
-                        u,
-                        offset,
-                        length,
-                        format,
-                    )));
-                }
-                let mut results: Vec<Value> = Vec::with_capacity(handles.len());
-                for h in handles {
-                    match h.await {
-                        Ok(v) => results.push(v),
-                        Err(e) => {
-                            let msg = format!("fetch task panicked: {e}");
-                            results.push(crate::to_value!({"error": msg}));
-                        }
-                    }
-                }
-                return crate::to_value!({"results": Value::array(results)});
-            }
-
             let url_str = match args.pointer("/url").and_then(|v| v.as_str()) {
                 Some(u) => u.to_string(),
                 None => {
                     return crate::to_value!({
-                        "error": "missing required parameter: either `url` (string) or `urls` (array)"
+                        "error": "missing required parameter: `url`"
                     });
                 }
             };
@@ -634,50 +572,4 @@ mod tests {
         );
     }
 
-    /// Batch fetch across multiple distinct hosts. Verifies the response
-    /// shape (`{"results": [...]}`), input-order preservation, and that all
-    /// fetches return a non-empty body.
-    #[tokio::test]
-    #[ignore = "requires network"]
-    async fn network_batch_fetch_returns_results_in_order() {
-        let state = WebFetchState::new();
-        let urls = vec![
-            "https://example.com/".to_string(),
-            "https://example.org/".to_string(),
-            "https://example.net/".to_string(),
-        ];
-        let mut handles = Vec::with_capacity(urls.len());
-        for u in urls.iter() {
-            handles.push(tokio::spawn(fetch_one(
-                state.clone(),
-                u.clone(),
-                0,
-                DEFAULT_BODY_CHARS,
-                BodyFormat::Text,
-            )));
-        }
-        let mut results = Vec::with_capacity(handles.len());
-        for h in handles {
-            results.push(h.await.unwrap());
-        }
-        assert_eq!(results.len(), urls.len());
-        for (i, r) in results.iter().enumerate() {
-            let url = r
-                .pointer("/url")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default();
-            let status = r
-                .pointer("/status")
-                .and_then(|v| v.as_integer())
-                .unwrap_or(0);
-            let body = r.pointer("/body").and_then(|v| v.as_str()).unwrap_or("");
-            assert!(
-                url.starts_with(&urls[i].trim_end_matches('/')),
-                "result {i} url mismatch: input={} got={url}",
-                urls[i]
-            );
-            assert_eq!(status, 200, "result {i}: {r:?}");
-            assert!(!body.is_empty(), "result {i} body empty");
-        }
-    }
 }

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -51,6 +51,10 @@ async fn rate_limit_for(state: &WebFetchState, host: &str) {
             .and_then(|when| PER_HOST_MIN_INTERVAL.checked_sub(now.duration_since(*when)))
             .unwrap_or(Duration::ZERO);
         m.insert(host.to_string(), now + wait);
+        // Self-trim: only keep hosts hit within the rate-limit window.
+        // Future timestamps (the entry we just inserted with non-zero wait)
+        // survive because `duration_since` saturates to zero for them.
+        m.retain(|_, when| now.duration_since(*when) < PER_HOST_MIN_INTERVAL);
         wait
     };
     if !wait.is_zero() {
@@ -440,6 +444,26 @@ mod tests {
         assert_eq!(BodyFormat::parse("HTML"), Some(BodyFormat::Html));
         assert_eq!(BodyFormat::parse("raw"), Some(BodyFormat::Html));
         assert_eq!(BodyFormat::parse("xml"), None);
+    }
+
+    /// `last_hit` self-trim invariants. The retain expression is replicated
+    /// here exactly as `rate_limit_for` uses it; if either drifts, this test
+    /// catches it before the table starts growing unbounded again.
+    #[test]
+    fn last_hit_retain_keeps_fresh_and_future_drops_stale() {
+        let now = Instant::now();
+        let mut m: HashMap<String, Instant> = HashMap::new();
+        m.insert("fresh".into(), now);
+        m.insert("stale".into(), now - PER_HOST_MIN_INTERVAL * 2);
+        // Mirrors `rate_limit_for`: the just-inserted entry uses `now + wait`,
+        // i.e. a future timestamp when wait > 0.
+        m.insert("future".into(), now + PER_HOST_MIN_INTERVAL);
+
+        m.retain(|_, when| now.duration_since(*when) < PER_HOST_MIN_INTERVAL);
+
+        assert!(m.contains_key("fresh"));
+        assert!(m.contains_key("future"));
+        assert!(!m.contains_key("stale"));
     }
 
     #[test]

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -456,19 +456,22 @@ pub fn get_web_fetch_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
                 .map(|n| n.max(256).min(MAX_BODY_CHARS as i64) as usize)
                 .unwrap_or(DEFAULT_BODY_CHARS);
 
-            // `urls` (array) takes precedence over `url` when both are sent.
-            let urls_array = args.pointer("/urls").and_then(|v| v.as_array()).cloned();
+            // Accept `urls` only when it is a non-empty array of strings.
+            // An empty/missing `urls` (some LLMs send `"urls": []` next to a
+            // single `url`) falls through to the single-URL path so callers
+            // get a result instead of a validation error.
+            let urls_array: Option<Vec<String>> = args
+                .pointer("/urls")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<String>>()
+                })
+                .filter(|v| !v.is_empty());
 
             if let Some(urls) = urls_array {
-                let urls: Vec<String> = urls
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect();
-                if urls.is_empty() {
-                    return crate::to_value!({
-                        "error": "`urls` array is empty or contains no strings"
-                    });
-                }
                 if urls.len() > MAX_BATCH_URLS {
                     let msg = format!(
                         "batch size {} exceeds max {MAX_BATCH_URLS} — split into multiple calls",
@@ -682,10 +685,7 @@ mod tests {
                 .pointer("/status")
                 .and_then(|v| v.as_integer())
                 .unwrap_or(0);
-            let body = r
-                .pointer("/body")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let body = r.pointer("/body").and_then(|v| v.as_str()).unwrap_or("");
             assert!(
                 url.starts_with(&urls[i].trim_end_matches('/')),
                 "result {i} url mismatch: input={} got={url}",


### PR DESCRIPTION
## Summary

Adds a `web_fetch` builtin that fetches a URL and returns the readable body. Complements `web_search`: search gives metadata, fetch gives the actual page so a caller can verify what a snippet claimed.

## Surface

- `AgentSpec::web_fetch_tool()` / `AgentBuilder::web_fetch_tool()` add the tool to a spec. Opt-in, like `web_search_tool`; not included in `system_tools()`.
- One URL per call. ailoy already parallelises tool calls, so the model can issue several `web_fetch` calls in one turn without the tool needing its own batch path.
- Returns `{url, status, title, content_type, body, body_length_total, next_offset, complete, retrieved_at}`.

## Behavior

- `format` parameter, default `"text"`:
  - `"text"` — visible text only, no markup. Smallest token cost.
  - `"markdown"` — CommonMark output, keeps headings, lists, tables, and link targets.
  - `"html"` — response body unchanged.
- HTML responses go through `html-to-markdown-rs`, which parses with `html5ever` and drops `<script>`/`<style>`/inline `<svg>`/etc. Non-HTML responses (JSON, plain text, …) pass through verbatim regardless of `format`.
- Title comes from `metadata.document.title` with `og:title` as a fallback.
- `skip_images=true` so inline base64 data-URIs don't dominate the body.
- Response body cap: 2 MiB downloaded, streamed chunk by chunk.
- Readable body clamped to 30 KiB by default (hard cap 60 KiB). `offset` pages past the first window on the same URL; `next_offset` echoes the next char index.
- URL length cap: 2048 characters. Request timeout: 10 seconds.
- Per-host rate limit: one request per second.

## Tests

Default unit tests (run on every `cargo test`):

- `slice_body` math (ASCII + unicode boundaries) and the `next_offset` contract that callers rely on.
- `BodyFormat::parse` accepts `text`/`plain`/`markdown`/`md`/`html`/`raw`.
- HTML conversion: `text` strips `<script>` + `<style>`, `markdown` preserves headings + link targets, `html` returns the body verbatim, non-HTML content types pass through.
- Title extraction prefers `<title>` and falls back to `og:title`.
- Tool descriptor shape.

Network-required tests, `#[ignore = "requires network"]` to match the convention used by `web_search` (run with `cargo test -- --ignored`):

- Single-URL `format="text"` fetch against `https://example.com/` — HTTP 200, body contains `Example Domain`, `retrieved_at` populated.
- Same endpoint with `format="html"` — body contains raw `<html…>` markup.

## Notes

- New dependency: `html-to-markdown-rs = "3.4"` with the `metadata` feature. This is what powers the `text`/`markdown` modes and the title extraction. MSRV is `1.85` (the crate is edition 2024). One transitive cost: a second copy of `html5ever` (0.39 alongside `scraper`'s 0.35) gets compiled until either crate moves.
- The factory closes over a process-wide `WebFetchState` (HTTP client, rate-limit ledger), matching how `web_search` shares one `MetaSearcher` across calls.

## Changelog during review

- Dropped robots.txt handling entirely (parser + cache + pre-fetch check), in response to maintainer preference. ailoy follows the host's response and rate limits per-host.
- Replaced the hand-written `walk()` flattener with `html-to-markdown-rs` and added the `markdown` format option. The earlier description's HTML→text conversion mechanics are now an implementation detail.
- Dropped the `urls` batch path. ailoy's parallel tool calling covers the same use case without nudging the model toward batched calls.
- Rewrote `slice_body` to a single `char_indices()` pass that returns `(slice, total_chars, Option<next_offset>)`, dropping the `Vec<char>` copy and the redundant `slice.chars().count()` in `fetch_one`.