### PR TITLE
fix(sandbox): decouple VM removal from Machine::shutdown

### DIFF
--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -1491,7 +1491,7 @@ mod tests {
 
         drop(_console);
         src.shutdown().await;
-        remove_persisted(&src_name).await.ok();
+        Sandbox::remove_persisted(&src_name).await.ok();
     }
 
     #[tokio::test]
@@ -1539,8 +1539,8 @@ mod tests {
 
         drop(child_console);
         child.shutdown().await;
-        remove_persisted(&src_name).await.ok();
-        remove_persisted(&child_name).await.ok();
+        Sandbox::remove_persisted(&src_name).await.ok();
+        Sandbox::remove_persisted(&child_name).await.ok();
     }
 
     #[tokio::test]
@@ -1597,8 +1597,8 @@ mod tests {
 
         drop(src_console);
         src.shutdown().await;
-        remove_persisted(&src_name).await.ok();
-        remove_persisted(&child_name).await.ok();
+        Sandbox::remove_persisted(&src_name).await.ok();
+        Sandbox::remove_persisted(&child_name).await.ok();
     }
 
     #[tokio::test]
@@ -1635,7 +1635,7 @@ mod tests {
         );
 
         child.shutdown().await;
-        remove_persisted(&src_name).await.ok();
-        remove_persisted(&child_name).await.ok();
+        Sandbox::remove_persisted(&src_name).await.ok();
+        Sandbox::remove_persisted(&child_name).await.ok();
     }
 }

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -97,7 +97,7 @@ pub struct SandboxConfig {
 
     /// When `true`, the VM definition survives drop of the [`Sandbox`] struct
     /// and can be reattached by name in a future session. Use
-    /// [`remove_persisted`] to delete it explicitly.
+    /// [`Sandbox::remove_persisted`] to delete it explicitly.
     ///
     /// Independent of `Machine::boot`/`Machine::shutdown` cycles — those only
     /// start and stop the VM regardless of this flag. Default: `false`.
@@ -275,6 +275,32 @@ impl Sandbox {
     async fn remove(name: &str) {
         Self::stop(name).await;
         let _ = MsbSandbox::remove(name).await;
+    }
+
+    /// Remove a `persist = true` sandbox by name without holding a [`Sandbox`] instance.
+    ///
+    /// Intended for explicit cleanup when the `Sandbox` object is no longer available
+    /// (e.g. after a process restart). For `persist = false` sandboxes, removal happens
+    /// automatically on drop.
+    ///
+    /// Idempotent: if the named sandbox does not exist, returns `Ok(())`.
+    pub async fn remove_persisted(name: &str) -> anyhow::Result<()> {
+        match MsbSandbox::get(name).await {
+            Err(_) => Ok(()),
+            Ok(handle) => {
+                match handle.status() {
+                    SandboxStatus::Running | SandboxStatus::Draining => {
+                        let connected = handle.connect().await?;
+                        connected.stop_and_wait().await?;
+                        connected.remove_persisted().await?;
+                    }
+                    _ => {
+                        handle.remove().await?;
+                    }
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -586,31 +612,6 @@ async fn vm_is_running(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Remove a `persist = true` sandbox by name without holding a [`Sandbox`] instance.
-///
-/// This is the explicit cleanup hook for `persist = true` sandboxes. For
-/// `persist = false` sandboxes, removal happens automatically on `Sandbox` drop.
-///
-/// Idempotent: if the named sandbox does not exist, returns `Ok(())`.
-pub async fn remove_persisted(name: &str) -> anyhow::Result<()> {
-    match MsbSandbox::get(name).await {
-        Err(_) => Ok(()),
-        Ok(handle) => {
-            match handle.status() {
-                SandboxStatus::Running | SandboxStatus::Draining => {
-                    let connected = handle.connect().await?;
-                    connected.stop_and_wait().await?;
-                    connected.remove_persisted().await?;
-                }
-                _ => {
-                    handle.remove().await?;
-                }
-            }
-            Ok(())
-        }
-    }
-}
-
 fn apply_volume_mount(builder: SandboxBuilder, mount: &VolumeMount) -> SandboxBuilder {
     match mount {
         VolumeMount::Bind {
@@ -920,7 +921,7 @@ mod tests {
         let handle = env.get().await.unwrap();
         assert!(vm_is_running(&name).await, "VM should be running again");
         drop(handle);
-        remove_persisted(&name).await.ok();
+        Sandbox::remove_persisted(&name).await.ok();
     }
 
     /// Repeated boot/drop cycles are safe with `persist = false` — the VM
@@ -969,7 +970,7 @@ mod tests {
             "restart should be well under 3s, got {restart_ms}ms"
         );
         drop(_h);
-        remove_persisted(&name).await.ok();
+        Sandbox::remove_persisted(&name).await.ok();
     }
 
     // ── concurrent access ────────────────────────────────────────────────────
@@ -1008,7 +1009,7 @@ mod tests {
             assert_eq!(r.exit_code, 0);
         }
         drop(handles);
-        remove_persisted(&name).await.ok();
+        Sandbox::remove_persisted(&name).await.ok();
     }
 
     /// Two cloned `Arc<RunEnvHandle>`s can issue `exec` concurrently from
@@ -1173,7 +1174,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_persisted_idempotent() {
-        let result = remove_persisted("ailoy-nonexistent-sandbox-xyz-12345").await;
+        let result = Sandbox::remove_persisted("ailoy-nonexistent-sandbox-xyz-12345").await;
         assert!(
             result.is_ok(),
             "remove_persisted on unknown name should return Ok, got: {result:?}"
@@ -1199,7 +1200,7 @@ mod tests {
                 .expect("write failed");
         }
 
-        remove_persisted(&name)
+        Sandbox::remove_persisted(&name)
             .await
             .expect("remove_persisted failed");
 
@@ -1217,7 +1218,7 @@ mod tests {
             "fresh VM should not contain the marker file from the previous run"
         );
         drop(handle);
-        remove_persisted(&name).await.ok();
+        Sandbox::remove_persisted(&name).await.ok();
     }
 
     // ── volume mounts ────────────────────────────────────────────────────────

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -586,6 +586,31 @@ async fn vm_is_running(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Remove a `persist = true` sandbox by name without holding a [`Sandbox`] instance.
+///
+/// This is the explicit cleanup hook for `persist = true` sandboxes. For
+/// `persist = false` sandboxes, removal happens automatically on `Sandbox` drop.
+///
+/// Idempotent: if the named sandbox does not exist, returns `Ok(())`.
+pub async fn remove_persisted(name: &str) -> anyhow::Result<()> {
+    match MsbSandbox::get(name).await {
+        Err(_) => Ok(()),
+        Ok(handle) => {
+            match handle.status() {
+                SandboxStatus::Running | SandboxStatus::Draining => {
+                    let connected = handle.connect().await?;
+                    connected.stop_and_wait().await?;
+                    connected.remove_persisted().await?;
+                }
+                _ => {
+                    handle.remove().await?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 fn apply_volume_mount(builder: SandboxBuilder, mount: &VolumeMount) -> SandboxBuilder {
     match mount {
         VolumeMount::Bind {
@@ -637,25 +662,6 @@ mod tests {
         RunEnv::sandbox(SandboxConfig::default())
             .await
             .expect("failed to create sandbox")
-    }
-
-    async fn remove_persisted(name: &str) -> anyhow::Result<()> {
-        match MsbSandbox::get(name).await {
-            Err(_) => Ok(()),
-            Ok(handle) => {
-                match handle.status() {
-                    SandboxStatus::Running | SandboxStatus::Draining => {
-                        let connected = handle.connect().await?;
-                        connected.stop_and_wait().await?;
-                        connected.remove_persisted().await?;
-                    }
-                    _ => {
-                        handle.remove().await?;
-                    }
-                }
-                Ok(())
-            }
-        }
     }
 
     // ── config & validation ──────────────────────────────────────────────────

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -1,7 +1,8 @@
 //! microsandbox-backed `Machine` for runenv.
 //!
 //! Heavyweight, fallible setup happens in `Sandbox::new`; `Machine::boot`
-//! restarts the VM, and `Machine::shutdown` stops/removes it.
+//! starts the VM, `Machine::shutdown` stops it, and dropping the `Sandbox`
+//! removes the VM definition (unless `config.persist` is `true`).
 
 use std::{
     collections::HashMap,
@@ -94,8 +95,12 @@ pub struct SandboxConfig {
     /// Maximum characters to keep from stdout/stderr. Default: `30_000`.
     pub max_output_chars: usize,
 
-    /// When `true`, the sandbox is not removed on drop and can be reused by
-    /// name in a future session. Default: `false`.
+    /// When `true`, the VM definition survives drop of the [`Sandbox`] struct
+    /// and can be reattached by name in a future session. Use
+    /// [`remove_persisted`] to delete it explicitly.
+    ///
+    /// Independent of `Machine::boot`/`Machine::shutdown` cycles — those only
+    /// start and stop the VM regardless of this flag. Default: `false`.
     pub persist: bool,
 
     /// Volume mounts attached at sandbox creation time.
@@ -137,7 +142,8 @@ fn fresh_sandbox_name() -> String {
 ///
 /// The VM is created at construction time and left stopped; `boot()` starts
 /// it for the duration of the returned [`SandboxConsole`], and `shutdown()`
-/// stops (and, unless `config.persist`, removes) it.
+/// stops it. The VM definition is removed when the `Sandbox` value is
+/// dropped, unless `config.persist` is `true`.
 pub struct Sandbox {
     config: SandboxConfig,
     name: String,
@@ -236,7 +242,8 @@ impl Sandbox {
         })
     }
 
-    async fn stop(name: &str, persist: bool) {
+    /// Stop the named VM if it is running. Does not remove the VM definition.
+    async fn stop(name: &str) {
         match MsbSandbox::get(name).await {
             Err(e) => log::warn!("sandbox stop: get '{name}' failed: {e}"),
             Ok(handle) => {
@@ -261,10 +268,13 @@ impl Sandbox {
                 let _ = handle.stop().await;
             }
         }
+    }
 
-        if !persist {
-            let _ = MsbSandbox::remove(name).await;
-        }
+    /// Stop the VM and remove its definition. Called only from `Drop`
+    /// for non-persist sandboxes; never from `Machine::shutdown`.
+    async fn remove(name: &str) {
+        Self::stop(name).await;
+        let _ = MsbSandbox::remove(name).await;
     }
 }
 
@@ -296,16 +306,18 @@ impl Machine for Sandbox {
         })
     }
 
+    /// Stops the VM only; the VM definition is removed when the `Sandbox` is dropped.
     async fn shutdown(&mut self) {
-        Self::stop(&self.name, self.config.persist).await;
+        Self::stop(&self.name).await;
     }
 }
 
 impl Drop for Sandbox {
     fn drop(&mut self) {
-        // Catches VMs that were created in `new()` but never reached
-        // `Machine::shutdown` (e.g. the `RunEnv` was dropped without ever
-        // calling `get()`). Persisted VMs survive.
+        // Drop is the sole owner of VM definition removal for non-persist
+        // sandboxes. `Machine::shutdown` only stops the VM; removal happens
+        // here so the VM definition survives multiple boot/shutdown cycles
+        // within the same `Sandbox` lifetime.
         if self.config.persist {
             return;
         }
@@ -316,7 +328,7 @@ impl Drop for Sandbox {
                 .enable_all()
                 .build()
             {
-                rt.block_on(Self::stop(&name, false));
+                rt.block_on(Self::remove(&name));
             }
             let _ = tx.send(());
         });
@@ -574,28 +586,6 @@ async fn vm_is_running(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Remove a `persist = true` sandbox by name without holding a [`Sandbox`] instance.
-///
-/// Idempotent: if the named sandbox does not exist, returns `Ok(())`.
-pub async fn remove_persisted(name: &str) -> anyhow::Result<()> {
-    match MsbSandbox::get(name).await {
-        Err(_) => Ok(()),
-        Ok(handle) => {
-            match handle.status() {
-                SandboxStatus::Running | SandboxStatus::Draining => {
-                    let connected = handle.connect().await?;
-                    connected.stop_and_wait().await?;
-                    connected.remove_persisted().await?;
-                }
-                _ => {
-                    handle.remove().await?;
-                }
-            }
-            Ok(())
-        }
-    }
-}
-
 fn apply_volume_mount(builder: SandboxBuilder, mount: &VolumeMount) -> SandboxBuilder {
     match mount {
         VolumeMount::Bind {
@@ -647,6 +637,25 @@ mod tests {
         RunEnv::sandbox(SandboxConfig::default())
             .await
             .expect("failed to create sandbox")
+    }
+
+    async fn remove_persisted(name: &str) -> anyhow::Result<()> {
+        match MsbSandbox::get(name).await {
+            Err(_) => Ok(()),
+            Ok(handle) => {
+                match handle.status() {
+                    SandboxStatus::Running | SandboxStatus::Draining => {
+                        let connected = handle.connect().await?;
+                        connected.stop_and_wait().await?;
+                        connected.remove_persisted().await?;
+                    }
+                    _ => {
+                        handle.remove().await?;
+                    }
+                }
+                Ok(())
+            }
+        }
     }
 
     // ── config & validation ──────────────────────────────────────────────────
@@ -804,6 +813,54 @@ mod tests {
 
     // ── VM lifecycle ─────────────────────────────────────────────────────────
 
+    /// VM definition survives `Machine::shutdown` (handle drop) when
+    /// `persist = false` — subsequent boots on the same `Sandbox` must succeed.
+    /// The definition is only removed when the `Sandbox` struct itself is dropped.
+    #[tokio::test]
+    async fn test_vm_definition_survives_machine_shutdown_with_persist_false() {
+        let name = format!("at-vmdef-{}", short_id());
+        let env = RunEnv::sandbox(SandboxConfig {
+            name: Some(name.clone()),
+            persist: false,
+            ..SandboxConfig::default()
+        })
+        .await
+        .unwrap();
+
+        // 1st boot/shutdown cycle
+        {
+            let h = env.get().await.unwrap();
+            let r = h
+                .exec_shell("echo a > ./m.txt".to_string(), None)
+                .await
+                .unwrap();
+            assert_eq!(r.exit_code, 0);
+        } // handle drop → Machine::shutdown is called
+
+        // VM definition must still exist
+        assert!(
+            MsbSandbox::get(&name).await.is_ok(),
+            "VM definition must survive handle drop when persist=false"
+        );
+
+        // 2nd boot must succeed and file state must be preserved
+        let h2 = env.get().await.unwrap();
+        let r = h2
+            .exec_shell("cat ./m.txt".to_string(), None)
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0, "second boot must succeed: {}", r.stderr);
+        drop(h2);
+
+        // VM definition must be gone after the Sandbox is dropped
+        drop(env);
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        assert!(
+            MsbSandbox::get(&name).await.is_err(),
+            "VM definition must be removed when persist=false Sandbox is dropped"
+        );
+    }
+
     /// A single boot serves multiple `exec` calls without the VM going down
     /// between them.
     #[tokio::test]
@@ -860,13 +917,15 @@ mod tests {
         remove_persisted(&name).await.ok();
     }
 
-    /// Repeated boot/drop cycles are safe — no resource leak or double-stop error.
+    /// Repeated boot/drop cycles are safe with `persist = false` — the VM
+    /// definition survives each cycle and no resource leak or double-stop error
+    /// occurs. Removal happens only when the `Sandbox` is dropped.
     #[tokio::test]
     async fn test_start_stop_idempotent() {
         let name = format!("at-si-{}", short_id());
         let env = RunEnv::sandbox(SandboxConfig {
             name: Some(name.clone()),
-            persist: true,
+            persist: false,
             ..SandboxConfig::default()
         })
         .await
@@ -878,7 +937,8 @@ mod tests {
             drop(handle);
             assert!(!vm_is_running(&name).await);
         }
-        remove_persisted(&name).await.ok();
+        // VM definition is still present — removal happens on Sandbox drop.
+        assert!(MsbSandbox::get(&name).await.is_ok());
     }
 
     #[tokio::test]
@@ -1078,17 +1138,12 @@ mod tests {
 
     // ── persistence ──────────────────────────────────────────────────────────
 
-    /// With `persist = true`, files written during one boot survive the next.
+    /// Files written during one boot survive the next — the VM definition is
+    /// preserved across stop/start cycles as long as the `Sandbox` is alive,
+    /// regardless of `persist`.
     #[tokio::test]
     async fn test_filesystem_persists_across_stop_start() {
-        let name = format!("at-fp-{}", short_id());
-        let env = RunEnv::sandbox(SandboxConfig {
-            name: Some(name.clone()),
-            persist: true,
-            ..SandboxConfig::default()
-        })
-        .await
-        .unwrap();
+        let env = make_env().await;
 
         {
             let handle = env.get().await.unwrap();
@@ -1108,8 +1163,6 @@ mod tests {
             content.contains("hello"),
             "file should survive stop/start cycle, got: {content:?}"
         );
-        drop(handle);
-        remove_persisted(&name).await.ok();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

When an agent executed multiple tool calls against the same sandbox, the second tool call would fail with a \"sandbox not found\" error. The root cause was a combination of three behaviors:

1. **`Sandbox::stop`** called `MsbSandbox::remove(name)` whenever `persist=false`, permanently deleting the VM definition from the microsandbox DB.
2. **`RunEnvHandle::drop`** triggered `Machine::shutdown` (→ `Sandbox::stop`) every time the strong count of `Arc<RunEnvHandle>` hit zero.
3. **Agents hold handles briefly**: `ensure_files_materialised` takes and immediately drops a handle before the LLM call, and each tool task in `execute_tool_calls` independently calls `runenv.get()` and drops the handle when its stream ends.

This meant: tool A finishes → handle drops → `Machine::shutdown` → VM **removed** → tool B starts → `start_and_connect` cannot find the registered name → error.

## Fix

Decouple VM *removal* from VM *stop* by separating responsibilities:

- **`Machine::shutdown`** (called on every handle drop): stops the VM only — never removes its definition.
- **`Sandbox::Drop`**: sole owner of VM definition removal for `persist=false` sandboxes. The VM definition now survives multiple boot/shutdown cycles within the same `Sandbox` lifetime and is only deleted when the `Sandbox` struct itself is dropped.

### Key code changes (`src/runenv/sandbox.rs`)

- `Sandbox::stop(name)` — removed `persist: bool` parameter and the trailing `MsbSandbox::remove` call. Now stop-only.
- New private `Sandbox::remove(name)` — stops then removes the VM definition. Called exclusively from `Drop`.
- `Machine::shutdown` — now calls `Self::stop` only; no longer reads `self.config.persist`.
- `Drop for Sandbox` — calls `Self::remove` instead of `Self::stop(…, false)`. Drop is now the *sole* owner of VM removal, not just a safety net.
- `Sandbox::remove_persisted(name)` — public associated function for explicit cleanup of `persist=true` sandboxes when the `Sandbox` instance is no longer available (e.g. after a process restart).

### `persist` semantics redefined

`SandboxConfig::persist` now controls whether the **VM definition survives `Sandbox` struct drop**, independent of `Machine::boot`/`Machine::shutdown` cycles:

| | `persist = false` (default) | `persist = true` |
|---|---|---|
| On `Machine::shutdown` | VM stopped | VM stopped |
| On `Sandbox` drop | VM stopped + **removed** | VM left intact |
| Cleanup | automatic | explicit `Sandbox::remove_persisted(name)` call |

## Tests

- **New**: `test_vm_definition_survives_machine_shutdown_with_persist_false` — directly reproduces the bug scenario: two sequential boot/shutdown cycles with `persist=false`, asserting the VM definition survives between them and is removed only after `Sandbox` drop.
- **Updated**: `test_start_stop_idempotent` — switched to `persist=false` to directly validate the new guarantee (VM definition survives repeated boot/drop cycles within one `Sandbox` lifetime).
- **Updated**: `test_filesystem_persists_across_stop_start` — removed `persist=true` dependency; filesystem state persists across stop/start cycles regardless of the `persist` flag, as long as the `Sandbox` is alive.