### PR TITLE
feat(lang_model): per-call thinking toggle for Moonshot kimi-k2

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -174,6 +174,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn thinking(mut self, mode: crate::lang_model::ThinkingMode) -> Self {
+        self.spec = self.spec.thinking(mode);
+        self
+    }
+
     /// Append a single pre-fill [`FileEntry`] to `spec.files`.  The file is
     /// written into the runenv on the agent's first `run`.
     pub fn file(mut self, entry: FileEntry) -> Self {

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -218,6 +218,13 @@ impl AgentSpec {
         self
     }
 
+    pub fn thinking(mut self, mode: crate::lang_model::ThinkingMode) -> Self {
+        self.model_options
+            .get_or_insert_with(LangModelOptions::new)
+            .thinking = Some(mode);
+        self
+    }
+
     pub fn file(mut self, file: FileEntry) -> Self {
         self.files.push(file);
         self

--- a/src/lang_model/impl/api/anthropic.rs
+++ b/src/lang_model/impl/api/anthropic.rs
@@ -434,6 +434,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            thinking: None,
         };
         f(&req)
     }
@@ -655,6 +656,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            thinking: None,
         };
         let val = AnthropicMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -52,6 +52,12 @@ impl LangModelProvider {
     }
 }
 
+/// Moonshot kimi-k2.5 / kimi-k2.6 accept a `thinking` toggle in the request
+/// body. Other ChatCompletion-schema vendors (OpenAI, x.ai, DeepSeek) ignore it.
+fn is_moonshot_thinking_model(model: &str) -> bool {
+    model.starts_with("kimi-k2.5") || model.starts_with("kimi-k2.6")
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct ChatCompletionMarshal;
 
@@ -233,6 +239,18 @@ impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
                 .insert("top_p".to_owned(), top_p.into());
         }
         // top_k is not part of the OpenAI ChatCompletion spec; intentionally ignored.
+        if let Some(mode) = req.thinking
+            && is_moonshot_thinking_model(req.model)
+        {
+            let s = match mode {
+                crate::lang_model::ThinkingMode::Enabled => "enabled",
+                crate::lang_model::ThinkingMode::Disabled => "disabled",
+            };
+            body.as_object_mut().unwrap().insert(
+                "thinking".into(),
+                to_value!({ "type": s }),
+            );
+        }
         if let Some(ResponseFormat::JsonSchema(schema)) = req.response_format {
             let wire_schema = self.marshal_response_schema(schema);
             body.as_object_mut().unwrap().insert(
@@ -444,6 +462,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            thinking: None,
         };
         f(&req)
     }
@@ -485,6 +504,90 @@ mod tests {
         });
     }
 
