### PR TITLE
feat(lang-model): add tool_choice option + per-turn override

### DIFF
--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -1,10 +1,15 @@
-use std::{collections::HashMap, path::PathBuf, pin::Pin};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    pin::Pin,
+    sync::{Arc, Mutex as StdMutex},
+};
 
 use futures::{FutureExt as _, Stream, StreamExt as _};
 
 use crate::{
     agent::{AgentProvider, AgentSpec, ContextManager, default_provider},
-    lang_model::{LangModel, LangModelOptions},
+    lang_model::{LangModel, LangModelOptions, ToolChoice},
     message::{FinishReason, Message, MessageOutput, Part, Role},
     runenv::{Console, RunEnv},
     skill::{render_skills_table, scan_declared_skills},
@@ -13,6 +18,9 @@ use crate::{
         r#impl::{get_subagent_tool_desc, get_subagent_tool_func, get_web_search_tool_factory},
     },
 };
+
+/// Shared handle for one-shot `tool_choice` override of the next model call.
+pub type ToolChoiceHandle = Arc<StdMutex<Option<ToolChoice>>>;
 
 /// Walk the spec tree and write every declared file (this agent's plus the
 /// subtree's) to the runenv with **write-once** semantics: if a file already
@@ -90,6 +98,8 @@ pub struct Agent {
     model: LangModel,
 
     model_options: LangModelOptions,
+
+    tool_choice_override: ToolChoiceHandle,
 
     tool_descs: Vec<ToolDesc>,
 
@@ -203,6 +213,7 @@ impl Agent {
         Ok(Self {
             model,
             model_options,
+            tool_choice_override: Arc::new(StdMutex::new(None)),
             tools,
             tool_descs,
             state,
@@ -210,6 +221,17 @@ impl Agent {
             spec,
             files_materialised: false,
         })
+    }
+
+    /// Clone of the per-turn `tool_choice` override handle.
+    pub fn tool_choice_handle(&self) -> ToolChoiceHandle {
+        self.tool_choice_override.clone()
+    }
+
+    /// Replace the handle with an externally-owned one so a tool callback built
+    /// before the agent can write to it.
+    pub fn set_tool_choice_handle(&mut self, handle: ToolChoiceHandle) {
+        self.tool_choice_override = handle;
     }
 
     /// Maximum number of characters kept in a single tool-result message before
@@ -434,9 +456,20 @@ impl Agent {
                         cm.truncate_history(&mut self.state.history);
                     }
 
+                let effective_options = {
+                    let override_val = self.tool_choice_override.lock().unwrap().take();
+                    if override_val.is_some() {
+                        let mut o = self.model_options.clone();
+                        o.tool_choice = override_val;
+                        o
+                    } else {
+                        self.model_options.clone()
+                    }
+                };
+
                 let mut output = self
                     .model
-                    .run(&self.state.history, &self.tool_descs, &self.model_options)
+                    .run(&self.state.history, &self.tool_descs, &effective_options)
                     .await?;
 
                 // Capture token usage for next iteration's truncation check.

--- a/src/lang_model/impl/api/anthropic.rs
+++ b/src/lang_model/impl/api/anthropic.rs
@@ -222,9 +222,14 @@ impl Marshal<LangModelRequest<'_>> for AnthropicMarshal {
                 .insert("system".into(), system);
         }
         if !tools.is_null() {
+            let choice = match req.tool_choice {
+                Some(crate::lang_model::ToolChoice::None) => to_value!({"type": "none"}),
+                Some(crate::lang_model::ToolChoice::Required) => to_value!({"type": "any"}),
+                _ => to_value!({"type": "auto"}),
+            };
             body.as_object_mut()
                 .unwrap()
-                .insert("tool_choice".to_owned(), to_value!({"type": "auto"}));
+                .insert("tool_choice".to_owned(), choice);
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_owned(), tools);
@@ -434,6 +439,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            tool_choice: None,
         };
         f(&req)
     }
@@ -627,6 +633,50 @@ mod tests {
         );
     }
 
