### PR TITLE
fix(web_fetch): switch to wreq Firefox emulation to bypass TLS bot detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ unicode-segmentation = "1.12.0"
 url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1"
 uuid = { version = "1.18.0", features = ["v4"] }
-wreq = "5.3.0"
+wreq = { version = "5.3.0", features = ["stream"] }
 wreq-util = "2.2.6"
 
 [dev-dependencies]

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -31,6 +31,7 @@ impl WebFetchState {
     fn new() -> Self {
         let client = Client::builder()
             .emulation(Emulation::Firefox135)
+            .redirect(wreq::redirect::Policy::limited(10))
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .expect("wreq::Client builder cannot fail with these settings");

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -4,8 +4,9 @@ use std::time::{Duration, Instant};
 
 use html_to_markdown_rs::{ConversionOptions, OutputFormat};
 use parking_lot::Mutex;
-use reqwest::Client;
 use url::Url;
+use wreq::Client;
+use wreq_util::Emulation;
 
 use crate::{
     datatype::Value,
@@ -19,8 +20,6 @@ const MAX_DOWNLOAD_BYTES: usize = 2 * 1024 * 1024;
 const MAX_URL_CHARS: usize = 2048;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 const PER_HOST_MIN_INTERVAL: Duration = Duration::from_millis(1000);
-const USER_AGENT: &str =
-    "Mozilla/5.0 (compatible; ailoy/web_fetch; +https://github.com/brekkylab/ailoy)";
 
 #[derive(Clone)]
 struct WebFetchState {
@@ -31,10 +30,10 @@ struct WebFetchState {
 impl WebFetchState {
     fn new() -> Self {
         let client = Client::builder()
-            .user_agent(USER_AGENT)
+            .emulation(Emulation::Firefox135)
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
-            .expect("reqwest::Client builder cannot fail with these settings");
+            .expect("wreq::Client builder cannot fail with these settings");
         Self {
             client,
             last_hit: Arc::new(Mutex::new(HashMap::new())),
@@ -76,7 +75,7 @@ async fn download(
     let final_url = resp.url().to_string();
     let content_type = resp
         .headers()
-        .get(reqwest::header::CONTENT_TYPE)
+        .get(wreq::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
@@ -531,7 +530,8 @@ mod tests {
         let state = WebFetchState::new();
         let result = fetch_one(
             state,
-            "https://example.com/".to_string(),
+            "https://www.accuweather.com/ko/kr/bundang-gu/2330398/current-weather/2330398"
+                .to_string(),
             0,
             DEFAULT_BODY_CHARS,
             BodyFormat::Text,
@@ -551,8 +551,8 @@ mod tests {
             .unwrap_or("");
         assert_eq!(status, 200, "result: {result:?}");
         assert!(
-            body.to_ascii_lowercase().contains("example domain"),
-            "body should mention `Example Domain`, got first 200 chars: {:?}",
+            body.to_ascii_lowercase().contains("accuweather") || body.contains("분당구"),
+            "body should mention AccuWeather or 분당구, got first 200 chars: {:?}",
             &body.chars().take(200).collect::<String>()
         );
         assert!(retrieved_at.ends_with('Z'), "retrieved_at: {retrieved_at}");


### PR DESCRIPTION
## Summary

- Replace `reqwest::Client` with `wreq::Client` using `Emulation::Firefox135` in `web_fetch`
- Add `stream` feature to `wreq` dependency to enable `bytes_stream()` support
- Update network integration test URL to AccuWeather and fix the corresponding body assertion

## Background

The `reqwest` crate's `rustls` backend produces a distinctive TLS ClientHello fingerprint that Akamai and similar WAFs detect and block at the handshake level — before any HTTP-layer headers are even inspected. This caused `web_fetch` to fail with a transport-level error (`HTTP/2 INTERNAL_ERROR` or `ECONNRESET`) on sites protected by Akamai, even when using a browser-like User-Agent string.

The `web_search` Bing engine already solved the same problem using `wreq` with `Emulation::Firefox135`, which replicates the Firefox TLS handshake (cipher suites, extensions, GREASE values) to pass fingerprint-based bot detection. This PR applies the same fix to `web_fetch`.

## Changes

| File | Change |
|---|---|
| `Cargo.toml` | Add `features = ["stream"]` to `wreq` for `bytes_stream()` |
| `src/tool/impl/builtins/web_fetch.rs` | Swap `reqwest::Client` → `wreq::Client` with Firefox emulation; remove dead `USER_AGENT` constant |
| `src/tool/impl/builtins/web_fetch.rs` (tests) | Update network test URL to AccuWeather (분당구) and fix body assertion |

## Test plan

- [x] All 14 unit tests in `web_fetch` pass (`cargo test -p ailoy web_fetch`)
- [x] Network integration test `network_single_fetch_returns_200_and_body` passes against AccuWeather with `--include-ignored`
- [x] Network integration test `network_single_fetch_html_returns_raw_markup` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)