### PR TITLE
feat(spec): add shell_tool() single-tool builder

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -105,6 +105,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn shell_tool(mut self) -> Self {
+        self.spec = self.spec.shell_tool();
+        self
+    }
+
     pub fn web_search_tool(mut self, engines: Vec<WebSearchEngineKind>) -> Self {
         self.spec = self.spec.web_search_tool(engines);
         self

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -145,6 +145,12 @@ impl AgentSpec {
         self
     }
 
+    /// Append only the `shell` tool, without the other `system_tools` entries.
+    pub fn shell_tool(mut self) -> Self {
+        self.tools.push(get_shell_tool_desc());
+        self
+    }
+
     /// Add the `web_search` tool to the spec.
     ///
     /// Pass a non-empty `engines` vec to restrict which engines are used;


### PR DESCRIPTION
Adds `AgentSpec::shell_tool()` and `AgentBuilder::shell_tool()`, mirroring the existing `python_repl_tool()` and `web_search_tool()` single-tool builders. It appends only the `shell` ToolDesc, without the rest of the `system_tools()` bundle (read/write/edit/glob/grep).

The motivation is callers that want shell on top of a custom tool set, not the full system bundle. `get_shell_tool_desc` is `pub(crate)`, so until now the only way to get a shell tool from an external crate was either `system_tools()` (which drags in five more tools) or hand-rolling a `ToolDesc` named `"shell"` to match the builtin factory key. This builder exposes the canonical desc directly.

Example:

```rust
let spec = AgentSpec::new("openai/gpt-5.4-mini")
    .instruction(prompt)
    .tools([/* custom tools */])
    .shell_tool();
```

`cargo check --features sandbox` passes.