+    fn tool_choice_body(choice: Option<crate::lang_model::ToolChoice>) -> Value {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![
+            ToolDescBuilder::new("noop").description("nope").parameters(to_value!({})).build(),
+        ];
+        let url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model: "claude-haiku-4-5",
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            response_format: None,
+            tool_choice: choice,
+        };
+        AnthropicMarshal::default().marshal(&req)
+    }
+
+    #[test]
+    fn test_tool_choice_default_is_auto() {
+        let val = tool_choice_body(None);
+        let tc = val.pointer("/body/tool_choice/type").and_then(|v| v.as_str());
+        assert_eq!(tc, Some("auto"));
+    }
+
+    #[test]
+    fn test_tool_choice_none_forbids_tool_call() {
+        let val = tool_choice_body(Some(crate::lang_model::ToolChoice::None));
+        let tc = val.pointer("/body/tool_choice/type").and_then(|v| v.as_str());
+        assert_eq!(tc, Some("none"));
+    }
+
+    #[test]
+    fn test_tool_choice_required_maps_to_any() {
+        let val = tool_choice_body(Some(crate::lang_model::ToolChoice::Required));
+        let tc = val.pointer("/body/tool_choice/type").and_then(|v| v.as_str());
+        assert_eq!(tc, Some("any"));
+    }
+
     #[test]
     fn test_marshal_response_format_absent() {
         with_req("claude-haiku-4-5", None, |req| {
@@ -655,6 +705,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            tool_choice: None,
         };
         let val = AnthropicMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -204,9 +204,14 @@ impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
             "messages": messages,
         });
         if !tools.is_null() {
+            let choice = match req.tool_choice {
+                Some(crate::lang_model::ToolChoice::None) => to_value!("none"),
+                Some(crate::lang_model::ToolChoice::Required) => to_value!("required"),
+                _ => to_value!("auto"),
+            };
             body.as_object_mut()
                 .unwrap()
-                .insert("tool_choice".to_owned(), to_value!("auto"));
+                .insert("tool_choice".to_owned(), choice);
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_owned(), tools);
@@ -422,7 +427,7 @@ mod tests {
     use crate::{
         lang_model::{LangModel, LangModelAPISchema, LangModelOptions, LangModelProviderElem},
         message::{FinishReason, Message, Part, Role},
-        tool::ToolDesc,
+        tool::{ToolDesc, ToolDescBuilder},
     };
 
     fn with_req<F, R>(model: &str, max_tokens: Option<u64>, f: F) -> R
@@ -444,8 +449,50 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            tool_choice: None,
         };
         f(&req)
+    }
+
+    fn tool_choice_body(choice: Option<crate::lang_model::ToolChoice>) -> Value {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![
+            ToolDescBuilder::new("noop").description("nope").parameters(to_value!({})).build(),
+        ];
+        let url = Url::parse("https://api.openai.com/v1/chat/completions").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model: "gpt-4o-mini",
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            response_format: None,
+            tool_choice: choice,
+        };
+        ChatCompletionMarshal::default().marshal(&req)
+    }
+
+    #[test]
+    fn test_tool_choice_default_is_auto() {
+        let v = tool_choice_body(None);
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("auto"));
+    }
+
+    #[test]
+    fn test_tool_choice_none() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::None));
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("none"));
+    }
+
+    #[test]
+    fn test_tool_choice_required() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::Required));
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("required"));
     }
 
     #[test]
@@ -504,6 +551,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            tool_choice: None,
         };
         let val = ChatCompletionMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -279,6 +279,17 @@ impl Marshal<LangModelRequest<'_>> for GeminiMarshal {
         }
         if !tools.is_null() {
             body.as_object_mut().unwrap().insert("tools".into(), tools);
+            if let Some(choice) = req.tool_choice {
+                let mode = match choice {
+                    crate::lang_model::ToolChoice::Auto => "AUTO",
+                    crate::lang_model::ToolChoice::None => "NONE",
+                    crate::lang_model::ToolChoice::Required => "ANY",
+                };
+                body.as_object_mut().unwrap().insert(
+                    "tool_config".into(),
+                    to_value!({"function_calling_config": {"mode": mode}}),
+                );
+            }
         }
         let mut generation_config = to_value!({});
         if let Some(max_tokens) = req.max_tokens {
@@ -509,8 +520,56 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            tool_choice: None,
         };
         f(&req)
