### PR TITLE
fix(runenv): unblock Drop, persist /tmp, rename Machine verbs, bump msb 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,12 +2513,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2761,6 +2770,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,6 +2982,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3164,9 @@ name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -3248,13 +3300,15 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
+ "base64 0.22.1",
  "bytes",
  "chrono",
+ "ciborium",
  "crossterm",
  "dbus",
  "dirs",
@@ -3267,12 +3321,14 @@ dependencies = [
  "microsandbox-db",
  "microsandbox-filesystem",
  "microsandbox-image",
+ "microsandbox-metrics",
  "microsandbox-migration",
  "microsandbox-network",
  "microsandbox-protocol",
  "microsandbox-runtime",
  "microsandbox-utils",
  "nix 0.30.1",
+ "notify",
  "rand 0.10.1",
  "reqwest 0.13.2",
  "scopeguard",
@@ -3291,8 +3347,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3303,8 +3359,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3316,8 +3372,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3340,17 +3396,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "microsandbox-metrics"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+dependencies = [
+ "chrono",
+ "libc",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "microsandbox-migration"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3376,6 +3443,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "smoltcp",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "time",
@@ -3386,8 +3454,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3399,8 +3467,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "bytes",
  "chrono",
@@ -3409,6 +3477,7 @@ dependencies = [
  "libc",
  "microsandbox-db",
  "microsandbox-filesystem",
+ "microsandbox-metrics",
  "microsandbox-network",
  "microsandbox-protocol",
  "microsandbox-utils",
@@ -3426,8 +3495,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.6"
-source = "git+https://github.com/superradcompany/microsandbox?rev=1294b4d7f850741e4d7fa91624226fcb45aa848a#1294b4d7f850741e4d7fa91624226fcb45aa848a"
+version = "0.5.0"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
 dependencies = [
  "dirs",
  "libc",
@@ -3482,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c29ba9c9c8a38cd001c0c9af16bd3c75be328ab8c95a3aa933b125c1d93f41c"
+checksum = "1204f9be84d1d6a7522745f2ca8c1daaad10b6974c31491b23fbfba8948ea436"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3502,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb4327e3efe423f3bcdca0390589193834b9f73eb54bb13b90f48f1755b499e"
+checksum = "99f3fb3872287fbe2f9022da8e4b99bd7e2d56bffa225dc8e76ff5f8bea207c0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3518,15 +3587,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc7dbc08509138172ccd3b40df5c1501ad498ba12f2643eb013320205f9c987"
+checksum = "81e9b644799f042ecd9ff8e1083548b069bfe5c055fb30a2ee5488d32d532305"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d88b81a52ae5b3fe1afb1692b0785a4fe946c77bbc9e43a030e84e90627819"
+checksum = "80daaaa5c82e40b410813655552dae003273439dd4f663fdf8c0d482daa81690"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3535,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6d808b3c4d5a7c24fba02a64f2f704da973cf6820deedd2811c2ec795b9fc"
+checksum = "60168afa59b23513902fca621af0ae2e34b7c1eb6778c4dfdbcbf639d90e9d88"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3549,7 +3618,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.16.4",
+ "lru 0.13.0",
  "msb_krun_arch",
  "msb_krun_hvf",
  "msb_krun_polly",
@@ -3563,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce2de785e2cceda28ce03f20a9eeb895ac947ab66b09db31077a070bd6dda86"
+checksum = "ff58dae8f64ded015362c7cf34fc6d3137e21ac67a2a2d9266c930d74de515c2"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -3575,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047a3f886330138dd6a681ef96b0b2257b494f295535bdd641841068f5847bc"
+checksum = "8c276f8c223cfef11a20777ceebf11452cbdbec0753f4f530490600abfd54e6c"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3585,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db57f147c6e1aca9a14d137ada76b6df78b538a0673d86b33652be78e9784499"
+checksum = "5c1cc89c4d634828d4487321dc1ad27440d5b610b51a313572b5b41e5ad810c0"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3595,18 +3664,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0c3a0923f194852028fd0e809a8d26c5465bc550f59c08b25bae5dd9885457"
+checksum = "3d2da7cdc57310229e8edfe559df924ae7deb747dacac65dc42898aeec44c62f"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbae5590c539ee8b9ed0e2d4c50c6ee5b546f03f9eb2408b885628514ddb9a6"
+checksum = "68805ba9921de9794b2c5a5e4e2efc6f0dbe5206e5c3bcc602d072823373a068"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3619,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd62153e5ffe89a76b775c89b9c01b65d38c67a32ca8d516a910d4cb497d367"
+checksum = "d6042a24c047faba9b2c033db72257d765cb7dde393d61943d45cccac6e1fa12"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3694,6 +3763,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4346,7 +4442,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4384,7 +4480,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6991,17 +7087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7484,7 +7569,7 @@ dependencies = [
  "typed-builder 0.21.2",
  "url",
  "webpki-root-certs 0.26.11",
- "windows-registry 0.5.3",
+ "windows-registry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"
 log = "0.4"
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", rev = "1294b4d7f850741e4d7fa91624226fcb45aa848a", optional = true }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.0", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -287,7 +287,7 @@ mod tests {
             .build()
             .unwrap();
         // Smoke check: runenv is plugged in and usable.
-        let handle = agent.state.runenv.get().await.expect("runenv boot failed");
+        let handle = agent.state.runenv.get().await.expect("runenv start failed");
         let result = handle
             .exec("sh".into(), vec!["-c".into(), "echo ok".into()], None)
             .await
@@ -499,7 +499,7 @@ mod tests {
             .unwrap();
 
         // Write through the underlying VM, read back through parent's runenv.
-        let handle = runenv.get().await.expect("runenv boot failed");
+        let handle = runenv.get().await.expect("runenv start failed");
         handle
             .write(
                 std::path::Path::new("/workspace/shared_test.txt"),
@@ -513,7 +513,7 @@ mod tests {
             .runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .read(std::path::Path::new("/workspace/shared_test.txt"))
             .await
             .expect("read failed");
@@ -529,7 +529,7 @@ mod tests {
             .runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .write(std::path::Path::new("/workspace/shared.txt"), b"shared_ok")
             .await
             .expect("write failed");
@@ -539,7 +539,7 @@ mod tests {
             .runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .read(std::path::Path::new("/workspace/shared.txt"))
             .await
             .expect("subagent runenv should see file written by parent");

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -324,7 +324,7 @@ impl Agent {
                 let outcome: Result<anyhow::Result<bool>, _> =
                     std::panic::AssertUnwindSafe(async move {
                         // Boot the runenv lazily: only when a tool actually runs.
-                        // RunEnv caches the booted handle so concurrent tool calls
+                        // RunEnv caches the started handle so concurrent tool calls
                         // share the same VM.
                         let handle = runenv.get().await?;
                         let mut stream = tool.call(call_args, call_id_for_call, handle);
@@ -1161,7 +1161,7 @@ mod tests {
             .runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .read(std::path::Path::new(log))
             .await
             .expect("failed to read log");
@@ -1314,7 +1314,7 @@ To activate a skill, read its SKILL.md using the shell tool \
 
         // Seed the sandbox with the skill file and the test PDF before running the agent.
         let pdf_bytes = minimal_pdf_bytes();
-        let handle = agent.state.runenv.get().await.expect("runenv boot failed");
+        let handle = agent.state.runenv.get().await.expect("runenv start failed");
         let _ = handle
             .exec(
                 "sh".to_string(),
@@ -1355,7 +1355,7 @@ To activate a skill, read its SKILL.md using the shell tool \
             .runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .read(std::path::Path::new("/workspace/test.md"))
             .await
             .expect("agent should have written /workspace/test.md");
@@ -1464,7 +1464,7 @@ To activate a skill, read its SKILL.md using the shell tool \
         let result = runenv
             .get()
             .await
-            .expect("runenv boot failed")
+            .expect("runenv start failed")
             .exec(
                 "sh".to_string(),
                 vec!["-c".to_string(), "cat /workspace/sentinel.txt".to_string()],

--- a/src/runenv/local.rs
+++ b/src/runenv/local.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use super::{Console, ExecResult, Machine};
 
-/// `Machine` that runs commands directly on the host. Boot/shutdown are
+/// `Machine` that runs commands directly on the host. Start/stop are
 /// no-ops because there is no underlying VM to spin up.
 #[derive(Debug, Clone, Default)]
 pub struct Local {}
@@ -19,11 +19,11 @@ impl Local {
 impl Machine for Local {
     type Handle = LocalConsole;
 
-    async fn boot(&mut self) -> anyhow::Result<LocalConsole> {
+    async fn start(&mut self) -> anyhow::Result<LocalConsole> {
         Ok(LocalConsole {})
     }
 
-    async fn shutdown(&mut self) {}
+    async fn stop(&mut self) {}
 }
 
 pub struct LocalConsole {}

--- a/src/runenv/mod.rs
+++ b/src/runenv/mod.rs
@@ -434,6 +434,7 @@ impl Drop for RunEnvHandle {
             }
             let _ = tx.send(());
         });
-        let _ = rx.recv_timeout(std::time::Duration::from_secs(30));
+        // let _ = rx.recv_timeout(std::time::Duration::from_secs(30));
+        let _ = rx;
     }
 }

--- a/src/runenv/mod.rs
+++ b/src/runenv/mod.rs
@@ -41,12 +41,12 @@
 //! # Lifecycle
 //!
 //! A `RunEnv` is cheap to construct and starts out idle. The underlying
-//! machine is only booted on demand: callers obtain a [`RunEnvHandle`] via
-//! [`RunEnv::get`], which lazily boots the container on the first call and
-//! reuses the same booted handle for subsequent callers. When the last
-//! outstanding `RunEnvHandle` is dropped, the container is shut down
+//! machine is only started on demand: callers obtain a [`RunEnvHandle`] via
+//! [`RunEnv::get`], which lazily starts the container on the first call and
+//! reuses the same started handle for subsequent callers. When the last
+//! outstanding `RunEnvHandle` is dropped, the container is stopped
 //! automatically and the `RunEnv` returns to the idle state, ready to be
-//! booted again on the next `get()`.
+//! started again on the next `get()`.
 //!
 //! All operations against the environment go through the handle, which
 //! derefs to [`Console`].
@@ -55,9 +55,9 @@
 //!
 //! To add a new kind of running environment, implement two traits:
 //!
-//! - [`Machine`]: describes how to boot and shut down the underlying
-//!   machine. `boot` returns a handle type that implements [`Console`].
-//! - [`Console`]: the booted handle. At minimum, implement
+//! - [`Machine`]: describes how to start and stop the underlying
+//!   machine. `start` returns a handle type that implements [`Console`].
+//! - [`Console`]: the started handle. At minimum, implement
 //!   [`Console::get_os`] and [`Console::exec`]; the other methods
 //!   (`exec_shell`, `get_cwd`, `read`, `write`) have default implementations
 //!   built on top of `exec`, but may be overridden for efficiency when a
@@ -70,18 +70,18 @@
 //! use ailoy::runenv::{Console, Machine, ExecResult, RunEnv};
 //!
 //! struct MyMachine { /* connection state, config, ... */ }
-//! struct MyConsole { /* booted session, e.g. an SSH channel */ }
+//! struct MyConsole { /* started session, e.g. an SSH channel */ }
 //!
 //! #[async_trait]
 //! impl Machine for MyMachine {
 //!     type Handle = MyConsole;
 //!
-//!     async fn boot(&mut self) -> anyhow::Result<Self::Handle> {
+//!     async fn start(&mut self) -> anyhow::Result<Self::Handle> {
 //!         // open connection, spawn shell, etc.
 //!         Ok(MyConsole { /* ... */ })
 //!     }
 //!
-//!     async fn shutdown(&mut self) {
+//!     async fn stop(&mut self) {
 //!         // close connection, kill process, etc.
 //!     }
 //! }
@@ -128,37 +128,37 @@ pub use local::*;
 #[cfg(feature = "sandbox")]
 pub use sandbox::*;
 
-/// Backend that knows how to boot and tear down a running environment,
-/// yielding a [`Console`] handle for the booted instance.
+/// Backend that knows how to start and stop a running environment,
+/// yielding a [`Console`] handle for the started instance.
 ///
 /// See the [module-level documentation](self) for the overall design.
 #[async_trait]
 pub trait Machine: Send + Sync + 'static {
     type Handle: Console;
 
-    async fn boot(&mut self) -> anyhow::Result<Self::Handle>;
+    async fn start(&mut self) -> anyhow::Result<Self::Handle>;
 
-    async fn shutdown(&mut self);
+    async fn stop(&mut self);
 }
 
 /// Object-safe erased view of `Machine`. The blanket impl below adapts any
 /// concrete `Machine` by boxing the handle into `Arc<dyn Console>`.
 #[async_trait]
 trait MachineDyn: Send + Sync + 'static {
-    async fn boot(&mut self) -> anyhow::Result<Arc<dyn Console>>;
+    async fn start(&mut self) -> anyhow::Result<Arc<dyn Console>>;
 
-    async fn shutdown(&mut self);
+    async fn stop(&mut self);
 }
 
 #[async_trait]
 impl<B: Machine> MachineDyn for B {
-    async fn boot(&mut self) -> anyhow::Result<Arc<dyn Console>> {
+    async fn start(&mut self) -> anyhow::Result<Arc<dyn Console>> {
         // UFCS so this doesn't recurse into the MachineDyn impl we're in.
-        Ok(Arc::new(Machine::boot(self).await?))
+        Ok(Arc::new(Machine::start(self).await?))
     }
 
-    async fn shutdown(&mut self) {
-        Machine::shutdown(self).await;
+    async fn stop(&mut self) {
+        Machine::stop(self).await;
     }
 }
 
@@ -171,7 +171,7 @@ pub struct ExecResult {
     pub timed_out: bool,
 }
 
-/// Handle to a booted running environment, exposing command execution and
+/// Handle to a started running environment, exposing command execution and
 /// file I/O against it.
 ///
 /// See the [module-level documentation](self) for the overall design.
@@ -182,7 +182,7 @@ pub trait Console: Send + Sync {
     /// Run `program` with `args`. `timeout` is in seconds; when elapsed the
     /// resulting [`ExecResult`] has `timed_out = true`.
     ///
-    /// Takes `&self` so a single booted handle can be shared by multiple
+    /// Takes `&self` so a single started handle can be shared by multiple
     /// `RunEnvHandle` clones. Implementations are responsible for their own
     /// internal synchronization (e.g. a Mutex around the stdin/stdout pipe).
     async fn exec(
@@ -336,7 +336,7 @@ enum RunEnvState {
 }
 
 /// A running environment. Wraps a [`Machine`] backend and hands out shared
-/// [`RunEnvHandle`]s through [`RunEnv::get`]; the backend is booted on the
+/// [`RunEnvHandle`]s through [`RunEnv::get`]; the backend is started on the
 /// first `get` and shut down when the last handle is dropped.
 ///
 /// See the [module-level documentation](self) for the overall design.
@@ -368,9 +368,9 @@ impl RunEnv {
             let mut s = self.state.lock().await;
             match &*s {
                 RunEnvState::Idle => {
-                    // Hold the state lock through boot; other callers block on
+                    // Hold the state lock through start; other callers block on
                     // `state.lock().await` and observe `Running` once we finish.
-                    let console = self.machine.lock().await.boot().await?;
+                    let console = self.machine.lock().await.start().await?;
                     let handle = Arc::new(RunEnvHandle {
                         machine: self.machine.clone(),
                         console,
@@ -384,7 +384,7 @@ impl RunEnv {
                         return Ok(inner);
                     }
                     // Last user handle just dropped but the `Drop`-spawned
-                    // shutdown hasn't acquired the state lock yet. Release the
+                    // stop hasn't acquired the state lock yet. Release the
                     // state lock so it can make progress, then retry.
                     drop(s);
                     tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -394,7 +394,7 @@ impl RunEnv {
     }
 }
 
-/// Shared handle to a booted [`RunEnv`]. Derefs to [`Console`] so callers can
+/// Shared handle to a started [`RunEnv`]. Derefs to [`Console`] so callers can
 /// invoke `exec`, `read`, `write`, etc. directly on the handle.
 ///
 /// See the [module-level documentation](self) for the overall design.
@@ -425,10 +425,10 @@ impl Drop for RunEnvHandle {
                 .build()
             {
                 rt.block_on(async move {
-                    // Hold the state lock through shutdown so concurrent `get()` calls
+                    // Hold the state lock through stop so concurrent `get()` calls
                     // block until we transition back to `Idle`.
                     let mut s = state.lock().await;
-                    machine.lock().await.shutdown().await;
+                    machine.lock().await.stop().await;
                     *s = RunEnvState::Idle;
                 });
             }

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -357,23 +357,6 @@ impl Sandbox {
         match MsbSandbox::get(name).await {
             Err(e) => log::warn!("sandbox stop: get '{name}' failed: {e}"),
             Ok(handle) => {
-                // TODO: remove once superradcompany/microsandbox#746 is merged and
-                // agentd is updated past v0.4.6. The prebuilt agentd v0.4.6 does not
-                // call sync() before poweroff; that call was added in the unreleased
-                // PR #746 branch. Without an explicit syncfs the overlayfs ext4
-                // journal is committed but never checkpointed at VM exit, leaving the
-                // on-disk block bitmap stale — subsequent starts reallocate "free"
-                // blocks that still hold data, corrupting files. Running sync -f /
-                // here, while the VM is fully live, forces the checkpoint via
-                // ovl_sync_fs → ext4_sync_fs → jbd2_journal_flush before the
-                // shutdown sequence begins.
-                if matches!(
-                    handle.status(),
-                    SandboxStatus::Running | SandboxStatus::Draining
-                ) && let Ok(connected) = handle.connect().await
-                {
-                    let _ = connected.shell("sync -f / 2>/dev/null || sync").await;
-                }
                 let _ = handle.stop().await;
             }
         }

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -1,11 +1,11 @@
 //! microsandbox-backed `Machine` for runenv.
 //!
-//! Heavyweight, fallible setup happens in `Sandbox::new`; `Machine::boot`
-//! starts the VM, `Machine::shutdown` stops it, and dropping the `Sandbox`
+//! Heavyweight, fallible setup happens in `Sandbox::new`; `Machine::start`
+//! starts the VM, `Machine::stop` stops it, and dropping the `Sandbox`
 //! removes the VM definition (unless `config.persist` is `true`).
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -15,6 +15,7 @@ use microsandbox::{
     ExecOutput, MicrosandboxError, Sandbox as MsbSandbox, Snapshot,
     sandbox::{ExecOptionsBuilder, PullPolicy, SandboxBuilder, SandboxStatus},
 };
+use tokio::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -58,6 +59,74 @@ pub enum VolumeMount {
     },
 }
 
+impl VolumeMount {
+    /// Guest mount path. Matches the `guest` field across all variants.
+    pub fn guest_path(&self) -> &str {
+        match self {
+            VolumeMount::Bind { guest, .. }
+            | VolumeMount::Named { guest, .. }
+            | VolumeMount::Tmpfs { guest, .. } => guest,
+        }
+    }
+}
+
+/// Label key/value applied to volumes ailoy provisions. The startup sweep
+/// removes only labelled volumes so volumes from other tools are never touched.
+const AILOY_VOLUME_LABEL_KEY: &str = "ailoy.managed";
+const AILOY_VOLUME_LABEL_VALUE: &str = "true";
+
+/// Prefix for the per-sandbox `/tmp` volume injected by `Sandbox::new`.
+const AILOY_TMP_VOLUME_PREFIX: &str = "ailoy-tmp-";
+
+fn tmp_volume_name(sandbox_name: &str) -> String {
+    format!("{AILOY_TMP_VOLUME_PREFIX}{sandbox_name}")
+}
+
+static STARTUP_SWEEP_DONE: OnceCell<()> = OnceCell::const_new();
+
+/// Remove `ailoy-tmp-*` volumes left over by previous process invocations
+/// (panic, SIGKILL, or a `RunEnvHandle::Drop` background thread racing
+/// process exit). Targets only volumes that carry the `ailoy.managed` label
+/// and whose owner sandbox is no longer present, so volumes from other
+/// tools and from an in-flight `Sandbox::new` in a parallel process are
+/// left alone.
+async fn sweep_orphan_tmp_volumes() {
+    let active: HashSet<String> = match MsbSandbox::list().await {
+        Ok(handles) => handles.into_iter().map(|h| h.name().to_string()).collect(),
+        Err(e) => {
+            log::warn!("startup sweep: list sandboxes failed: {e}");
+            return;
+        }
+    };
+
+    let volumes = match microsandbox::Volume::list().await {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("startup sweep: list volumes failed: {e}");
+            return;
+        }
+    };
+
+    for v in volumes {
+        let vname = v.name().to_string();
+        let Some(owner) = vname.strip_prefix(AILOY_TMP_VOLUME_PREFIX) else {
+            continue;
+        };
+        let labelled = v.labels().iter().any(|(k, val)| {
+            k == AILOY_VOLUME_LABEL_KEY && val == AILOY_VOLUME_LABEL_VALUE
+        });
+        if !labelled {
+            continue;
+        }
+        if active.contains(owner) {
+            continue;
+        }
+        if let Err(e) = microsandbox::Volume::remove(&vname).await {
+            log::warn!("startup sweep: remove '{vname}' failed: {e}");
+        }
+    }
+}
+
 /// Configuration for creating a new sandbox.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SandboxConfig {
@@ -80,7 +149,7 @@ pub struct SandboxConfig {
     pub memory_mib: u32,
 
     /// Default working directory inside the sandbox. Default: `"/workspace"`.
-    /// Created automatically after boot if it does not already exist.
+    /// Created automatically after start if it does not already exist.
     pub workdir: String,
 
     /// Environment variables passed to every command.
@@ -99,7 +168,7 @@ pub struct SandboxConfig {
     /// and can be reattached by name in a future session. Use
     /// [`Sandbox::remove_persisted`] to delete it explicitly.
     ///
-    /// Independent of `Machine::boot`/`Machine::shutdown` cycles — those only
+    /// Independent of `Machine::start`/`Machine::stop` cycles — those only
     /// start and stop the VM regardless of this flag. Default: `false`.
     pub persist: bool,
 
@@ -140,9 +209,9 @@ fn fresh_sandbox_name() -> String {
 
 /// `Machine` implementation backed by a microsandbox VM.
 ///
-/// The VM is created at construction time and left stopped; `boot()` starts
-/// it for the duration of the returned [`SandboxConsole`], and `shutdown()`
-/// stops it. The VM definition is removed when the `Sandbox` value is
+/// The VM is created at construction time and left stopped; `start()` boots
+/// the VM for the duration of the returned [`SandboxConsole`], and `stop()`
+/// halts it. The VM definition is removed when the `Sandbox` value is
 /// dropped, unless `config.persist` is `true`.
 pub struct Sandbox {
     config: SandboxConfig,
@@ -152,7 +221,7 @@ pub struct Sandbox {
 impl Sandbox {
     /// Install the microsandbox runtime if needed, create or attach to the
     /// named VM, ensure `workdir` exists, then stop the VM.
-    pub async fn new(config: SandboxConfig) -> anyhow::Result<Self> {
+    pub async fn new(mut config: SandboxConfig) -> anyhow::Result<Self> {
         use anyhow::Context as _;
 
         if let Some(home) = &config.home {
@@ -174,17 +243,59 @@ impl Sandbox {
             log::info!("microsandbox runtime installed");
         }
 
+        STARTUP_SWEEP_DONE
+            .get_or_init(|| async { sweep_orphan_tmp_volumes().await })
+            .await;
+
         let name = config.name.clone().unwrap_or_else(fresh_sandbox_name);
         validate_sandbox_name(&name)?;
 
-        let inner = if config.persist && MsbSandbox::get(&name).await.is_ok() {
+        // Pre-populate `/tmp` with a per-sandbox named volume so the
+        // microsandbox auto-tmpfs escape hatch (apply_runtime_defaults in
+        // microsandbox 0.4.6 lib/sandbox/config.rs:305-323) fires and `/tmp`
+        // survives the start/stop cycle that `RunEnvHandle::Drop` drives.
+        // A user-supplied `/tmp` mount takes precedence.
+        let tmp_vol_provisioned = if config.volumes.iter().any(|v| v.guest_path() == "/tmp") {
+            None
+        } else {
+            let vol_name = tmp_volume_name(&name);
+            match microsandbox::Volume::builder(&vol_name)
+                .label(AILOY_VOLUME_LABEL_KEY, AILOY_VOLUME_LABEL_VALUE)
+                .create()
+                .await
+            {
+                Ok(_) => {}
+                // `persist=true` reattach: reuse the existing volume.
+                Err(MicrosandboxError::VolumeAlreadyExists(_)) => {}
+                Err(e) => {
+                    return Err(anyhow::anyhow!("create /tmp named volume: {e}"));
+                }
+            }
+            config.volumes.push(VolumeMount::Named {
+                name: vol_name.clone(),
+                guest: "/tmp".to_string(),
+                readonly: false,
+            });
+            Some(vol_name)
+        };
+
+        let inner = match if config.persist && MsbSandbox::get(&name).await.is_ok() {
             MsbSandbox::start_detached(&name)
                 .await
-                .context("sandbox start")?
+                .context("sandbox start")
         } else {
             create_registered(&name, &config)
                 .await
-                .context("sandbox create-registered")?
+                .context("sandbox create-registered")
+        } {
+            Ok(s) => s,
+            Err(e) => {
+                // Roll back the volume we just provisioned.
+                if let Some(vol) = tmp_vol_provisioned {
+                    let _ = microsandbox::Volume::remove(&vol).await;
+                }
+                return Err(e);
+            }
         };
         let _ = inner.shell(&format!("mkdir -p {}", config.workdir)).await;
         inner.stop_and_wait().await?;
@@ -196,7 +307,7 @@ impl Sandbox {
     ///
     /// The source sandbox must be stopped; running sandboxes are rejected
     /// with an error. The returned `Sandbox` is registered but stopped, ready
-    /// to be booted.
+    /// to be started.
     pub async fn fork(&self, new_cfg: SandboxConfig) -> anyhow::Result<Sandbox> {
         if vm_is_running(&self.name).await {
             anyhow::bail!("cannot fork running sandbox '{}'; stop it first", self.name);
@@ -242,7 +353,7 @@ impl Sandbox {
     }
 
     /// Stop the named VM if it is running. Does not remove the VM definition.
-    async fn stop(name: &str) {
+    async fn stop_vm(name: &str) {
         match MsbSandbox::get(name).await {
             Err(e) => log::warn!("sandbox stop: get '{name}' failed: {e}"),
             Ok(handle) => {
@@ -251,7 +362,7 @@ impl Sandbox {
                 // call sync() before poweroff; that call was added in the unreleased
                 // PR #746 branch. Without an explicit syncfs the overlayfs ext4
                 // journal is committed but never checkpointed at VM exit, leaving the
-                // on-disk block bitmap stale — subsequent boots reallocate "free"
+                // on-disk block bitmap stale — subsequent starts reallocate "free"
                 // blocks that still hold data, corrupting files. Running sync -f /
                 // here, while the VM is fully live, forces the checkpoint via
                 // ovl_sync_fs → ext4_sync_fs → jbd2_journal_flush before the
@@ -269,10 +380,13 @@ impl Sandbox {
     }
 
     /// Stop the VM and remove its definition. Called only from `Drop`
-    /// for non-persist sandboxes; never from `Machine::shutdown`.
+    /// for non-persist sandboxes; never from `Machine::stop`.
     async fn remove(name: &str) {
-        Self::stop(name).await;
+        Self::stop_vm(name).await;
         let _ = MsbSandbox::remove(name).await;
+        // Drop the per-sandbox /tmp volume provisioned in `Sandbox::new`.
+        // No-op if the user supplied their own /tmp mount.
+        let _ = microsandbox::Volume::remove(&tmp_volume_name(name)).await;
     }
 
     /// Remove a `persist = true` sandbox by name without holding a [`Sandbox`] instance.
@@ -296,6 +410,7 @@ impl Sandbox {
                         handle.remove().await?;
                     }
                 }
+                let _ = microsandbox::Volume::remove(&tmp_volume_name(name)).await;
                 Ok(())
             }
         }
@@ -316,9 +431,9 @@ impl std::fmt::Debug for Sandbox {
 impl Machine for Sandbox {
     type Handle = SandboxConsole;
 
-    async fn boot(&mut self) -> anyhow::Result<SandboxConsole> {
+    async fn start(&mut self) -> anyhow::Result<SandboxConsole> {
         let inner = start_and_connect(&self.name).await?;
-        // Bind-mounted workdirs reset on each boot — re-create.
+        // Bind-mounted workdirs reset on each start — re-create.
         let _ = inner
             .shell(&format!("mkdir -p {}", self.config.workdir))
             .await;
@@ -331,16 +446,16 @@ impl Machine for Sandbox {
     }
 
     /// Stops the VM only; the VM definition is removed when the `Sandbox` is dropped.
-    async fn shutdown(&mut self) {
-        Self::stop(&self.name).await;
+    async fn stop(&mut self) {
+        Self::stop_vm(&self.name).await;
     }
 }
 
 impl Drop for Sandbox {
     fn drop(&mut self) {
         // Drop is the sole owner of VM definition removal for non-persist
-        // sandboxes. `Machine::shutdown` only stops the VM; removal happens
-        // here so the VM definition survives multiple boot/shutdown cycles
+        // sandboxes. `Machine::stop` only stops the VM; removal happens
+        // here so the VM definition survives multiple start/stop cycles
         // within the same `Sandbox` lifetime.
         if self.config.persist {
             return;
@@ -445,7 +560,7 @@ impl Console for SandboxConsole {
 
 /// Start the sandbox with one force-stop retry on `SandboxStillRunning`, then
 /// detach lifecycle ownership and reconnect without it, so dropping the
-/// returned handle will not SIGTERM the VM. SIGTERM bypasses agentd's shutdown
+/// returned handle will not SIGTERM the VM. SIGTERM bypasses agentd's stop
 /// path and loses in-flight dirty pages; all stops must go through `Sandbox::stop`.
 async fn start_and_connect(name: &str) -> anyhow::Result<MsbSandbox> {
     let inner = match MsbSandbox::start_detached(name).await {
@@ -465,10 +580,10 @@ async fn start_and_connect(name: &str) -> anyhow::Result<MsbSandbox> {
     inner.detach().await;
     MsbSandbox::get(name)
         .await
-        .map_err(|e| anyhow::anyhow!("boot: sandbox not found: {e}"))?
+        .map_err(|e| anyhow::anyhow!("start: sandbox not found: {e}"))?
         .connect()
         .await
-        .map_err(|e| anyhow::anyhow!("boot: connect failed: {e}"))
+        .map_err(|e| anyhow::anyhow!("start: connect failed: {e}"))
 }
 
 fn handle_exec_result(
@@ -666,7 +781,7 @@ mod tests {
 
     /// Wait until `vm_is_running(name)` returns false, polling every 50ms.
     /// Returns true if the VM stopped before `deadline`, false on timeout.
-    /// Used after handle drop, where the background shutdown thread stops
+    /// Used after handle drop, where the background stop thread stops
     /// the VM asynchronously and `drop` itself returns immediately.
     async fn wait_until_stopped(name: &str, deadline: std::time::Duration) -> bool {
         let start = Instant::now();
@@ -836,11 +951,11 @@ mod tests {
 
     // ── VM lifecycle ─────────────────────────────────────────────────────────
 
-    /// VM definition survives `Machine::shutdown` (handle drop) when
-    /// `persist = false` — subsequent boots on the same `Sandbox` must succeed.
+    /// VM definition survives `Machine::stop` (handle drop) when
+    /// `persist = false` — subsequent starts on the same `Sandbox` must succeed.
     /// The definition is only removed when the `Sandbox` struct itself is dropped.
     #[tokio::test]
-    async fn test_vm_definition_survives_machine_shutdown_with_persist_false() {
+    async fn test_vm_definition_survives_machine_stop_with_persist_false() {
         let name = format!("at-vmdef-{}", short_id());
         let env = RunEnv::sandbox(SandboxConfig {
             name: Some(name.clone()),
@@ -850,7 +965,7 @@ mod tests {
         .await
         .unwrap();
 
-        // 1st boot/shutdown cycle
+        // 1st start/stop cycle
         {
             let h = env.get().await.unwrap();
             let r = h
@@ -858,7 +973,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(r.exit_code, 0);
-        } // handle drop → Machine::shutdown is called
+        } // handle drop → Machine::stop is called
 
         // VM definition must still exist
         assert!(
@@ -866,13 +981,13 @@ mod tests {
             "VM definition must survive handle drop when persist=false"
         );
 
-        // 2nd boot must succeed and file state must be preserved
+        // 2nd start must succeed and file state must be preserved
         let h2 = env.get().await.unwrap();
         let r = h2
             .exec_shell("cat ./m.txt".to_string(), None)
             .await
             .unwrap();
-        assert_eq!(r.exit_code, 0, "second boot must succeed: {}", r.stderr);
+        assert_eq!(r.exit_code, 0, "second start must succeed: {}", r.stderr);
         drop(h2);
 
         // VM definition must be gone after the Sandbox is dropped
@@ -884,7 +999,7 @@ mod tests {
         );
     }
 
-    /// A single boot serves multiple `exec` calls without the VM going down
+    /// A single start serves multiple `exec` calls without the VM going down
     /// between them.
     #[tokio::test]
     async fn test_vm_stays_up_across_exec_calls() {
@@ -911,7 +1026,7 @@ mod tests {
         }
     }
 
-    /// Dropping the last handle shuts the VM down; `get()` boots it again.
+    /// Dropping the last handle stops the VM; `get()` starts it again.
     #[tokio::test]
     async fn test_stop_and_start() {
         let name = format!("at-ss-{}", short_id());
@@ -940,7 +1055,7 @@ mod tests {
         Sandbox::remove_persisted(&name).await.ok();
     }
 
-    /// Repeated boot/drop cycles are safe with `persist = false` — the VM
+    /// Repeated start/drop cycles are safe with `persist = false` — the VM
     /// definition survives each cycle and no resource leak or double-stop error
     /// occurs. Removal happens only when the `Sandbox` is dropped.
     #[tokio::test]
@@ -994,8 +1109,8 @@ mod tests {
 
     // ── concurrent access ────────────────────────────────────────────────────
 
-    /// Concurrent `RunEnv::get()` calls all succeed and share the same booted VM —
-    /// the machine is booted at most once.
+    /// Concurrent `RunEnv::get()` calls all succeed and share the same started VM —
+    /// the machine is started at most once.
     #[tokio::test]
     async fn test_concurrent_get() {
         let name = format!("at-cg-{}", short_id());
@@ -1164,7 +1279,7 @@ mod tests {
 
     // ── persistence ──────────────────────────────────────────────────────────
 
-    /// Files written during one boot survive the next — the VM definition is
+    /// Files written during one start survive the next — the VM definition is
     /// preserved across stop/start cycles as long as the `Sandbox` is alive,
     /// regardless of `persist`.
     #[tokio::test]
@@ -1422,6 +1537,145 @@ mod tests {
         );
     }
 
+    /// `/tmp` is backed by an auto-injected named volume, so writes from one
+    /// handle scope survive into the next within the same `Sandbox`.
+    #[tokio::test]
+    async fn test_tmp_persists_across_starts() {
+        let env = make_env().await;
+
+        {
+            let h = env.get().await.unwrap();
+            h.exec_shell("echo hello > /tmp/probe".to_string(), None)
+                .await
+                .expect("write failed");
+        }
+
+        let h = env.get().await.unwrap();
+        let r = h
+            .exec_shell(
+                "cat /tmp/probe 2>/dev/null || echo MISSING".to_string(),
+                None,
+            )
+            .await
+            .expect("read failed");
+        assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+        assert!(
+            r.stdout.contains("hello"),
+            "stdout: {:?}",
+            r.stdout
+        );
+    }
+
+    /// User-supplied `/tmp` mounts take precedence over the auto-injected
+    /// named volume, so callers can opt out and get tmpfs semantics back.
+    #[tokio::test]
+    async fn test_user_tmpfs_overrides_default_tmp() {
+        let env = RunEnv::sandbox(SandboxConfig {
+            volumes: vec![VolumeMount::Tmpfs {
+                guest: "/tmp".to_string(),
+                size_mib: Some(64),
+            }],
+            ..SandboxConfig::default()
+        })
+        .await
+        .expect("failed to create sandbox");
+
+        {
+            let h = env.get().await.unwrap();
+            h.exec_shell("echo hello > /tmp/probe".to_string(), None)
+                .await
+                .expect("write failed");
+        }
+
+        let h = env.get().await.unwrap();
+        let r = h
+            .exec_shell(
+                "cat /tmp/probe 2>/dev/null || echo MISSING".to_string(),
+                None,
+            )
+            .await
+            .expect("read failed");
+        assert!(
+            r.stdout.contains("MISSING"),
+            "user tmpfs at /tmp must wipe between starts, stdout: {:?}",
+            r.stdout
+        );
+    }
+
+    /// Dropping a non-persist `Sandbox` removes its auto-injected `/tmp`
+    /// volume along with the VM definition.
+    #[tokio::test]
+    async fn test_tmp_volume_removed_on_sandbox_drop() {
+        use microsandbox::Volume;
+
+        let name = format!("drop-test-{}", short_id());
+        let vol = tmp_volume_name(&name);
+        {
+            let _env = RunEnv::sandbox(SandboxConfig {
+                name: Some(name.clone()),
+                persist: false,
+                ..SandboxConfig::default()
+            })
+            .await
+            .expect("failed to create sandbox");
+            Volume::get(&vol)
+                .await
+                .expect("volume must exist while sandbox is alive");
+        }
+
+        // Drop runs cleanup on a background thread; poll until the volume
+        // disappears or the deadline elapses.
+        let start = Instant::now();
+        loop {
+            if Volume::get(&vol).await.is_err() {
+                return;
+            }
+            if start.elapsed() >= std::time::Duration::from_secs(30) {
+                panic!("volume '{vol}' was not removed within 30s of Sandbox drop");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    /// The startup sweep removes `ailoy.managed` volumes whose owner sandbox
+    /// is no longer present. Volumes without the label are left alone.
+    #[tokio::test]
+    async fn test_startup_sweep_targets_only_labelled_orphans() {
+        use microsandbox::Volume;
+
+        // Orphan: ailoy-tmp-* prefix + ailoy.managed label, no owner sandbox.
+        let orphan_owner = format!("nonexistent-{}", Uuid::new_v4());
+        let orphan_vol = tmp_volume_name(&orphan_owner);
+        Volume::builder(&orphan_vol)
+            .label(AILOY_VOLUME_LABEL_KEY, AILOY_VOLUME_LABEL_VALUE)
+            .create()
+            .await
+            .expect("create orphan volume");
+
+        // Bystander: ailoy-tmp-* prefix but no label, mimicking an external
+        // volume coincidentally named like ours.
+        let bystander_vol = format!("ailoy-tmp-external-{}", Uuid::new_v4());
+        Volume::builder(&bystander_vol)
+            .create()
+            .await
+            .expect("create bystander volume");
+
+        sweep_orphan_tmp_volumes().await;
+
+        let orphan_present = Volume::get(&orphan_vol).await.is_ok();
+        let bystander_present = Volume::get(&bystander_vol).await.is_ok();
+
+        if bystander_present {
+            let _ = Volume::remove(&bystander_vol).await;
+        }
+        if orphan_present {
+            let _ = Volume::remove(&orphan_vol).await;
+        }
+
+        assert!(!orphan_present, "labelled orphan must be swept");
+        assert!(bystander_present, "unlabelled volume must be left alone");
+    }
+
     // ── networking ───────────────────────────────────────────────────────────
 
     /// By default the sandbox can reach external hosts.
@@ -1472,8 +1726,8 @@ mod tests {
 
     // ── fork ─────────────────────────────────────────────────────────────────
     //
-    // Fork operates on the underlying `Sandbox`, not on a booted handle, so
-    // these tests bypass `RunEnv` and drive `Machine::boot` / `Machine::shutdown`
+    // Fork operates on the underlying `Sandbox`, not on a started handle, so
+    // these tests bypass `RunEnv` and drive `Machine::start` / `Machine::stop`
     // directly.
 
     #[tokio::test]
@@ -1489,7 +1743,7 @@ mod tests {
 
         // Boot the VM directly so we can observe the "running" state when
         // calling `fork`.
-        let _console = src.boot().await.expect("boot");
+        let _console = src.start().await.expect("start");
         assert!(
             vm_is_running(&src_name).await,
             "should be running before fork"
@@ -1509,7 +1763,7 @@ mod tests {
         );
 
         drop(_console);
-        src.shutdown().await;
+        src.stop().await;
         Sandbox::remove_persisted(&src_name).await.ok();
     }
 
@@ -1527,13 +1781,13 @@ mod tests {
         .expect("create source");
 
         {
-            let console = src.boot().await.expect("boot src");
+            let console = src.start().await.expect("start src");
             console
                 .exec_shell("echo fork_content > ./note.txt".to_string(), None)
                 .await
                 .expect("write note");
         }
-        src.shutdown().await;
+        src.stop().await;
 
         let mut child = src
             .fork(SandboxConfig {
@@ -1544,7 +1798,7 @@ mod tests {
             .await
             .expect("fork");
 
-        let child_console = child.boot().await.expect("boot child");
+        let child_console = child.start().await.expect("start child");
         let bytes = child_console
             .read(Path::new("./note.txt"))
             .await
@@ -1557,7 +1811,7 @@ mod tests {
         );
 
         drop(child_console);
-        child.shutdown().await;
+        child.stop().await;
         Sandbox::remove_persisted(&src_name).await.ok();
         Sandbox::remove_persisted(&child_name).await.ok();
     }
@@ -1576,13 +1830,13 @@ mod tests {
         .expect("create source");
 
         {
-            let console = src.boot().await.expect("boot src");
+            let console = src.start().await.expect("start src");
             console
                 .exec_shell("echo original > ./data.txt".to_string(), None)
                 .await
                 .expect("write original");
         }
-        src.shutdown().await;
+        src.stop().await;
 
         let mut child = src
             .fork(SandboxConfig {
@@ -1594,15 +1848,15 @@ mod tests {
             .expect("fork");
 
         {
-            let console = child.boot().await.expect("boot child");
+            let console = child.start().await.expect("start child");
             console
                 .exec_shell("echo mutated > ./data.txt".to_string(), None)
                 .await
                 .expect("mutate child");
         }
-        child.shutdown().await;
+        child.stop().await;
 
-        let src_console = src.boot().await.expect("boot src after fork");
+        let src_console = src.start().await.expect("start src after fork");
         let bytes = src_console
             .read(Path::new("./data.txt"))
             .await
@@ -1615,7 +1869,7 @@ mod tests {
         );
 
         drop(src_console);
-        src.shutdown().await;
+        src.stop().await;
         Sandbox::remove_persisted(&src_name).await.ok();
         Sandbox::remove_persisted(&child_name).await.ok();
     }
@@ -1653,7 +1907,7 @@ mod tests {
             "snapshot should be deleted after fork, still found at {snap_dir:?}"
         );
 
-        child.shutdown().await;
+        child.stop().await;
         Sandbox::remove_persisted(&src_name).await.ok();
         Sandbox::remove_persisted(&child_name).await.ok();
     }

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -356,7 +356,8 @@ impl Drop for Sandbox {
             }
             let _ = tx.send(());
         });
-        let _ = rx.recv_timeout(std::time::Duration::from_secs(30));
+        // let _ = rx.recv_timeout(std::time::Duration::from_secs(30));
+        let _ = rx;
     }
 }
 
@@ -663,6 +664,23 @@ mod tests {
             .expect("failed to create sandbox")
     }
 
+    /// Wait until `vm_is_running(name)` returns false, polling every 50ms.
+    /// Returns true if the VM stopped before `deadline`, false on timeout.
+    /// Used after handle drop, where the background shutdown thread stops
+    /// the VM asynchronously and `drop` itself returns immediately.
+    async fn wait_until_stopped(name: &str, deadline: std::time::Duration) -> bool {
+        let start = Instant::now();
+        loop {
+            if !vm_is_running(name).await {
+                return true;
+            }
+            if start.elapsed() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
     // ── config & validation ──────────────────────────────────────────────────
 
     /// `SandboxConfig::name` round-trips through JSON: Some is preserved, None is omitted.
@@ -912,8 +930,8 @@ mod tests {
         );
         drop(handle);
         assert!(
-            !vm_is_running(&name).await,
-            "VM should be stopped after handle drop"
+            wait_until_stopped(&name, std::time::Duration::from_secs(30)).await,
+            "VM should be stopped within 30s of handle drop"
         );
 
         let handle = env.get().await.unwrap();
@@ -940,7 +958,10 @@ mod tests {
             let handle = env.get().await.unwrap();
             assert!(vm_is_running(&name).await);
             drop(handle);
-            assert!(!vm_is_running(&name).await);
+            assert!(
+                wait_until_stopped(&name, std::time::Duration::from_secs(30)).await,
+                "VM should be stopped within 30s of handle drop"
+            );
         }
         // VM definition is still present — removal happens on Sandbox drop.
         assert!(MsbSandbox::get(&name).await.is_ok());


### PR DESCRIPTION
## Summary

Four facets of the same handle-lifecycle problem in sandbox-backed `Agent::run`. Each is a thin change; they ship together because they share the same code path and the same reviewer thread.

**(1) `RunEnvHandle::Drop` and `Sandbox::Drop` block the caller thread on a sync `recv_timeout(30s)`.** When `Drop` fires on a tokio worker the worker stalls for up to 30 seconds and later-scheduled futures on the same runtime starve. Measured on a 4-parallel `api_search` turn against a sandbox-backed agent on `claude-opus-4-7`: 97 to 99 seconds wall time with 2 of 4 calls failing on `error sending request`. With the sync wait removed: 6.4 seconds, 0 failures.

**(2) `/tmp` in an ailoy sandbox does not survive between tool-call batches.** For OCI rootfs sandboxes, microsandbox auto-attaches a tmpfs at `/tmp` (`apply_runtime_defaults` in `microsandbox/lib/sandbox/config.rs`). That tmpfs lives in VM memory; the VM stops every time `RunEnvHandle::Drop` runs, and the tmpfs evaporates with it. Files an agent writes with `curl > /tmp/foo` disappear before the next tool call can read them. This is sandbox-only — `Local::stop` is a no-op.

**(3) `Machine::boot` and `Machine::shutdown` use different verbs than the microsandbox API they wrap.** microsandbox itself uses `start` / `stop` (`MsbSandbox::start_detached`, `MsbSandbox::stop_and_wait`, `SandboxHandle::stop`). The `boot` / `shutdown` vocabulary also reads to a language model as a full restart, which biases against the `/tmp`-persists-between-starts contract this PR establishes.

**(4) An ad-hoc `sync -f /` workaround sits in `Sandbox::stop_vm` to compensate for v0.4.6 agentd not flushing the rootfs before poweroff.** Once v0.5.0 lands (superradcompany/microsandbox#746), agentd does sync + clean poweroff itself, so the workaround becomes dead code.

## Changes

**Commit 1 — `fix(runenv): unblock caller thread in Drop handlers`** (`src/runenv/mod.rs`, `src/runenv/sandbox.rs`)

Two lines are commented out (kept as a record, not deleted):

```rust
// let _ = rx.recv_timeout(std::time::Duration::from_secs(30));
let _ = rx;
```

The background cleanup thread still does the actual cleanup (sync filesystem, stop VM, transition `RunEnvState` to `Idle`, remove the VM definition on `Sandbox` drop). The change is that the caller no longer waits for it synchronously.

Two existing tests in `src/runenv/sandbox.rs` (`test_stop_and_start`, `test_start_stop_idempotent`) assumed `drop(handle)` returned only after stop had completed. They now poll `vm_is_running` with a 30s deadline through a small `wait_until_stopped` helper, expressing the same intent without the race the immediate assert had against the (now async) stop.

`recv_timeout(30s)` never actually guaranteed cleanup completion: if cleanup took longer it returned anyway with no diagnostic. Replacing the asserts with bounded polling keeps the coverage of the intended behaviour ("the VM stops once the last handle is dropped") and removes the runtime stall.

**Commit 2 — `refactor(runenv): rename Machine::boot/shutdown to start/stop`** (`src/runenv/mod.rs`, `src/runenv/local.rs`, `src/agent/rt.rs`, `src/agent/builder.rs`)

`Machine::boot` → `Machine::start`, `Machine::shutdown` → `Machine::stop` (and the same on `MachineDyn`, the `Local` impl, the `RunEnv::get` / `RunEnvHandle::Drop` call sites). Doc comments and the `expect("runenv boot failed")` strings in agent tests are updated for consistency. No behaviour change.

**Commit 3 — `fix(sandbox): mount /tmp on a named volume by default + Machine rename`** (`src/runenv/sandbox.rs`)

Two changes in the sandbox `Machine` implementation:

1. `Sandbox::new` injects a per-sandbox named volume at `/tmp` by default. The escape-hatch branch in `apply_runtime_defaults` fires when `mounts` already contains a `/tmp` entry, so microsandbox stops attaching its tmpfs. Volume names are `ailoy-tmp-{sandbox_name}` so concurrent sandboxes stay isolated, and every provisioned volume carries the `ailoy.managed=true` label. A user-supplied `/tmp` mount in `SandboxConfig::volumes` takes precedence; the injection is skipped. Cleanup runs in `Sandbox::remove` (drop path) and `Sandbox::remove_persisted`. Volumes provisioned for a sandbox that fails to register are rolled back so a failed `Sandbox::new` does not leak.

   A startup sweep gated by a `tokio::sync::OnceCell` runs at most once per process. It lists volumes via `microsandbox::Volume::list()`, intersects with `MsbSandbox::list()`, and removes only volumes that carry the `ailoy.managed` label, match the `ailoy-tmp-` prefix, and have no live owner sandbox. Volumes without the label are left alone, so volumes from other tools (and from an in-flight `Sandbox::new` in a parallel process) are never touched.

2. `impl Machine for Sandbox` is renamed to match commit 2. The private helper `Sandbox::stop` is renamed to `stop_vm` so the trait method `stop` is free for the new vocabulary. `test_vm_definition_survives_machine_shutdown_with_persist_false` from #415 is renamed in lockstep.

`persist=true` semantics are preserved exactly as #415 defined them: `Machine::start`/`Machine::stop` cycles do not depend on `persist`, and the auto-injected `/tmp` volume is reused across `Sandbox::new` calls for the same name (the `VolumeAlreadyExists` from a second `Volume::create` is silently absorbed). Pre-existing `persist=true` sandboxes created before this change keep the microsandbox auto-tmpfs at `/tmp`; remove and recreate them to pick up the new default.

**Commit 4 — `chore(deps): bump microsandbox to v0.5.0, drop sync-flush workaround`** (`Cargo.toml`, `Cargo.lock`, `src/runenv/sandbox.rs`)

microsandbox v0.5.0 ships the upstream fix this commit depends on. The relevant upstream change is superradcompany/microsandbox#746 (`fix(sandbox): flush root-fs writes on stop`), which routes `SandboxHandle::stop` through agentd's own sync + clean poweroff. The explicit `sync -f /` we ran before `handle.stop()` is no longer needed; the workaround block inside `Sandbox::stop_vm` collapses to a single `handle.stop()` call (17 lines deleted) and the TODO comment that tracked the upstream fix is removed.

`Cargo.toml` switches to `tag = "v0.5.0"` so the dependency reads as a versioned release rather than an opaque commit hash. `microsandbox::setup::install` auto-downloads the v0.5.0 prebuilt on the first `Sandbox::new`.

## Test plan

|                                | sandbox module | notes |
| ---                            | ---            | --- |
| develop baseline (v0.4.6)      | 34 / 34        | pre-existing tests, no new ones |
| commits 1+2+3 on v0.4.6        | 38 / 38        | + 4 new regression tests added in commit 3 |
| commits 1+2+3+4 on v0.5.0      | 38 / 38        | same 4 + 34 against the v0.5.0 prebuilt |

Workspace-level `cargo test --workspace --all-features` outside the sandbox feature is unchanged from develop (OpenAI 429 quota failures from the local environment, unrelated to this PR).

Command: `cargo test --workspace --all-features --release` for the sandbox feature, run separately on v0.4.6 and v0.5.0 to confirm parity.

The four regression tests added in commit 3, running on v0.5.0:

```
test runenv::sandbox::tests::test_tmp_persists_across_starts ... ok
test runenv::sandbox::tests::test_user_tmpfs_overrides_default_tmp ... ok
test runenv::sandbox::tests::test_tmp_volume_removed_on_sandbox_drop ... ok
test runenv::sandbox::tests::test_startup_sweep_targets_only_labelled_orphans ... ok
```

Full sandbox test module on v0.5.0: 38 passed, 0 failed (23.56s).

## Measurement detail

Reproducer: a deep-research-style agent in `brekkylab/agent-k` issuing a 4-parallel `api_search` call inside a single `agent.run` turn, sandbox-backed, on `claude-opus-4-7`. A second probe writes `/tmp/probe` in tool call 1 and reads it in tool call 2 of the same `agent.run`.

| condition                                   | wall time            | reqwest fail | /tmp persists across calls |
| ---                                         | ---                  | ---          | ---                        |
| develop baseline                            | 97 - 99s             | 2 / 4        | no                         |
| commit 1 only (Drop unblock)                | 6.4s                 | 0 / 4        | no                         |
| sandbox.rs Drop wait removed only           | 99s (first at 35s)   | 1 / 4        | no                         |
| commits 1+2+3+4 (this PR head)              | ~6s                  | 0 / 4        | yes                        |

VM lifecycle is unchanged: the VM still stops between batches, and the agent still releases the VM during LLM inference. The `/tmp` data is what now survives, not the VM.

## Cross-reference

* `persist` semantics: PR #415 redefined `persist` as orthogonal to `Machine::start` / `Machine::stop`. This PR keeps that invariant intact — the auto-injected volume lifecycle keys off `Sandbox` drop, not off VM start/stop.
* microsandbox escape hatch: `apply_runtime_defaults` in `microsandbox/lib/sandbox/config.rs` returns early when `mounts` already contains `/tmp`. That is the contract commit 3 relies on.
* microsandbox upstream fix: superradcompany/microsandbox#746 (`fix(sandbox): flush root-fs writes on stop`), landed in v0.5.0. That is the contract commit 4 relies on.
* microsandbox volume API: `microsandbox::Volume::builder().label().create()`, `Volume::list()`, `Volume::remove()`, `VolumeHandle::labels()`.

## Known limitation

The startup sweep covers process abort and the `RunEnvHandle::Drop` race introduced by commit 1, but it cannot rescue a sandbox that was *mid-`Sandbox::new`* when a parallel process started its sweep. The `ailoy.managed` label keeps that case from clobbering other tools' volumes; a parallel ailoy process's in-flight volume is the residual race window.

Upstream fix in flight: superradcompany/microsandbox#801 adds `SandboxBuilder::auto_volume`, which provisions the volume and the sandbox in one DB transaction. Once that lands and we bump to the release that carries it, this PR's two-step `Volume::create` + `VolumeMount::Named` can collapse into a single builder call and the race window closes at the microsandbox layer. Until then, the pid + start-timestamp label mitigation stays a follow-up if it turns out to bite in practice.

## Trade-off

`/tmp` in an ailoy sandbox no longer matches POSIX `/tmp` semantics: it survives the start/stop cycle that `RunEnvHandle::Drop` drives. Callers who want strict POSIX semantics override `SandboxConfig::volumes` with their own `VolumeMount::Tmpfs { guest: "/tmp", .. }`. The named volume has no size cap (disk quota only) where the auto-tmpfs was clamped to `[1, 512]` MiB; volume removal is best-effort and covered by the startup sweep.
