### PR TITLE
fix(lang_model/gemini): default missing content.role to Assistant

### DIFF
--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -398,7 +398,7 @@ fn parse_candidate_content(candidate: &Value) -> anyhow::Result<MessageDelta> {
         .pointer("/content")
         .ok_or_else(|| anyhow::anyhow!("Missing content in candidate"))?;
 
-    // Parse role
+    // Gemini occasionally omits `content.role`; candidates are always model output.
     if let Some(r) = content.pointer("/role") {
         let s = r
             .as_str()
@@ -412,6 +412,8 @@ fn parse_candidate_content(candidate: &Value) -> anyhow::Result<MessageDelta> {
             other => bail!("Unknown role: {other}"),
         };
         rv.role = Some(v);
+    } else {
+        rv.role = Some(Role::Assistant);
     }
 
     // Parse parts
@@ -486,7 +488,7 @@ mod tests {
     use crate::{
         datatype::{Bytes, Value},
         lang_model::{LangModel, LangModelAPISchema, LangModelOptions, LangModelProviderElem},
-        message::{FinishReason, Message, Part, Role, TokenUsage},
+        message::{Delta, FinishReason, Message, Part, Role, TokenUsage},
         tool::{ToolDesc, ToolDescBuilder},
     };
 
@@ -538,6 +540,21 @@ mod tests {
                 cache_read_input_tokens: None,
             })
         );
+    }
+
+    /// Missing `content.role` defaults to Assistant instead of bailing.
+    #[test]
+    fn test_unmarshal_missing_content_role_defaults_to_assistant() {
+        let response = to_value!({
+            "candidates": [{
+                "content": {"parts": [{"text": "Hello from Gemini."}]},
+                "finishReason": "STOP"
+            }]
+        });
+        let out = GeminiUnmarshal::default().unmarshal(response).unwrap();
+        assert_eq!(out.delta.role, Some(Role::Assistant));
+        let msg = out.delta.finish().expect("finish() must not bail");
+        assert_eq!(msg.role, Role::Assistant);
     }
 
     /// Verifies functionResponse.response.result marshaling for all Part variants.


### PR DESCRIPTION
## Summary

Closes #425.

The Gemini adapter occasionally received a candidate whose `content.parts` is populated but `content.role` is omitted (observed on `gemini-2.5-flash` near `finishReason: STOP` in multi-turn tool-use). `parse_candidate_content` had no `else` branch, leaving `MessageDelta.role` as `None`, so `MessageDelta::finish()` then bailed with `"Role not specified"` and aborted the agent loop mid-conversation, discarding otherwise-valid partial output.

`candidate.content` of a `generateContent` response is by spec always model output, so when `content.role` is absent we now default to `Role::Assistant` instead of leaving the field unset.

## Changes

- `src/lang_model/impl/api/gemini.rs`: add an `else` branch in `parse_candidate_content` to set `rv.role = Some(Role::Assistant)` when `content.role` is missing.
- Regression test `test_unmarshal_missing_content_role_defaults_to_assistant`: feeds the exact sanitized sample from the issue, asserts `delta.role == Some(Assistant)` and that `finish()` returns `Ok` rather than bailing.

## Test plan

- [x] `cargo test --lib --no-default-features 'lang_model::r#impl::api::gemini::tests::'` — 8 passed, 2 ignored (API-key gated).
- [x] Same with `-- --include-ignored` and `GEMINI_API_KEY` set — 10 passed, including the live `test_run_max_tokens` and `test_run_response_format_json_schema`.