### PR TITLE
chore(deps): bump microsandbox to v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "dedent",
  "derive_builder",
  "dirs",
@@ -81,7 +81,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "strum 0.27.2",
- "strum_macros",
+ "strum_macros 0.27.2",
  "tar",
  "tempfile",
  "test-with",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -225,15 +225,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -456,6 +456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -525,12 +526,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -584,7 +579,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -592,6 +587,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1323,13 +1327,13 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1421,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1564,11 +1568,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -2189,17 +2193,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
@@ -2343,7 +2336,7 @@ checksum = "42f856d5f5daa55ea8b81bd746f1e49170fe589eccd2f5020d9ea888417983ab"
 dependencies = [
  "ahash",
  "astral-tl",
- "base64 0.22.1",
+ "base64",
  "html-escape",
  "html5ever 0.39.0",
  "lru 0.18.0",
@@ -2375,6 +2368,21 @@ dependencies = [
  "log",
  "markup5ever 0.39.0",
 ]
+
+[[package]]
+name = "httlib-hpack"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cf60e5e8567c6ff914a590f1452821de9377a560338a562e570a6ff052aae3"
+dependencies = [
+ "httlib-huffman",
+]
+
+[[package]]
+name = "httlib-huffman"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
 
 [[package]]
 name = "http"
@@ -2502,7 +2510,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2918,7 +2926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd"
 dependencies = [
  "ahash",
- "base64 0.22.1",
+ "base64",
  "bytecount",
  "email_address",
  "fancy-regex 0.14.0",
@@ -2941,7 +2949,8 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.22.1",
+ "aws-lc-rs",
+ "base64",
  "getrandom 0.2.17",
  "js-sys",
  "serde",
@@ -3039,9 +3048,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -3167,15 +3176,6 @@ checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -3297,13 +3297,13 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6611b7bf93b63777a11fe0b20b4ab5054106e1acedd515b17baaf35db305da40"
+checksum = "a6f91b58d997dfd74f4601b80f144a4667e1677bb13f57238e1c039fa48e76bd"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "ciborium",
@@ -3316,6 +3316,7 @@ dependencies = [
  "hex",
  "keyring",
  "libc",
+ "microsandbox-agent-client",
  "microsandbox-db",
  "microsandbox-filesystem",
  "microsandbox-image",
@@ -3325,7 +3326,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-runtime",
  "microsandbox-utils",
- "nix 0.30.1",
+ "nix 0.31.3",
  "notify",
  "rand 0.10.1",
  "reqwest 0.13.2",
@@ -3344,10 +3345,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "microsandbox-db"
-version = "0.5.2"
+name = "microsandbox-agent-client"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9189d47562fa2d3535c41d90f628889fdb2df97b5d6cda47d989f4bac8db9299"
+checksum = "7e184a041d79df660a10e9c514792399bbb67c713265b624817c3f3ad766a781"
+dependencies = [
+ "ciborium",
+ "microsandbox-protocol",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "microsandbox-db"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87eeed9be262679abdb925fba1285e99809d84f6e5be18a2255e60b872c4864"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3358,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd9bb1b8f24d18d0ee8b87bb69116aa980e28f46f9d21b95e828b6e8454fb22"
+checksum = "75f7112c3fcb920b204d1e6fb8e6ce251bfe33690c17f8a56915dcfbf2897b9f"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3372,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b630bf80e759c44cee3548f838fa1924a3b19602ee514852119110a94796736"
+checksum = "381b6282bc2c684151a709ffcca84d2adeecb7a85fab8f13762c7f1f99c75a9e"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3383,12 +3398,13 @@ dependencies = [
  "libc",
  "microsandbox-utils",
  "oci-client",
- "oci-spec",
+ "oci-spec 0.10.0",
  "rustls-pemfile",
  "scopeguard",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -3398,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee41ba848ec0b748016de0ae699d38a4c7bd2f944e9bcf2547f49be9aa51549"
+checksum = "501b62cbcec4b7562d81959e2f5e1299b5cd92e92863ea86daf555458479c46d"
 dependencies = [
  "chrono",
  "libc",
@@ -3410,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea26dfddce6da6248f75ca73466f7703c5890585840b53437e69b8e447f70b9e"
+checksum = "554d8b7d4953714b0c158cbc817a3f36330a6008fe9a13cc4c1dc805074db86c"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3420,11 +3436,11 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95022aa7fe1ecded9c680e1d52de80d66f3f9f48888fec829b05ead0d4a4623d"
+checksum = "3c4bcb0a667fd97e7a65f104b412e516e4a877c3c2901e51753e559f7c6fdc3d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "core-foundation 0.9.4",
  "crossbeam-queue",
@@ -3432,9 +3448,10 @@ dependencies = [
  "futures",
  "hickory-client",
  "hickory-proto",
+ "httlib-hpack",
  "ipnetwork",
  "libc",
- "lru 0.16.4",
+ "lru 0.18.0",
  "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
@@ -3448,7 +3465,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "smoltcp",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "time",
@@ -3459,23 +3476,24 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830f6feb8ed866946651cea9d2f693103cec812fc8be47ff2ad089e81945f4"
+checksum = "c98091c1c97d5a93ec47443d95db23975a556b2668cf0b56bb07dbe3bddc2f32"
 dependencies = [
  "chrono",
  "ciborium",
  "serde",
  "serde_bytes",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84eadc5c5fc8d55f135ae718cd51c712817cea8ef54ae942c09318b596e33fb5"
+checksum = "add1d9f8cbeed847971a21787a50b8898c6277eccf30aa9689f67ca9c66c6f0b"
 dependencies = [
  "bytes",
  "chrono",
@@ -3489,7 +3507,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
- "nix 0.30.1",
+ "nix 0.31.3",
  "rustls",
  "sea-orm",
  "serde",
@@ -3502,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f449293c7b6630dfccda66980000bd882a22369d9c2d885a7a808a68c323a7"
+checksum = "c4a433b500b639127ff65ee61aa5986e172fd062f60ef00af167797053ef3ac4"
 dependencies = [
  "dirs",
  "libc",
@@ -3559,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1204f9be84d1d6a7522745f2ca8c1daaad10b6974c31491b23fbfba8948ea436"
+checksum = "cf131d9095781217f075f4fa91e90ac3bbdd73779c0c6ecffe4f9939e4e76ddf"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3579,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f3fb3872287fbe2f9022da8e4b99bd7e2d56bffa225dc8e76ff5f8bea207c0"
+checksum = "4829b5bca7b4358112b326f6a524f75e88b083021986f93207112f3dff8502fc"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3595,15 +3613,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e9b644799f042ecd9ff8e1083548b069bfe5c055fb30a2ee5488d32d532305"
+checksum = "c2ca9ef715086cdde379d70731e4dc5dcf585519d2ab2b99da51932b4f063c3a"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80daaaa5c82e40b410813655552dae003273439dd4f663fdf8c0d482daa81690"
+checksum = "1b36578ce6cc6ad91cc5a21bbcb995de32b367ed6f3c52925534c5ea560cd633"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3612,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60168afa59b23513902fca621af0ae2e34b7c1eb6778c4dfdbcbf639d90e9d88"
+checksum = "28ac6edc3f3baed1a5d6626fb3ed1b9e1e639b92e30c24011f5a1c40de8161fb"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3640,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58dae8f64ded015362c7cf34fc6d3137e21ac67a2a2d9266c930d74de515c2"
+checksum = "2ede32a6da32fa31299fbb6963519c0b672c1ad97be7ea8222699cd382c31a25"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -3652,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c276f8c223cfef11a20777ceebf11452cbdbec0753f4f530490600abfd54e6c"
+checksum = "98d29e15913e7e775faf1146bf98388f8affbc68bdea030defd1b77f7c3065ff"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3662,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cc89c4d634828d4487321dc1ad27440d5b610b51a313572b5b41e5ad810c0"
+checksum = "ad3609057e96d2daf74efc79d7233ae51db7bbccd4fa8416596a76ace9c344fa"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3672,18 +3690,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2da7cdc57310229e8edfe559df924ae7deb747dacac65dc42898aeec44c62f"
+checksum = "f83ce2af57f58bceb3f8a25bbe6f39fade4007c9b54310023770e31f7acf7bb6"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68805ba9921de9794b2c5a5e4e2efc6f0dbe5206e5c3bcc602d072823373a068"
+checksum = "dd4e950963626139eb483199d653403c1f717876d2d0b540e94a94001ea360f4"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3696,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6042a24c047faba9b2c033db72257d765cb7dde393d61943d45cccac6e1fa12"
+checksum = "f7ce9aae47f5f78ade6fa2cb7fba48245195f683799f93e9e41efa1844491e61"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3761,6 +3779,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3904,24 +3934,25 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hex",
  "http",
  "http-auth",
  "jsonwebtoken",
  "lazy_static",
- "oci-spec",
+ "oci-spec 0.9.0",
  "olpc-cjson",
  "regex",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3941,15 +3972,32 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
- "strum_macros",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -4125,7 +4173,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -4604,9 +4652,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -4726,7 +4774,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4767,7 +4815,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4821,7 +4869,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4832,7 +4880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "futures",
  "http",
@@ -5005,7 +5053,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5640,7 +5688,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "crc",
@@ -5716,7 +5764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.0",
  "byteorder",
  "bytes",
@@ -5759,7 +5807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.0",
  "byteorder",
  "chrono",
@@ -5918,7 +5966,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5926,6 +5983,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6187,9 +6256,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6497,6 +6566,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6513,7 +6588,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "percent-encoding",
@@ -6531,7 +6606,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http",
  "httparse",
  "log",
@@ -7548,7 +7623,7 @@ dependencies = [
  "antidote",
  "arc-swap",
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "boring2",
  "bytes",
  "encoding_rs",
@@ -7598,9 +7673,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -7610,7 +7685,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -7651,10 +7726,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.16"
 log = "0.4"
-microsandbox = { version = "0.5.2", optional = true }
+microsandbox = { version = "0.5.6", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use microsandbox::{
     ExecOutput, MicrosandboxError, Sandbox as MsbSandbox, Snapshot,
     sandbox::{ExecOptionsBuilder, PullPolicy, SandboxBuilder, SandboxStatus},
+    validate_sandbox_name,
 };
 use tokio::sync::OnceCell;
 use schemars::JsonSchema;
@@ -42,13 +43,26 @@ pub enum VolumeMount {
     /// or `$MSB_HOME/volumes/<name>/`).
     /// The volume persists across sandbox restarts and can be shared between sandboxes.
     Named {
-        /// Name of the pre-existing microsandbox volume.
+        /// Name of the microsandbox volume.
         name: String,
         /// Absolute guest path.
         guest: String,
         /// When `true`, the guest cannot write to this mount.
         #[serde(default)]
         readonly: bool,
+        /// When `true`, create the named volume atomically with the sandbox
+        /// if it does not yet exist, or reuse a compatible existing one. The
+        /// volume row is inserted in the same DB transaction as the sandbox
+        /// row, so a parallel scan never observes an orphan-shaped row.
+        ///
+        /// When `false` (default), the volume must already exist.
+        #[serde(default)]
+        create_if_missing: bool,
+        /// Labels attached to the volume when it is created. When reusing an
+        /// existing volume, microsandbox requires these to match the
+        /// persisted labels.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        labels: Vec<(String, String)>,
     },
     /// Memory-backed temporary filesystem. Disappears when the sandbox stops.
     Tmpfs {
@@ -248,57 +262,36 @@ impl Sandbox {
             .await;
 
         let name = config.name.clone().unwrap_or_else(fresh_sandbox_name);
-        validate_sandbox_name(&name)?;
+        validate_sandbox_name(&name)
+            .map_err(|e| anyhow::anyhow!("sandbox name '{name}': {e}"))?;
 
-        // Pre-populate `/tmp` with a per-sandbox named volume so the
-        // microsandbox auto-tmpfs escape hatch (apply_runtime_defaults in
-        // microsandbox 0.4.6 lib/sandbox/config.rs:305-323) fires and `/tmp`
+        // Pre-populate `/tmp` with a per-sandbox named volume so it
         // survives the start/stop cycle that `RunEnvHandle::Drop` drives.
         // A user-supplied `/tmp` mount takes precedence.
-        let tmp_vol_provisioned = if config.volumes.iter().any(|v| v.guest_path() == "/tmp") {
-            None
-        } else {
-            let vol_name = tmp_volume_name(&name);
-            match microsandbox::Volume::builder(&vol_name)
-                .label(AILOY_VOLUME_LABEL_KEY, AILOY_VOLUME_LABEL_VALUE)
-                .create()
-                .await
-            {
-                Ok(_) => {}
-                // `persist=true` reattach: reuse the existing volume.
-                Err(MicrosandboxError::VolumeAlreadyExists(_)) => {}
-                Err(e) => {
-                    return Err(anyhow::anyhow!("create /tmp named volume: {e}"));
-                }
-            }
+        if !config.volumes.iter().any(|v| v.guest_path() == "/tmp") {
             config.volumes.push(VolumeMount::Named {
-                name: vol_name.clone(),
+                name: tmp_volume_name(&name),
                 guest: "/tmp".to_string(),
                 readonly: false,
+                create_if_missing: true,
+                labels: vec![(
+                    AILOY_VOLUME_LABEL_KEY.to_string(),
+                    AILOY_VOLUME_LABEL_VALUE.to_string(),
+                )],
             });
-            Some(vol_name)
-        };
+        }
 
-        let inner = match if config.persist && MsbSandbox::get(&name).await.is_ok() {
+        let inner = if config.persist && MsbSandbox::get(&name).await.is_ok() {
             MsbSandbox::start_detached(&name)
                 .await
-                .context("sandbox start")
+                .context("sandbox start")?
         } else {
             create_registered(&name, &config)
                 .await
-                .context("sandbox create-registered")
-        } {
-            Ok(s) => s,
-            Err(e) => {
-                // Roll back the volume we just provisioned.
-                if let Some(vol) = tmp_vol_provisioned {
-                    let _ = microsandbox::Volume::remove(&vol).await;
-                }
-                return Err(e);
-            }
+                .context("sandbox create-registered")?
         };
         let _ = inner.shell(&format!("mkdir -p {}", config.workdir)).await;
-        inner.stop_and_wait().await?;
+        inner.stop().await?;
 
         Ok(Self { config, name })
     }
@@ -314,7 +307,8 @@ impl Sandbox {
         }
 
         let new_name = new_cfg.name.clone().unwrap_or_else(fresh_sandbox_name);
-        validate_sandbox_name(&new_name)?;
+        validate_sandbox_name(&new_name)
+            .map_err(|e| anyhow::anyhow!("sandbox name '{new_name}': {e}"))?;
         let snap_name = format!("fork-{new_name}");
 
         let handle = MsbSandbox::get(&self.name)
@@ -383,16 +377,13 @@ impl Sandbox {
         match MsbSandbox::get(name).await {
             Err(_) => Ok(()),
             Ok(handle) => {
-                match handle.status() {
-                    SandboxStatus::Running | SandboxStatus::Draining => {
-                        let connected = handle.connect().await?;
-                        connected.stop_and_wait().await?;
-                        connected.remove_persisted().await?;
-                    }
-                    _ => {
-                        handle.remove().await?;
-                    }
+                if matches!(
+                    handle.status(),
+                    SandboxStatus::Running | SandboxStatus::Draining
+                ) {
+                    handle.stop().await?;
                 }
+                handle.remove().await?;
                 let _ = microsandbox::Volume::remove(&tmp_volume_name(name)).await;
                 Ok(())
             }
@@ -549,10 +540,8 @@ async fn start_and_connect(name: &str) -> anyhow::Result<MsbSandbox> {
     let inner = match MsbSandbox::start_detached(name).await {
         Ok(s) => s,
         Err(MicrosandboxError::SandboxStillRunning(_)) => {
-            if let Ok(h) = MsbSandbox::get(name).await
-                && let Ok(c) = h.connect().await
-            {
-                let _ = c.stop_and_wait().await;
+            if let Ok(h) = MsbSandbox::get(name).await {
+                let _ = h.stop().await;
             }
             MsbSandbox::start_detached(name)
                 .await
@@ -610,48 +599,13 @@ fn check_home_conflict(requested: &Path, current: Option<&std::ffi::OsStr>) -> a
     Ok(())
 }
 
-/// Validate that `name` won't produce a socket path that exceeds the OS limit.
-fn validate_sandbox_name(name: &str) -> anyhow::Result<()> {
-    #[cfg(target_os = "macos")]
-    const SUN_PATH_MAX: usize = 104;
-    #[cfg(not(target_os = "macos"))]
-    const SUN_PATH_MAX: usize = 108;
-
-    let home = microsandbox::config::config().home();
-    let home_str = home
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("home directory path is not valid UTF-8"))?;
-
-    const SANDBOXES_PREFIX: &str = "/sandboxes/";
-    const RUNTIME_SUFFIX: &str = "/runtime/agent.sock";
-
-    let socket_path_len =
-        home_str.len() + SANDBOXES_PREFIX.len() + name.len() + RUNTIME_SUFFIX.len() + 1; // null terminator
-
-    if socket_path_len > SUN_PATH_MAX {
-        let max_name = SUN_PATH_MAX
-            .saturating_sub(home_str.len() + SANDBOXES_PREFIX.len() + RUNTIME_SUFFIX.len() + 1);
-        anyhow::bail!(
-            "sandbox name '{}' is too long ({} chars); the resulting socket path \
-             would be {} bytes but the OS limit (SUN_PATH_MAX) is {}. \
-             With home directory '{}', the maximum sandbox name length is {} chars.",
-            name,
-            name.len(),
-            socket_path_len,
-            SUN_PATH_MAX,
-            home_str,
-            max_name,
-        );
-    }
-    Ok(())
-}
-
 async fn create_registered(name: &str, config: &SandboxConfig) -> anyhow::Result<MsbSandbox> {
     let mut builder = MsbSandbox::builder(name)
         .image(config.image.as_str())
         .cpus(config.cpus)
         .memory(config.memory_mib)
-        .pull_policy(PullPolicy::IfMissing);
+        .pull_policy(PullPolicy::IfMissing)
+        .detached(true);
 
     for (k, v) in &config.env {
         builder = builder.env(k.as_str(), v.as_str());
@@ -662,7 +616,7 @@ async fn create_registered(name: &str, config: &SandboxConfig) -> anyhow::Result
     for mount in &config.volumes {
         builder = apply_volume_mount(builder, mount);
     }
-    let sb = builder.create_detached().await?;
+    let sb = builder.create().await?;
     Ok(sb)
 }
 
@@ -674,7 +628,8 @@ async fn create_from_snapshot(
     let mut builder = MsbSandbox::builder(new_name)
         .from_snapshot(snap_name)
         .cpus(config.cpus)
-        .memory(config.memory_mib);
+        .memory(config.memory_mib)
+        .detached(true);
 
     for (k, v) in &config.env {
         builder = builder.env(k.as_str(), v.as_str());
@@ -687,7 +642,7 @@ async fn create_from_snapshot(
     }
 
     let sb = builder
-        .create_detached()
+        .create()
         .await
         .map_err(|e| anyhow::anyhow!("fork: create from snapshot: {e}"))?;
 
@@ -695,7 +650,7 @@ async fn create_from_snapshot(
     // required when forking a sandbox whose workdir wasn't in the source.
     let _ = sb.shell(&format!("mkdir -p {}", config.workdir)).await;
 
-    sb.stop_and_wait()
+    sb.stop()
         .await
         .map_err(|e| anyhow::anyhow!("fork: stop new sandbox: {e}"))?;
 
@@ -727,11 +682,25 @@ fn apply_volume_mount(builder: SandboxBuilder, mount: &VolumeMount) -> SandboxBu
             name,
             guest,
             readonly,
+            create_if_missing,
+            labels,
         } => {
             let name = name.clone();
             let ro = *readonly;
+            let ensure = *create_if_missing;
+            let labels = labels.clone();
             builder.volume(guest, move |m| {
-                let m = m.named(name);
+                let m = if ensure {
+                    m.named_with(name, move |mut n| {
+                        n = n.ensure_exists();
+                        for (k, v) in labels {
+                            n = n.label(k, v);
+                        }
+                        n
+                    })
+                } else {
+                    m.named(name)
+                };
                 if ro { m.readonly() } else { m }
             })
         }
@@ -855,17 +824,27 @@ mod tests {
         );
     }
 
-    /// Names that would exceed the socket path limit are rejected synchronously.
+    /// Names beyond the upstream 128 UTF-8 byte limit are rejected
+    /// synchronously by upstream `microsandbox::validate_sandbox_name`.
     #[test]
     fn test_name_too_long_is_rejected() {
-        let long_name = "a".repeat(100);
+        let long_name = "a".repeat(129);
         let result = validate_sandbox_name(&long_name);
-        assert!(result.is_err(), "expected Err for a 100-char name");
+        assert!(result.is_err(), "expected Err for a 129-byte name");
         let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("too long") && msg.contains("SUN_PATH_MAX"),
-            "error message should explain the limit, got: {msg}"
+            msg.contains("too long") || msg.contains("128"),
+            "error message should explain the byte limit, got: {msg}"
         );
+    }
+
+    /// Names up to 128 UTF-8 bytes pass syntactic validation; the runtime
+    /// may still reject longer-derived paths beyond that, but validation
+    /// itself accepts the boundary.
+    #[test]
+    fn test_name_at_128_bytes_passes_validation() {
+        let name = "a".repeat(128);
+        assert!(validate_sandbox_name(&name).is_ok());
     }
 
     // ── exec ─────────────────────────────────────────────────────────────────
@@ -1468,6 +1447,8 @@ mod tests {
                     name: vol_name.clone(),
                     guest: "/mnt/vol".to_string(),
                     readonly: false,
+                    create_if_missing: false,
+                    labels: Vec::new(),
                 }],
                 ..SandboxConfig::default()
             })
@@ -1486,12 +1467,16 @@ mod tests {
             write_result.stderr
         );
 
+        // Second mount opts into `create_if_missing` to also exercise the
+        // `ensure_exists` reuse path against the volume the first mount used.
         let read_result = async {
             let env = RunEnv::sandbox(SandboxConfig {
                 volumes: vec![VolumeMount::Named {
                     name: vol_name.clone(),
                     guest: "/mnt/vol".to_string(),
                     readonly: false,
+                    create_if_missing: true,
+                    labels: Vec::new(),
                 }],
                 ..SandboxConfig::default()
             })


### PR DESCRIPTION
## Summary

Bumps the microsandbox dependency from `v0.5.2` to `v0.5.6` and adopts the SDK-surface changes shipped along the way. PR #418 took `v0.5.0` → `v0.5.2`; this picks up `v0.5.3`–`v0.5.6`.

Two breaking sandbox-SDK changes land between `v0.5.2` and `v0.5.6`:

- superradcompany/microsandbox#909 — `refactor(sdk)!: use builder flag for detached creation`. The `SandboxBuilder::create_detached()` shortcut is removed; both `create_registered` and `create_from_snapshot` switch to `.detached(true).create()`.
- superradcompany/microsandbox#938 — `feat(sdk): unify sandbox lifecycle APIs`. `stop_and_wait` and `remove_persisted` are gone from the connected `Sandbox`, and `SandboxHandle::stop` is now completion-aware (waits for the VM to reach Stopped before returning). The `Sandbox::new` / fork stop path and the force-stop branch in `start_and_connect` all move to `inner.stop().await`. `Sandbox::remove_persisted` simplifies to a `handle.stop()` (if running) + `handle.remove()` pair — the previous `connect()` + `remove_persisted()` two-step is no longer needed.

Two upstream features are picked up at the same time:

- superradcompany/microsandbox#801 (race-free per-sandbox named volumes, originally referenced as pending in PR #418) + superradcompany/microsandbox#950 (idempotent named volume mounts). The auto-injected `/tmp` volume previously needed a separate `Volume::create` followed by a `VolumeMount::Named` push, with a manual `Volume::remove` salvage path if the sandbox create failed. It now flows through a single `m.named_with(name, |n| n.ensure_exists().label(...))` call, so the volume row is inserted in the same DB transaction as the sandbox row and the salvage path disappears. `VolumeMount::Named` gains `create_if_missing: bool` and `labels: Vec<(String, String)>`, exposing the new mount mode to ailoy users.
- superradcompany/microsandbox#830 — `feat(sandbox): enforce sandbox name byte limit`. ailoy used to derive its own sandbox-name cap from `SUN_PATH_MAX` against the per-sandbox agent-socket path. superradcompany/microsandbox#820 already moved that socket to a fixed-length hash under `~/.microsandbox/run/agent/` back in `v0.5.2`, so the OS-path derivation was obsolete. The local `validate_sandbox_name` is removed and validation delegates to upstream `microsandbox::validate_sandbox_name`. The syntactic cap rises from ~100 OS-dependent chars to 128 UTF-8 bytes; see *Practical name length* below for the runtime cap on `v0.5.6` specifically.

The other `v0.5.x` deltas — msb-metrics sidecar (#845/#856), legacy-mount config acceptance (#859), per-sandbox labels and label-selectors (#864), guest-runtime metrics (#939), CLI mount-kind flags (#927), oci image archive/save (#862), explicit named-volume modes from the CLI (#950), DNS/runtime/network hardening — are transparent at this layer.

## Dep form

The `microsandbox = { version = "0.5.2", optional = true }` line moves to `"0.5.6"`. Every transitive `microsandbox-*` member follows in `Cargo.lock`.

## Practical name length on v0.5.6

The new test `test_name_at_128_bytes_passes_validation` only covers the syntactic validator. End-to-end spawn for a 128-byte sandbox name fails on `v0.5.6` with `sandbox process exited (exit status: 0) before agent relay became available`, because the upstream spawn path uses the sandbox name as the guest `MSB_HOSTNAME` fallback and Linux `sethostname(2)` caps at `__NEW_UTS_LEN = 64` bytes. The boot-error trail is `agentd: init failed: init error: sethostname(<name>): EINVAL: Invalid argument`.

That is purely an upstream issue and is being addressed in superradcompany/microsandbox#971 (`fix(sandbox): keep guest hostname within UTS limit when sandbox name exceeds it`), which derives a 64-byte hostname from the sandbox name when no explicit `hostname()` is set. Until that PR lands and we move past `v0.5.6`, ailoy callers should keep sandbox names ≤ 64 UTF-8 bytes or set an explicit hostname via the microsandbox API. The validator-level 128-byte ceiling is intentional: it tracks what upstream claims to support, and tightens automatically as soon as upstream closes the gap.

## Verification

`~/.microsandbox/{bin,lib}` were wiped so the `v0.5.6` prebuilt was cold-pathed through `microsandbox::setup::install` on the first `Sandbox::new`. The full sandbox test module was then run.

```
cargo test --release --all-features runenv::sandbox::tests -- --test-threads=1
...
test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 299 filtered out; finished in 23.55s
```

The 39 tests are the 38 pre-existing ones plus a new `test_name_at_128_bytes_passes_validation` that exercises the upstream 128-byte boundary. `test_named_volume_persists_across_sandboxes` was extended to drive both an `existing`-mode mount and an `ensure_exists` reuse mount against the same volume in a single test, so the new `create_if_missing` path has live coverage.

`cargo check --all-features` and `cargo check --all-features --tests` also pass.

## Cross-reference

- superradcompany/microsandbox v0.5.3 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.3
- superradcompany/microsandbox v0.5.4 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.4
- superradcompany/microsandbox v0.5.5 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.5
- superradcompany/microsandbox v0.5.6 release: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.6
- superradcompany/microsandbox#971 — pending upstream fix for the hostname-cap gap discussed above.
