### PR TITLE
chore(deps): bump microsandbox to v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3164,9 +3164,6 @@ name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "lru"
@@ -3300,8 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6611b7bf93b63777a11fe0b20b4ab5054106e1acedd515b17baaf35db305da40"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3347,8 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9189d47562fa2d3535c41d90f628889fdb2df97b5d6cda47d989f4bac8db9299"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3359,8 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd9bb1b8f24d18d0ee8b87bb69116aa980e28f46f9d21b95e828b6e8454fb22"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3372,8 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b630bf80e759c44cee3548f838fa1924a3b19602ee514852119110a94796736"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3397,8 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee41ba848ec0b748016de0ae699d38a4c7bd2f944e9bcf2547f49be9aa51549"
 dependencies = [
  "chrono",
  "libc",
@@ -3408,16 +3410,19 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea26dfddce6da6248f75ca73466f7703c5890585840b53437e69b8e447f70b9e"
 dependencies = [
  "sea-orm-migration",
+ "serde_json",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95022aa7fe1ecded9c680e1d52de80d66f3f9f48888fec829b05ead0d4a4623d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3454,8 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c830f6feb8ed866946651cea9d2f693103cec812fc8be47ff2ad089e81945f4"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3467,8 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84eadc5c5fc8d55f135ae718cd51c712817cea8ef54ae942c09318b596e33fb5"
 dependencies = [
  "bytes",
  "chrono",
@@ -3495,8 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f449293c7b6630dfccda66980000bd882a22369d9c2d885a7a808a68c323a7"
 dependencies = [
  "dirs",
  "libc",
@@ -3618,7 +3626,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.13.0",
+ "lru 0.18.0",
  "msb_krun_arch",
  "msb_krun_hvf",
  "msb_krun_polly",
@@ -4442,7 +4450,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4480,7 +4488,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"
 log = "0.4"
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.0", optional = true }
+microsandbox = { version = "0.5.2", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"


### PR DESCRIPTION
## Summary

Bumps the microsandbox git tag from `v0.5.0` to `v0.5.2`.

Notable upstream changes shipped between `v0.5.0` and `v0.5.2`:

- superradcompany/microsandbox#810 — `fix(upgrade): support 0.5 upgrade path for old sandboxes`. Pre-0.5 sandboxes left over on disk now get a graceful restart-required path instead of a handshake failure on `exec`.
- superradcompany/microsandbox#820 — `fix(runtime): support long sandbox names for agent sockets`. The agent relay socket is derived from a fixed-length hash under `~/.microsandbox/run/agent/` instead of `<sandboxes>/<name>/runtime/agent.sock`, so long sandbox names no longer break `SUN_LEN`.

The other 0.5.x deltas — agentd absorbed into the root workspace (superradcompany/microsandbox#804), SSH enabled in release binaries (superradcompany/microsandbox#812), DNS / network-policy fixes (superradcompany/microsandbox#824, #825), SDK doc links (superradcompany/microsandbox#811, #826) — are transparent at this layer.

## Dep form

The dependency moves to a crates.io version requirement, replacing the previous `git + tag` form used while the v0.5.0 publish was still pending. Every `microsandbox-*` member is on crates.io 0.5.2.

```diff
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.0", optional = true }
+microsandbox = { version = "0.5.2", optional = true }
```

`validate_sandbox_name`'s `SUN_PATH_MAX` check is left as-is.

## Verification

The local `~/.microsandbox/{bin,lib}` caches were wiped, then the v0.5.2 prebuilt was cold-pathed through `microsandbox::setup::install` on the first `Sandbox::new`. The full sandbox test module was then run.

```
cargo test --release --all-features runenv::sandbox::tests -- --test-threads=1
...
test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 269 filtered out; finished in 21.33s
```

The 38 tests include the four regression tests added in #416 (`test_tmp_persists_across_starts`, `test_user_tmpfs_overrides_default_tmp`, `test_tmp_volume_removed_on_sandbox_drop`, `test_startup_sweep_targets_only_labelled_orphans`) plus the 34 pre-existing sandbox-feature tests.

`cargo check --all-features` also passes.

## Cross-reference

- superradcompany/microsandbox v0.5.1 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.1
- superradcompany/microsandbox v0.5.2 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.2
- The pending upstream PR for race-free per-sandbox auto-volumes (superradcompany/microsandbox#801) is unaffected by this bump and remains open against `main`.