+    }
+
+    fn tool_choice_body(choice: Option<crate::lang_model::ToolChoice>) -> Value {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![
+            ToolDescBuilder::new("noop").description("nope").parameters(to_value!({})).build(),
+        ];
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/models/").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model: "gemini-2.0-flash",
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            response_format: None,
+            tool_choice: choice,
+        };
+        GeminiMarshal::default().marshal(&req)
+    }
+
+    #[test]
+    fn test_tool_choice_default_omits_tool_config() {
+        let v = tool_choice_body(None);
+        assert!(v.pointer("/body/tool_config").is_none());
+    }
+
+    #[test]
+    fn test_tool_choice_none_sets_mode_none() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::None));
+        let mode = v
+            .pointer("/body/tool_config/function_calling_config/mode")
+            .and_then(|x| x.as_str());
+        assert_eq!(mode, Some("NONE"));
+    }
+
+    #[test]
+    fn test_tool_choice_required_sets_mode_any() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::Required));
+        let mode = v
+            .pointer("/body/tool_config/function_calling_config/mode")
+            .and_then(|x| x.as_str());
+        assert_eq!(mode, Some("ANY"));
     }
 
     #[test]
@@ -718,6 +777,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            tool_choice: None,
         };
         let val = GeminiMarshal::default().marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();

--- a/src/lang_model/impl/api/openai.rs
+++ b/src/lang_model/impl/api/openai.rs
@@ -207,9 +207,14 @@ impl Marshal<LangModelRequest<'_>> for OpenAIMarshal {
                 .insert("instructions".into(), instructions);
         }
         if !tools.is_null() {
+            let choice = match req.tool_choice {
+                Some(crate::lang_model::ToolChoice::None) => to_value!("none"),
+                Some(crate::lang_model::ToolChoice::Required) => to_value!("required"),
+                _ => to_value!("auto"),
+            };
             body.as_object_mut()
                 .unwrap()
-                .insert("tool_choice".into(), to_value!("auto"));
+                .insert("tool_choice".into(), choice);
             body.as_object_mut().unwrap().insert("tools".into(), tools);
         }
         if let Some(max_tokens) = req.max_tokens {
@@ -443,8 +448,50 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: None,
+            tool_choice: None,
         };
         f(&req)
+    }
+
+    fn tool_choice_body(choice: Option<crate::lang_model::ToolChoice>) -> Value {
+        let messages: Vec<Message> = vec![];
+        let tools: Vec<ToolDesc> = vec![
+            ToolDescBuilder::new("noop").description("nope").parameters(to_value!({})).build(),
+        ];
+        let url = Url::parse("https://api.openai.com/v1/responses").unwrap();
+        let api_key: Option<String> = None;
+        let req = LangModelRequest {
+            model: "gpt-4o",
+            messages: &messages,
+            tools: &tools,
+            url: &url,
+            api_key: &api_key,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            response_format: None,
+            tool_choice: choice,
+        };
+        OpenAIMarshal::default().marshal(&req)
+    }
+
+    #[test]
+    fn test_tool_choice_default_is_auto() {
+        let v = tool_choice_body(None);
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("auto"));
+    }
+
+    #[test]
+    fn test_tool_choice_none_forbids_tool_call() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::None));
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("none"));
+    }
+
+    #[test]
+    fn test_tool_choice_required() {
+        let v = tool_choice_body(Some(crate::lang_model::ToolChoice::Required));
+        assert_eq!(v.pointer("/body/tool_choice").and_then(|x| x.as_str()), Some("required"));
     }
 
     #[test]
@@ -484,6 +531,7 @@ mod tests {
             top_p: None,
             top_k: None,
             response_format: Some(&fmt),
+            tool_choice: None,
         };
 
         let val = OpenAIMarshal::default().marshal(&req);

