### PR TITLE
fix(lang_model): do not retry permanent quota 429s

### DIFF
--- a/src/lang_model/impl/api/anthropic.rs
+++ b/src/lang_model/impl/api/anthropic.rs
@@ -263,6 +263,9 @@ impl Marshal<LangModelRequest<'_>> for AnthropicMarshal {
 #[derive(Clone, Debug, Default)]
 pub struct AnthropicUnmarshal;
 
+// 429 is always transient; billing exhaustion is reported as 402, outside this path.
+impl super::QuotaClassifier for AnthropicUnmarshal {}
+
 impl Unmarshal<MessageDeltaOutput> for AnthropicUnmarshal {
     fn unmarshal(&mut self, val: Value) -> anyhow::Result<MessageDeltaOutput> {
         let root = val

--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -262,6 +262,10 @@ impl Marshal<LangModelRequest<'_>> for ChatCompletionMarshal {
 #[derive(Clone, Debug, Default)]
 pub struct ChatCompletionUnmarshal;
 
+// Shared by arbitrary OpenAI-compatible providers, so no provider-specific
+// quota signal can be assumed; treat 429 as transient and retry.
+impl super::QuotaClassifier for ChatCompletionUnmarshal {}
+
 impl ChatCompletionUnmarshal {
     fn parse_finish_reason(val: &Value) -> FinishReason {
         match val.as_str() {

--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -332,6 +332,26 @@ impl Marshal<LangModelRequest<'_>> for GeminiMarshal {
 #[derive(Clone, Debug, Default)]
 pub struct GeminiUnmarshal;
 
+impl super::QuotaClassifier for GeminiUnmarshal {
+    fn is_permanent_quota_error(&self, body: &str) -> bool {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+            return false;
+        };
+        let error = &json["error"];
+        // RESOURCE_EXHAUSTED covers both; a RetryInfo detail marks the transient case.
+        error["status"] == "RESOURCE_EXHAUSTED"
+            && !error["details"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .any(|d| {
+                    d["@type"]
+                        .as_str()
+                        .is_some_and(|t| t.ends_with("google.rpc.RetryInfo"))
+                })
+    }
+}
+
 impl Unmarshal<MessageDeltaOutput> for GeminiUnmarshal {
     fn unmarshal(&mut self, val: Value) -> anyhow::Result<MessageDeltaOutput> {
         let candidate = val
@@ -484,6 +504,7 @@ fn parse_candidate_content(candidate: &Value) -> anyhow::Result<MessageDelta> {
 mod tests {
     use url::Url;
 
+    use super::super::QuotaClassifier;
     use super::*;
     use crate::{
         datatype::{Bytes, Value},
@@ -940,6 +961,16 @@ mod tests {
             step2.message.contents.iter().any(|p| p.as_text().is_some()),
             "Expected text response after image tool result"
         );
+    }
+
+    #[test]
+    fn test_is_permanent_quota_error() {
+        let u = GeminiUnmarshal;
+        let quota = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.QuotaFailure"}]}}"#;
+        let rate = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"34s"}]}}"#;
+        assert!(u.is_permanent_quota_error(quota));
+        assert!(!u.is_permanent_quota_error(rate));
+        assert!(!u.is_permanent_quota_error("not json"));
     }
 }
 

--- a/src/lang_model/impl/api/mod.rs
+++ b/src/lang_model/impl/api/mod.rs
@@ -7,3 +7,11 @@ pub use anthropic::{AnthropicMarshal, AnthropicUnmarshal};
 pub use chat_completion::{ChatCompletionMarshal, ChatCompletionUnmarshal};
 pub use gemini::{GeminiMarshal, GeminiUnmarshal};
 pub use openai::{OpenAIMarshal, OpenAIUnmarshal};
+
+/// Classifies a 429 body as permanent quota exhaustion (don't retry) vs a
+/// transient rate limit. Defaults to transient.
+pub trait QuotaClassifier {
+    fn is_permanent_quota_error(&self, _body: &str) -> bool {
+        false
+    }
+}

--- a/src/lang_model/impl/api/mod.rs
+++ b/src/lang_model/impl/api/mod.rs
@@ -8,10 +8,42 @@ pub use chat_completion::{ChatCompletionMarshal, ChatCompletionUnmarshal};
 pub use gemini::{GeminiMarshal, GeminiUnmarshal};
 pub use openai::{OpenAIMarshal, OpenAIUnmarshal};
 
+use crate::{
+    datatype::Value,
+    lang_model::LangModelAPISchema,
+    message::{MessageDeltaOutput, Unmarshal},
+};
+
 /// Classifies a 429 body as permanent quota exhaustion (don't retry) vs a
 /// transient rate limit. Defaults to transient.
 pub trait QuotaClassifier {
     fn is_permanent_quota_error(&self, _body: &str) -> bool {
         false
+    }
+}
+
+/// Provider-specific response handling, dispatched dynamically so callers map a
+/// [`LangModelAPISchema`] to its implementation once and reuse it for both
+/// unmarshaling and 429 classification.
+pub trait ProviderApi: QuotaClassifier {
+    fn unmarshal_response(&self, val: Value) -> anyhow::Result<MessageDeltaOutput>;
+}
+
+impl<T> ProviderApi for T
+where
+    T: QuotaClassifier + Unmarshal<MessageDeltaOutput>,
+{
+    fn unmarshal_response(&self, val: Value) -> anyhow::Result<MessageDeltaOutput> {
+        T::default().unmarshal(val)
+    }
+}
+
+/// Maps a wire schema to its provider implementation.
+pub fn provider_api(schema: &LangModelAPISchema) -> Box<dyn ProviderApi + Send> {
+    match schema {
+        LangModelAPISchema::Anthropic => Box::new(AnthropicUnmarshal),
+        LangModelAPISchema::ChatCompletion => Box::new(ChatCompletionUnmarshal),
+        LangModelAPISchema::Gemini => Box::new(GeminiUnmarshal),
+        LangModelAPISchema::OpenAI => Box::new(OpenAIUnmarshal),
     }
 }

--- a/src/lang_model/impl/api/openai.rs
+++ b/src/lang_model/impl/api/openai.rs
@@ -259,6 +259,16 @@ impl Marshal<LangModelRequest<'_>> for OpenAIMarshal {
 #[derive(Clone, Debug, Default)]
 pub struct OpenAIUnmarshal;
 
+impl super::QuotaClassifier for OpenAIUnmarshal {
+    fn is_permanent_quota_error(&self, body: &str) -> bool {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+            return false;
+        };
+        let error = &json["error"];
+        error["type"] == "insufficient_quota" || error["code"] == "insufficient_quota"
+    }
+}
+
 impl Unmarshal<MessageDeltaOutput> for OpenAIUnmarshal {
     fn unmarshal(&mut self, val: Value) -> anyhow::Result<MessageDeltaOutput> {
         let root = val
@@ -416,6 +426,7 @@ impl Unmarshal<MessageDeltaOutput> for OpenAIUnmarshal {
 mod tests {
     use url::Url;
 
+    use super::super::QuotaClassifier;
     use super::*;
     use crate::{
         datatype::Bytes,
@@ -808,6 +819,17 @@ mod tests {
             resp.message.contents.iter().any(|p| p.as_text().is_some()),
             "Expected text response after image tool result"
         );
+    }
+
+    #[test]
+    fn test_is_permanent_quota_error() {
+        let u = OpenAIUnmarshal;
+        let quota = r#"{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}"#;
+        let rate = r#"{"error":{"type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}"#;
+        assert!(u.is_permanent_quota_error(quota));
+        assert!(!u.is_permanent_quota_error(rate));
+        // Unparseable body is treated as transient (don't suppress retries).
+        assert!(!u.is_permanent_quota_error("not json"));
     }
 }
 

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -4,8 +4,8 @@ use url::Url;
 use super::{LangModelAPISchema, LangModelProviderElem};
 use crate::{
     datatype::Value,
-    lang_model::{LangModelOptions, r#impl::api, r#impl::api::QuotaClassifier as _},
-    message::{Delta as _, Marshaled, Message, MessageOutput, Unmarshal as _},
+    lang_model::{LangModelOptions, r#impl::api},
+    message::{Delta as _, Marshaled, Message, MessageOutput},
     tool::ToolDesc,
 };
 
@@ -157,6 +157,7 @@ impl LangModel {
                 let body: serde_json::Value = body.clone().into();
 
                 // Send request with retry on 429 (rate limit)
+                let provider = api::provider_api(schema);
                 let client = reqwest::Client::new();
                 const MAX_RETRIES: u32 = 3;
                 let (status, response_text) = {
@@ -181,21 +182,7 @@ impl LangModel {
                                 .min(MAX_WAIT_SECS);
                             let text = response.text().await?;
                             // Permanent quota/credit exhaustion never recovers; don't retry.
-                            let permanent = match schema {
-                                LangModelAPISchema::Anthropic => {
-                                    api::AnthropicUnmarshal.is_permanent_quota_error(&text)
-                                }
-                                LangModelAPISchema::ChatCompletion => {
-                                    api::ChatCompletionUnmarshal.is_permanent_quota_error(&text)
-                                }
-                                LangModelAPISchema::Gemini => {
-                                    api::GeminiUnmarshal.is_permanent_quota_error(&text)
-                                }
-                                LangModelAPISchema::OpenAI => {
-                                    api::OpenAIUnmarshal.is_permanent_quota_error(&text)
-                                }
-                            };
-                            if permanent {
+                            if provider.is_permanent_quota_error(&text) {
                                 log::warn!("Quota exhausted (429), not retrying: {text}");
                                 last_status = Some(s);
                                 last_text = Some(text);
@@ -230,16 +217,7 @@ impl LangModel {
                     serde_json::from_str::<serde_json::Value>(&response_text)?.into();
 
                 // Unmarshal
-                let delta_output = match schema {
-                    LangModelAPISchema::Anthropic => {
-                        api::AnthropicUnmarshal.unmarshal(response_value)?
-                    }
-                    LangModelAPISchema::ChatCompletion => {
-                        api::ChatCompletionUnmarshal.unmarshal(response_value)?
-                    }
-                    LangModelAPISchema::Gemini => api::GeminiUnmarshal.unmarshal(response_value)?,
-                    LangModelAPISchema::OpenAI => api::OpenAIUnmarshal.unmarshal(response_value)?,
-                };
+                let delta_output = provider.unmarshal_response(response_value)?;
 
                 delta_output.finish()
             }

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -180,6 +180,13 @@ impl LangModel {
                                 .unwrap_or(1u64 << attempt)
                                 .min(MAX_WAIT_SECS);
                             let text = response.text().await?;
+                            // Permanent quota/credit exhaustion never recovers; don't retry.
+                            if is_permanent_quota_error(schema, &text) {
+                                log::warn!("Quota exhausted (429), not retrying: {text}");
+                                last_status = Some(s);
+                                last_text = Some(text);
+                                break;
+                            }
                             log::warn!(
                                 "Rate limited (429). Retrying after {}s (attempt {}/{}): {}",
                                 wait_secs,
@@ -223,6 +230,34 @@ impl LangModel {
                 delta_output.finish()
             }
         }
+    }
+}
+
+/// Whether a 429 body is permanent quota exhaustion (don't retry) vs a transient rate limit.
+fn is_permanent_quota_error(schema: &LangModelAPISchema, body: &str) -> bool {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let error = &json["error"];
+    match schema {
+        LangModelAPISchema::OpenAI | LangModelAPISchema::ChatCompletion => {
+            error["type"] == "insufficient_quota" || error["code"] == "insufficient_quota"
+        }
+        // RESOURCE_EXHAUSTED covers both; a RetryInfo in `details` marks the transient case.
+        LangModelAPISchema::Gemini => {
+            error["status"] == "RESOURCE_EXHAUSTED"
+                && !error["details"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .any(|d| {
+                        d["@type"]
+                            .as_str()
+                            .is_some_and(|t| t.ends_with("google.rpc.RetryInfo"))
+                    })
+        }
+        // 429 is always transient; credit exhaustion is a 402, outside this path.
+        LangModelAPISchema::Anthropic => false,
     }
 }
 
@@ -445,5 +480,76 @@ mod tests {
             "should have made 3 total attempts (2x 429 retried + 1 success)"
         );
         assert!(!resp.message.contents.is_empty());
+    }
+
+    /// Verifies a permanent quota 429 (`insufficient_quota`) is not retried.
+    #[tokio::test]
+    async fn test_run_does_not_retry_on_permanent_429() {
+        use std::sync::{Arc, Mutex};
+
+        use axum::{Router, body::Body, response::Response, routing::post};
+
+        let call_count = Arc::new(Mutex::new(0u32));
+        let count = call_count.clone();
+        let app = Router::new().route(
+            "/",
+            post(move || {
+                let count = count.clone();
+                async move {
+                    *count.lock().unwrap() += 1;
+                    Response::builder()
+                        .status(429)
+                        .body(Body::from(
+                            r#"{"error":{"type":"insufficient_quota","code":"insufficient_quota","message":"You exceeded your current quota"}}"#,
+                        ))
+                        .unwrap()
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let model = LangModel::new(
+            "test-model".to_string(),
+            LangModelProvider::chat_completion(&format!("http://{}/", addr), None).unwrap(),
+        );
+        let messages = vec![Message::new(Role::User).with_contents([Part::text("hi")])];
+
+        let result = model
+            .run(&messages, &[], &LangModelOptions::default())
+            .await;
+
+        assert!(result.is_err(), "permanent quota 429 must fail");
+        assert_eq!(
+            *call_count.lock().unwrap(),
+            1,
+            "permanent quota 429 must not be retried (1 attempt only)"
+        );
+    }
+
+    #[test]
+    fn test_is_permanent_quota_error() {
+        use LangModelAPISchema::*;
+
+        let openai_quota = r#"{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}"#;
+        let openai_rate = r#"{"error":{"type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}"#;
+        assert!(is_permanent_quota_error(&ChatCompletion, openai_quota));
+        assert!(is_permanent_quota_error(&OpenAI, openai_quota));
+        assert!(!is_permanent_quota_error(&ChatCompletion, openai_rate));
+
+        let gemini_quota = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.QuotaFailure"}]}}"#;
+        let gemini_rate = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"34s"}]}}"#;
+        assert!(is_permanent_quota_error(&Gemini, gemini_quota));
+        assert!(!is_permanent_quota_error(&Gemini, gemini_rate));
+
+        // Anthropic 429 is always transient; billing exhaustion is a 402.
+        assert!(!is_permanent_quota_error(&Anthropic, r#"{"type":"error","error":{"type":"rate_limit_error"}}"#));
+
+        // Unparseable body is treated as transient (don't suppress retries).
+        assert!(!is_permanent_quota_error(&OpenAI, "not json"));
     }
 }

--- a/src/lang_model/rt.rs
+++ b/src/lang_model/rt.rs
@@ -4,7 +4,7 @@ use url::Url;
 use super::{LangModelAPISchema, LangModelProviderElem};
 use crate::{
     datatype::Value,
-    lang_model::{LangModelOptions, r#impl::api},
+    lang_model::{LangModelOptions, r#impl::api, r#impl::api::QuotaClassifier as _},
     message::{Delta as _, Marshaled, Message, MessageOutput, Unmarshal as _},
     tool::ToolDesc,
 };
@@ -181,7 +181,21 @@ impl LangModel {
                                 .min(MAX_WAIT_SECS);
                             let text = response.text().await?;
                             // Permanent quota/credit exhaustion never recovers; don't retry.
-                            if is_permanent_quota_error(schema, &text) {
+                            let permanent = match schema {
+                                LangModelAPISchema::Anthropic => {
+                                    api::AnthropicUnmarshal.is_permanent_quota_error(&text)
+                                }
+                                LangModelAPISchema::ChatCompletion => {
+                                    api::ChatCompletionUnmarshal.is_permanent_quota_error(&text)
+                                }
+                                LangModelAPISchema::Gemini => {
+                                    api::GeminiUnmarshal.is_permanent_quota_error(&text)
+                                }
+                                LangModelAPISchema::OpenAI => {
+                                    api::OpenAIUnmarshal.is_permanent_quota_error(&text)
+                                }
+                            };
+                            if permanent {
                                 log::warn!("Quota exhausted (429), not retrying: {text}");
                                 last_status = Some(s);
                                 last_text = Some(text);
@@ -230,34 +244,6 @@ impl LangModel {
                 delta_output.finish()
             }
         }
-    }
-}
-
-/// Whether a 429 body is permanent quota exhaustion (don't retry) vs a transient rate limit.
-fn is_permanent_quota_error(schema: &LangModelAPISchema, body: &str) -> bool {
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
-        return false;
-    };
-    let error = &json["error"];
-    match schema {
-        LangModelAPISchema::OpenAI | LangModelAPISchema::ChatCompletion => {
-            error["type"] == "insufficient_quota" || error["code"] == "insufficient_quota"
-        }
-        // RESOURCE_EXHAUSTED covers both; a RetryInfo in `details` marks the transient case.
-        LangModelAPISchema::Gemini => {
-            error["status"] == "RESOURCE_EXHAUSTED"
-                && !error["details"]
-                    .as_array()
-                    .into_iter()
-                    .flatten()
-                    .any(|d| {
-                        d["@type"]
-                            .as_str()
-                            .is_some_and(|t| t.ends_with("google.rpc.RetryInfo"))
-                    })
-        }
-        // 429 is always transient; credit exhaustion is a 402, outside this path.
-        LangModelAPISchema::Anthropic => false,
     }
 }
 
@@ -515,7 +501,11 @@ mod tests {
 
         let model = LangModel::new(
             "test-model".to_string(),
-            LangModelProvider::chat_completion(&format!("http://{}/", addr), None).unwrap(),
+            LangModelProviderElem::API {
+                schema: LangModelAPISchema::OpenAI,
+                url: format!("http://{}/", addr).parse().unwrap(),
+                api_key: None,
+            },
         );
         let messages = vec![Message::new(Role::User).with_contents([Part::text("hi")])];
 
@@ -529,27 +519,5 @@ mod tests {
             1,
             "permanent quota 429 must not be retried (1 attempt only)"
         );
-    }
-
-    #[test]
-    fn test_is_permanent_quota_error() {
-        use LangModelAPISchema::*;
-
-        let openai_quota = r#"{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}"#;
-        let openai_rate = r#"{"error":{"type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}"#;
-        assert!(is_permanent_quota_error(&ChatCompletion, openai_quota));
-        assert!(is_permanent_quota_error(&OpenAI, openai_quota));
-        assert!(!is_permanent_quota_error(&ChatCompletion, openai_rate));
-
-        let gemini_quota = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.QuotaFailure"}]}}"#;
-        let gemini_rate = r#"{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"34s"}]}}"#;
-        assert!(is_permanent_quota_error(&Gemini, gemini_quota));
-        assert!(!is_permanent_quota_error(&Gemini, gemini_rate));
-
-        // Anthropic 429 is always transient; billing exhaustion is a 402.
-        assert!(!is_permanent_quota_error(&Anthropic, r#"{"type":"error","error":{"type":"rate_limit_error"}}"#));
-
-        // Unparseable body is treated as transient (don't suppress retries).
-        assert!(!is_permanent_quota_error(&OpenAI, "not json"));
     }
 }


### PR DESCRIPTION
## Summary

Stops retrying 429 responses that represent permanent quota or credit exhaustion.

Transient rate limits still go through the existing retry/backoff path. Permanent quota failures now return the provider error immediately, so callers do not spend the full retry budget on an error that cannot recover within the request.

## Problem

`LangModel::run` treated every HTTP 429 as a retryable rate limit. That is correct for temporary throttling, but not for quota or credit exhaustion. OpenAI reports permanent quota exhaustion as a 429 with `error.type` / `error.code = "insufficient_quota"`, which meant ailoy would retry the same non-recoverable failure before surfacing it.

Gemini uses `RESOURCE_EXHAUSTED` for both cases. The transient form includes `google.rpc.RetryInfo`; quota exhaustion does not. Anthropic billing exhaustion is outside this path because it is reported as 402 rather than 429.

## Changes

- `src/lang_model/rt.rs`: read the 429 response body before deciding whether to retry.
- Add `is_permanent_quota_error(schema, body)` to classify provider-specific permanent quota failures:
  - OpenAI / ChatCompletion: `insufficient_quota` in `error.type` or `error.code`.
  - Gemini: `RESOURCE_EXHAUSTED` without a `google.rpc.RetryInfo` detail.
  - Anthropic: always retryable in the 429 path.
- Keep unparseable 429 bodies retryable, preserving the previous behavior when the provider response is not structured JSON.
- Add regression coverage for both the permanent-quota short-circuit and the existing transient-429 retry path.

## Test plan

- [x] `cargo check --manifest-path /Users/nryoo/work/ailoy-429/Cargo.toml`
  - `Finished dev profile [unoptimized + debuginfo]`
- [x] `cargo test --manifest-path /Users/nryoo/work/ailoy-429/Cargo.toml --lib permanent`
  - `test lang_model::rt::tests::test_is_permanent_quota_error ... ok`
  - `test lang_model::rt::tests::test_run_does_not_retry_on_permanent_429 ... ok`
  - `test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 294 filtered out; finished in 0.03s`
- [x] `cargo test --manifest-path /Users/nryoo/work/ailoy-429/Cargo.toml --lib test_run_retries_on_429`
  - `test lang_model::rt::tests::test_run_retries_on_429 ... ok`
  - `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 295 filtered out; finished in 0.04s`