+    fn with_req_thinking<F, R>(
+        model: &str,
+        thinking: Option<crate::lang_model::ThinkingMode>,
+        f: F,
+    ) -> R
+    where
+        F: FnOnce(&LangModelRequest<'_>) -> R,
+    {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![];
+        let url = Url::parse("https://api.moonshot.ai/v1/chat/completions").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model,
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            response_format: None,
+            thinking,
+        };
+        f(&req)
+    }
+
+    #[test]
+    fn test_marshal_thinking_kimi_disabled() {
+        with_req_thinking(
+            "kimi-k2.6",
+            Some(crate::lang_model::ThinkingMode::Disabled),
+            |req| {
+                let val = ChatCompletionMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let thinking = body.as_object().unwrap().get("thinking").unwrap();
+                assert_eq!(
+                    thinking.as_object().unwrap().get("type").unwrap().as_str().unwrap(),
+                    "disabled"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_marshal_thinking_kimi_enabled() {
+        with_req_thinking(
+            "kimi-k2.5",
+            Some(crate::lang_model::ThinkingMode::Enabled),
+            |req| {
+                let val = ChatCompletionMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                let thinking = body.as_object().unwrap().get("thinking").unwrap();
+                assert_eq!(
+                    thinking.as_object().unwrap().get("type").unwrap().as_str().unwrap(),
+                    "enabled"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_marshal_thinking_ignored_on_other_models() {
+        with_req_thinking(
+            "gpt-4.1-mini",
+            Some(crate::lang_model::ThinkingMode::Disabled),
+            |req| {
+                let val = ChatCompletionMarshal::default().marshal(req);
+                let body = val.as_object().unwrap().get("body").unwrap();
+                assert!(body.as_object().unwrap().get("thinking").is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn test_marshal_thinking_absent_when_none() {
+        with_req_thinking("kimi-k2.6", None, |req| {
+            let val = ChatCompletionMarshal::default().marshal(req);
+            let body = val.as_object().unwrap().get("body").unwrap();
+            assert!(body.as_object().unwrap().get("thinking").is_none());
+        });
+    }
+
     #[test]
     fn test_marshal_response_format_json_schema() {
         let schema = to_value!({"type": "object", "properties": {"score": {"type": "integer"}}});
@@ -504,6 +607,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            thinking: None,
         };
         let val = ChatCompletionMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -509,6 +509,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            thinking: None,
         };
         f(&req)
     }
@@ -718,6 +719,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            thinking: None,
         };
         let val = GeminiMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/openai.rs
+++ b/src/lang_model/impl/api/openai.rs
@@ -443,6 +443,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            thinking: None,
         };
         f(&req)
     }
@@ -484,6 +485,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            thinking: None,
         };
 
         let val = OpenAIMarshal::default().marshal(&req);

--- a/src/lang_model/options.rs
+++ b/src/lang_model/options.rs
@@ -1,6 +1,15 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Toggle a provider's reasoning step where the API exposes one.
+/// Honoured by Moonshot kimi-k2.5/k2.6; other providers ignore it.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingMode {
+    Enabled,
+    Disabled,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct LangModelOptions {
     /// Maximum number of tokens the model may generate in a single response.
@@ -38,6 +47,10 @@ pub struct LangModelOptions {
     /// Constrains the model's output to a JSON schema validated at construction time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<super::ResponseFormat>,
+
+    /// Per-provider reasoning toggle. See [`ThinkingMode`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingMode>,
 }
 
 impl LangModelOptions {

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -4,7 +4,7 @@ use url::Url;
 use super::{LangModelAPISchema, LangModelProviderElem};
 use crate::{
     datatype::Value,
-    lang_model::{LangModelOptions, r#impl::api},
+    lang_model::{LangModelOptions, ThinkingMode, r#impl::api},
     message::{Delta as _, Marshaled, Message, MessageOutput, Unmarshal as _},
     tool::ToolDesc,
 };
@@ -70,6 +70,7 @@ pub(crate) struct LangModelRequest<'a> {
     pub top_p: Option<f64>,
     pub top_k: Option<u64>,
     pub response_format: Option<&'a ResponseFormat>,
+    pub thinking: Option<ThinkingMode>,
 }
 
 impl LangModel {
@@ -105,6 +106,7 @@ impl LangModel {
                     top_p: options.top_p,
                     top_k: options.top_k,
                     response_format: options.response_format.as_ref(),
+                    thinking: options.thinking,
                 };
 
                 let req = match schema {


### PR DESCRIPTION
## Summary

Adds a `thinking` option on `LangModelOptions` that the ChatCompletion marshal forwards as Moonshot's `\"thinking\": {\"type\": \"enabled\" | \"disabled\"}` request-body field. Today `kimi-k2.5` and `kimi-k2.6` default to thinking-enabled and emit responses where every streamed delta carries `reasoning_content` and `content` is left empty until reasoning finishes. Callers that just want a short answer (e.g. ReAct tool-call decisions on small queries) have no way through ailoy to flip that off; this PR adds one.

## Changes

`src/lang_model/options.rs`: new `ThinkingMode { Enabled, Disabled }` enum and a `thinking: Option<ThinkingMode>` field on `LangModelOptions`, following the same `Option` + `skip_serializing_if` pattern as the existing `max_tokens` / `temperature` / `top_p` / `top_k` / `response_format` fields.

`src/lang_model/rt.rs`: `LangModelRequest` carries the new option; `LangModel::run` forwards `options.thinking` into it next to the other model options.

`src/lang_model/impl/api/chat_completion.rs`: new private helper `is_moonshot_thinking_model(model: &str) -> bool` matching `kimi-k2.5` and `kimi-k2.6` (mirrors `is_openai_reasoning_model`). The marshal inserts `\"thinking\": {\"type\": ...}` into the request body only when both the option is set and the model passes that check. Other ChatCompletion-schema vendors (OpenAI, x.ai, DeepSeek) silently drop the field, matching how `temperature` / `top_p` are already dropped on OpenAI reasoning models.

`src/agent/spec.rs`, `src/agent/builder.rs`: new fluent setters `AgentSpec::thinking(mode)` and `AgentBuilder::thinking(mode)`, parallel to the existing `temperature` / `top_p` / `response_format` setters.

The four marshals (`chat_completion`, `openai`, `anthropic`, `gemini`) all construct `LangModelRequest` literals in test fixtures, so each gets `thinking: None` added to keep the struct literal exhaustive. No behaviour change in the latter three.

## Tests

`src/lang_model/impl/api/chat_completion.rs` adds four unit tests:

- `test_marshal_thinking_kimi_disabled`: `kimi-k2.6` + `Disabled` produces `\"thinking\": {\"type\": \"disabled\"}` in the wire body.
- `test_marshal_thinking_kimi_enabled`: `kimi-k2.5` + `Enabled` produces `\"thinking\": {\"type\": \"enabled\"}`.
- `test_marshal_thinking_ignored_on_other_models`: `gpt-4.1-mini` + `Disabled` produces no `thinking` field in the wire body.
- `test_marshal_thinking_absent_when_none`: `kimi-k2.6` with `thinking: None` produces no `thinking` field.

Full result on a clean develop tip:

\`\`\`
cargo test --features sandbox --lib lang_model
test result: ok. 54 passed; 0 failed; 5 ignored; 0 measured; 281 filtered out; finished in 2.51s
\`\`\`

The 5 ignored tests are the pre-existing `test_run_*` integration tests that require provider env keys.

## Motivation, observed behaviour

Direct streaming probe against `https://api.moonshot.ai/v1/chat/completions` for `kimi-k2.6` with `\"Say hi in 3 words\"` and `max_tokens: 50` emits 48 streamed chunks, every one of which is a `reasoning_content` delta; the model never reaches the `content` field within that budget. The same prompt with `\"thinking\": {\"type\": \"disabled\"}` in the body returns `\"Hello there, friend!\"` in 1.07s, with `content` populated and no `reasoning_content`. In a ReAct loop over a multi-turn agent (`Agent::run` with corpus tools), the thinking-on flavour amplifies into roughly 60-130s per turn before the first `tool_call` is emitted; flipping the toggle off brings it into the same range as the other small light-tier models.

## Trade-off

This PR keeps Moonshot's default behaviour (thinking enabled). Callers must opt out explicitly via `LangModelOptions { thinking: Some(ThinkingMode::Disabled), ... }` or `AgentSpec::thinking(ThinkingMode::Disabled)`. The `is_moonshot_thinking_model` helper is intentionally narrow (the two literal model prefixes) so future Moonshot models, or vendors that adopt the same shape, get an explicit decision rather than silent capture.