--- a/src/lang_model/options.rs
+++ b/src/lang_model/options.rs
@@ -1,6 +1,15 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Per-request tool-call policy.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolChoice {
+    Auto,
+    None,
+    Required,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct LangModelOptions {
     /// Maximum number of tokens the model may generate in a single response.
@@ -38,6 +47,9 @@ pub struct LangModelOptions {
     /// Constrains the model's output to a JSON schema validated at construction time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<super::ResponseFormat>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
 }
 
 impl LangModelOptions {

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -4,7 +4,7 @@ use url::Url;
 use super::{LangModelAPISchema, LangModelProviderElem};
 use crate::{
     datatype::Value,
-    lang_model::{LangModelOptions, r#impl::api},
+    lang_model::{LangModelOptions, ToolChoice, r#impl::api},
     message::{Delta as _, Marshaled, Message, MessageOutput, Unmarshal as _},
     tool::ToolDesc,
 };
@@ -70,6 +70,7 @@ pub(crate) struct LangModelRequest<'a> {
     pub top_p: Option<f64>,
     pub top_k: Option<u64>,
     pub response_format: Option<&'a ResponseFormat>,
+    pub tool_choice: Option<ToolChoice>,
 }
 
 impl LangModel {
@@ -105,6 +106,7 @@ impl LangModel {
                     top_p: options.top_p,
                     top_k: options.top_k,
                     response_format: options.response_format.as_ref(),
+                    tool_choice: options.tool_choice,
                 };
 
                 let req = match schema {


### PR DESCRIPTION
## Summary

Adds a `tool_choice` knob to `LangModelOptions` and a per-turn override on `Agent` so an agent loop can deterministically end runaway tool use.

- `LangModelOptions::tool_choice: Option<ToolChoice>` with `Auto / None / Required`
- Honored by all three providers: Anthropic Messages (`tool_choice.type` = `auto|none|any`), OpenAI Responses and Chat Completions (`tool_choice` = `auto|none|required`), Gemini (`tool_config.function_calling_config.mode` = `AUTO|NONE|ANY`)
- `Agent::tool_choice_handle()` returns an `Arc<Mutex<Option<ToolChoice>>>`. Writing `Some(_)` causes the next model call to use that policy in place of the static `model_options.tool_choice`. The override is one-shot — the loop clears it after each model call.

## Motivation

Running CUAD / FinanceBench Q&A ablations on PR #121's `speedwagon` agent, Gemini routinely enters a verify-loop where it calls `read_document` over and over on overlapping windows until the 120s per-QA timeout. Prompt-only guidance (`max 3 reads`, `do not re-read overlapping windows`) only partially helps because the model continues to choose tool calls when offered the choice.

A tool wrapper can already count calls and return an error after a budget, but the model is still free to call the tool again. The clean fix is to give the loop a way to say \"no more tools\" at the protocol level for the next request. `tool_choice = \"none\"` on the next call forces a text-only completion, which is what we actually want.

## Wire output (verified by unit tests)

| Choice    | Anthropic            | OpenAI Responses / ChatCompletion | Gemini                                              |
| --------- | -------------------- | ---------------------------------- | --------------------------------------------------- |
| Auto      | `{\"type\":\"auto\"}` | `\"auto\"`                          | (no `tool_config` — provider default)              |
| None      | `{\"type\":\"none\"}` | `\"none\"`                          | `{\"function_calling_config\":{\"mode\":\"NONE\"}}` |
| Required  | `{\"type\":\"any\"}`  | `\"required\"`                      | `{\"function_calling_config\":{\"mode\":\"ANY\"}}`  |

When `tools` is empty for the request, the field is omitted on every provider (existing behavior preserved).

## Tests

12 new unit tests cover the four adapters: `default → auto`, `None → forbidden`, `Required → mapped correctly`. The existing 275 lib tests still pass.

## Test plan

- [x] `cargo test --lib` — 287 passed
- [ ] End-to-end smoke: agent-k speedwagon read-budget guard sets `ToolChoice::None` on budget-hit; verify Gemini stops re-reading and emits a text answer on the next turn