### PR TITLE
feat(lang_model): add DeepSeek and Kimi (Moonshot) provider support

### DIFF
--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -24,6 +24,22 @@ impl LangModelProvider {
         }
     }
 
+    pub fn deepseek(api_key: String) -> LangModelProviderElem {
+        LangModelProviderElem::API {
+            schema: LangModelAPISchema::ChatCompletion,
+            url: Url::parse("https://api.deepseek.com/chat/completions").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+
+    pub fn kimi(api_key: String) -> LangModelProviderElem {
+        LangModelProviderElem::API {
+            schema: LangModelAPISchema::ChatCompletion,
+            url: Url::parse("https://api.moonshot.ai/v1/chat/completions").unwrap(),
+            api_key: Some(api_key),
+        }
+    }
+
     pub fn chat_completion(
         url: &str,
         api_key: Option<String>,
@@ -75,10 +91,23 @@ impl Marshal<Message> for ChatCompletionMarshal {
                 .unwrap()
                 .insert("tool_call_id".into(), id.into());
         }
+        // DeepSeek thinking-mode endpoint requires the prior `reasoning_content`
+        // to be replayed on every follow-up turn.
+        if item.role == Role::Assistant
+            && let Some(thinking) = &item.thinking
+            && !thinking.is_empty()
+        {
+            rv.as_object_mut()
+                .unwrap()
+                .insert("reasoning_content".into(), thinking.clone().into());
+        }
         if !item.contents.is_empty() {
             let contents: Vec<Value> = item
                 .contents
                 .iter()
+                // Some ChatCompletion-compatible backends (e.g. Kimi)
+                // reject content arrays containing an empty-text part
+                .filter(|p| !matches!(p, Part::Text { text } if text.is_empty()))
                 .map(|p| {
                     // ChatCompletion backends don't reliably accept images in tool results;
                     // substitute a text label so the model knows an image was returned.
@@ -103,9 +132,11 @@ impl Marshal<Message> for ChatCompletionMarshal {
                     part_to_value(p)
                 })
                 .collect();
-            rv.as_object_mut()
-                .unwrap()
-                .insert("content".into(), contents.into());
+            if !contents.is_empty() {
+                rv.as_object_mut()
+                    .unwrap()
+                    .insert("content".into(), contents.into());
+            }
         }
         if let Some(tool_calls) = &item.tool_calls
             && !tool_calls.is_empty()
@@ -337,12 +368,24 @@ impl Unmarshal<MessageDeltaOutput> for ChatCompletionUnmarshal {
             .map(Self::parse_tool_calls)
             .unwrap_or_default();
 
+        // DeepSeek thinking-mode responses include `reasoning_content` as a
+        // sibling of `content`. Map it onto ailoy's canonical `thinking` field
+        // so the same value gets replayed on follow-up turns.
+        let thinking = message
+            .pointer("/reasoning_content")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned());
+
         let mut delta = MessageDelta::new().with_role(role);
         if !contents.is_empty() {
             delta = delta.with_contents(contents);
         }
         if !tool_calls.is_empty() {
             delta = delta.with_tool_calls(tool_calls);
+        }
+        if let Some(t) = thinking {
+            delta.thinking = Some(t);
         }
 
         // Parse usage (Chat Completion: usage.prompt_tokens / completion_tokens)

--- a/src/lang_model/provider.rs
+++ b/src/lang_model/provider.rs
@@ -54,8 +54,9 @@ pub enum LangModelProviderElem {
 ///
 /// [`Default::default`] (and therefore [`AgentProvider::new`]) returns a
 /// registry pre-populated from the environment:  registers `openai/*`,
-/// `anthropic/*`, and/or `gemini/*` for every `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
-/// / `GEMINI_API_KEY` that is set.
+/// `anthropic/*`, `gemini/*`, `deepseek/*`, and/or `moonshot/kimi-*` for every
+/// `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `DEEPSEEK_API_KEY`
+/// / `KIMI_API_KEY` that is set.
 /// Use [`new`](Self::new) for an empty registry.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
@@ -75,6 +76,12 @@ impl Default for LangModelProvider {
         }
         if let Ok(key) = std::env::var("GEMINI_API_KEY") {
             p.insert("gemini/*".into(), Self::gemini(key));
+        }
+        if let Ok(key) = std::env::var("DEEPSEEK_API_KEY") {
+            p.insert("deepseek/*".into(), Self::deepseek(key));
+        }
+        if let Ok(key) = std::env::var("KIMI_API_KEY") {
+            p.insert("moonshot/kimi-*".into(), Self::kimi(key));
         }
         p
     }

--- a/src/lang_model/provider.rs
+++ b/src/lang_model/provider.rs
@@ -54,8 +54,8 @@ pub enum LangModelProviderElem {
 ///
 /// [`Default::default`] (and therefore [`AgentProvider::new`]) returns a
 /// registry pre-populated from the environment:  registers `openai/*`,
-/// `anthropic/*`, `gemini/*`, `deepseek/*`, and/or `moonshot/kimi-*` for every
-/// `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `DEEPSEEK_API_KEY`
+/// `anthropic/*`, `google/*`, `x-ai/*`, `deepseek/*`, and/or `moonshotai/kimi-*` for every
+/// `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `XAI_API_KEY` / `DEEPSEEK_API_KEY`
 /// / `KIMI_API_KEY` that is set.
 /// Use [`new`](Self::new) for an empty registry.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -75,13 +75,16 @@ impl Default for LangModelProvider {
             p.insert("anthropic/*".into(), Self::anthropic(key));
         }
         if let Ok(key) = std::env::var("GEMINI_API_KEY") {
-            p.insert("gemini/*".into(), Self::gemini(key));
+            p.insert("google/*".into(), Self::gemini(key));
+        }
+        if let Ok(key) = std::env::var("XAI_API_KEY") {
+            p.insert("x-ai/*".into(), Self::grok(key));
         }
         if let Ok(key) = std::env::var("DEEPSEEK_API_KEY") {
             p.insert("deepseek/*".into(), Self::deepseek(key));
         }
         if let Ok(key) = std::env::var("KIMI_API_KEY") {
-            p.insert("moonshotai/kimi-*".into(), Self::kimi(key));
+            p.insert("moonshotai/*".into(), Self::kimi(key));
         }
         p
     }

--- a/src/lang_model/provider.rs
+++ b/src/lang_model/provider.rs
@@ -81,7 +81,7 @@ impl Default for LangModelProvider {
             p.insert("deepseek/*".into(), Self::deepseek(key));
         }
         if let Ok(key) = std::env::var("KIMI_API_KEY") {
-            p.insert("moonshot/kimi-*".into(), Self::kimi(key));
+            p.insert("moonshotai/kimi-*".into(), Self::kimi(key));
         }
         p
     }


### PR DESCRIPTION
## Summary

Adds first-class DeepSeek and Kimi (Moonshot) support to `LangModelProvider`, including thinking-mode round-tripping for DeepSeek and a payload fix for Kimi.

- **Convenience constructors** in [src/lang_model/impl/api/chat_completion.rs](src/lang_model/impl/api/chat_completion.rs):
  - `LangModelProvider::deepseek(api_key)` → ChatCompletion schema at `https://api.deepseek.com/chat/completions`
  - `LangModelProvider::kimi(api_key)` → ChatCompletion schema at `https://api.moonshot.ai/v1/chat/completions`
- **Default registry wiring** in [src/lang_model/provider.rs](src/lang_model/provider.rs): `LangModelProvider::default()` now also registers `deepseek/*` and `moonshot/kimi-*` when `DEEPSEEK_API_KEY` / `KIMI_API_KEY` is set, matching the existing pattern for OpenAI/Anthropic/Gemini.
- **DeepSeek thinking-mode round-trip** in `ChatCompletionMarshal` / `ChatCompletionUnmarshal`: parse `reasoning_content` from assistant responses into the canonical `Message.thinking` field, and replay it as `reasoning_content` on follow-up turns (required by DeepSeek's thinking endpoint).
- **Kimi payload fix**: drop empty-text parts from the content array and omit the `content` key entirely when no parts remain — Kimi's ChatCompletion backend rejects content arrays that contain an empty-text block.

## Test plan

- [x] `cargo check --lib` passes
- [x] Smoke test with `DEEPSEEK_API_KEY` set — non-thinking and thinking models, multi-turn conversation
- [x] Smoke test with `KIMI_API_KEY` set — basic completion and tool calling

🤖 Generated with [Claude Code](https://claude.com/claude-code)