### PR TITLE
feat(vfs): add Gmail provider

### DIFF
--- a/src/vfs/accessor/gmail.rs
+++ b/src/vfs/accessor/gmail.rs
@@ -1,0 +1,221 @@
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+const OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GMAIL_API_BASE: &str = "https://gmail.googleapis.com/gmail/v1";
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GmailConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub refresh_token: String,
+}
+
+/// Holds Google OAuth credentials (one refresh token) and a cached access
+/// token. Mirrors [`GDriveAccessor`](super::GDriveAccessor)'s OAuth flow; both
+/// speak Google APIs with the same `client_id`/`secret`/`refresh_token`, but a
+/// Gmail mount needs a token whose scope covers Gmail (e.g.
+/// `https://www.googleapis.com/auth/gmail.modify`).
+pub struct GmailAccessor {
+    client: reqwest::Client,
+    config: GmailConfig,
+    /// Cached OAuth access token + its expiry. Refreshed proactively before
+    /// expiry and on a 401 (see [`Self::send_with_refresh`]).
+    access_token: Mutex<Option<(String, Instant)>>,
+}
+
+impl GmailAccessor {
+    pub fn new(config: &GmailConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            // Bound every request: a hung upstream call run behind the FUSE
+            // forward server would otherwise wedge the guest FUSE op (and any
+            // process touching the mount) forever. A timeout makes it recoverable.
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .connect_timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+            config: config.clone(),
+            access_token: Mutex::new(None),
+        })
+    }
+
+    async fn token(&self) -> anyhow::Result<String> {
+        let mut guard = self.access_token.lock().await;
+        // Reuse a cached token until it's within 60s of expiry (proactive refresh
+        // avoids the "everything 401s after ~1h" failure).
+        if let Some((t, exp)) = guard.as_ref()
+            && *exp > Instant::now() + Duration::from_secs(60)
+        {
+            return Ok(t.clone());
+        }
+        let resp = self
+            .client
+            .post(OAUTH_TOKEN_URL)
+            .form(&[
+                ("client_id", self.config.client_id.as_str()),
+                ("client_secret", self.config.client_secret.as_str()),
+                ("refresh_token", self.config.refresh_token.as_str()),
+                ("grant_type", "refresh_token"),
+            ])
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("google token exchange {status}: {body}");
+        }
+        let v: Value = serde_json::from_str(&body)?;
+        let token = v
+            .get("access_token")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| anyhow::anyhow!("no access_token in response"))?
+            .to_string();
+        let expires_in = v.get("expires_in").and_then(|e| e.as_u64()).unwrap_or(3600);
+        *guard = Some((
+            token.clone(),
+            Instant::now() + Duration::from_secs(expires_in),
+        ));
+        Ok(token)
+    }
+
+    /// Send a request built from the current access token; on 401 (expired or
+    /// revoked despite proactive refresh) drop the token, refresh, and retry once.
+    async fn send_with_refresh(
+        &self,
+        build: impl Fn(&str) -> reqwest::RequestBuilder,
+    ) -> anyhow::Result<reqwest::Response> {
+        let token = self.token().await?;
+        let resp = build(&token).send().await?;
+        if resp.status() != reqwest::StatusCode::UNAUTHORIZED {
+            return Ok(resp);
+        }
+        *self.access_token.lock().await = None;
+        let token = self.token().await?;
+        Ok(build(&token).send().await?)
+    }
+
+    async fn get_json(&self, url: &str) -> anyhow::Result<Value> {
+        let resp = self
+            .send_with_refresh(|t| self.client.get(url).bearer_auth(t))
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    /// All Gmail labels (system + user). Each is `{id, name, type}`.
+    pub async fn list_labels(&self) -> anyhow::Result<Vec<Value>> {
+        let url = format!("{GMAIL_API_BASE}/users/me/labels");
+        let v = self.get_json(&url).await?;
+        Ok(v.get("labels")
+            .and_then(|l| l.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// Message stubs (`{id, threadId}`) for a label and/or query.
+    pub async fn list_messages(
+        &self,
+        label_id: Option<&str>,
+        query: Option<&str>,
+        max_results: u32,
+    ) -> anyhow::Result<Vec<Value>> {
+        let mut params: Vec<(&str, String)> = vec![("maxResults", max_results.to_string())];
+        if let Some(l) = label_id {
+            params.push(("labelIds", l.to_string()));
+        }
+        if let Some(q) = query {
+            params.push(("q", q.to_string()));
+        }
+        let url = reqwest::Url::parse_with_params(
+            &format!("{GMAIL_API_BASE}/users/me/messages"),
+            &params,
+        )?;
+        let v = self
+            .send_with_refresh(|t| self.client.get(url.clone()).bearer_auth(t))
+            .await?
+            .error_for_status()?
+            .json::<Value>()
+            .await?;
+        Ok(v.get("messages")
+            .and_then(|m| m.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// Full message resource (`format=full`): headers, payload parts, labels,
+    /// `internalDate`, `sizeEstimate`.
+    pub async fn get_message_full(&self, id: &str) -> anyhow::Result<Value> {
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/{id}?format=full");
+        self.get_json(&url).await
+    }
+
+    /// Minimal message resource (`format=minimal`): `internalDate` + labels but
+    /// no headers/body. Used to date-bucket a label listing cheaply.
+    pub async fn get_message_minimal(&self, id: &str) -> anyhow::Result<Value> {
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/{id}?format=minimal");
+        self.get_json(&url).await
+    }
+
+    /// Fetch and base64url-decode an attachment's bytes.
+    pub async fn get_attachment(
+        &self,
+        message_id: &str,
+        attachment_id: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        let url =
+            format!("{GMAIL_API_BASE}/users/me/messages/{message_id}/attachments/{attachment_id}");
+        let v = self.get_json(&url).await?;
+        let data = v.get("data").and_then(|d| d.as_str()).unwrap_or("");
+        Ok(decode_b64url(data))
+    }
+
+    /// Move a message to Trash (the `rm` of a `.gmail.json`).
+    pub async fn trash(&self, message_id: &str) -> anyhow::Result<()> {
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/{message_id}/trash");
+        self.send_with_refresh(|t| {
+            self.client
+                .post(&url)
+                .bearer_auth(t)
+                .json(&serde_json::json!({}))
+        })
+        .await?
+        .error_for_status()?;
+        Ok(())
+    }
+
+    /// Send a raw (base64url) RFC-2822 message, optionally within a thread.
+    pub async fn send_raw(&self, raw_b64: &str, thread_id: Option<&str>) -> anyhow::Result<Value> {
+        let mut body = serde_json::json!({ "raw": raw_b64 });
+        if let Some(tid) = thread_id {
+            body["threadId"] = Value::from(tid);
+        }
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/send");
+        let resp = self
+            .send_with_refresh(|t| self.client.post(&url).bearer_auth(t).json(&body))
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("gmail send {status}: {text}");
+        }
+        Ok(serde_json::from_str(&text).unwrap_or(Value::Null))
+    }
+}
+
+/// Decode Gmail's base64url payload data, tolerating missing padding.
+fn decode_b64url(s: &str) -> Vec<u8> {
+    let trimmed = s.trim_end_matches('=');
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(trimmed)
+        .unwrap_or_default()
+}
+
+/// Base64url-encode raw MIME bytes for the Gmail `send` API.
+pub fn encode_b64url(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE.encode(bytes)
+}

--- a/src/vfs/accessor/mod.rs
+++ b/src/vfs/accessor/mod.rs
@@ -5,9 +5,11 @@
 //! credentials into logs. They stay host-only.
 
 mod gdrive;
+mod gmail;
 mod notion;
 mod s3;
 
 pub use gdrive::{GDriveAccessor, GDriveConfig};
+pub use gmail::{GmailAccessor, GmailConfig, encode_b64url};
 pub use notion::{NotionAccessor, NotionConfig};
 pub use s3::{S3Accessor, S3Config};

--- a/src/vfs/cache.rs
+++ b/src/vfs/cache.rs
@@ -182,8 +182,20 @@ impl Resource for CachedResource {
         if let Some(entries) = self.cache.list_dir_entries(path.as_str()) {
             return Ok(entries);
         }
+        // Incremental discovery for incomplete-listing providers (gmail): if we
+        // just resolved a child its parent's (capped) listing didn't include,
+        // drop the parent listing so the next readdir re-runs and folds it in
+        // (the provider remembers visited entries). Checked before set_dir,
+        // which would otherwise mark this path as listed.
+        let discovered = !self.inner.listings_complete()
+            && !path.is_root()
+            && self.cache.is_listed(parent_of(path.as_str()))
+            && self.cache.get(path.as_str()).is_none();
         let entries = self.inner.readdir(path).await?;
         self.cache.set_dir(path.as_str(), &entries);
+        if discovered {
+            self.cache.invalidate_dir(parent_of(path.as_str()));
+        }
         Ok(entries)
     }
 
@@ -213,8 +225,13 @@ impl Resource for CachedResource {
             Some(_) => return self.inner.stat(path).await,
             None => {
                 // Negative cache: a fresh parent listing that lacks this path
-                // proves it does not exist — skip the network probe.
-                if !path.is_root() && self.cache.is_listed(parent_of(key)) {
+                // proves it does not exist — skip the network probe. Only valid
+                // when the provider's listings are complete; gmail caps them, so
+                // a missing child may still exist and must be probed.
+                if !path.is_root()
+                    && self.inner.listings_complete()
+                    && self.cache.is_listed(parent_of(key))
+                {
                     anyhow::bail!("not found: {key}");
                 }
             }
@@ -271,6 +288,10 @@ impl Resource for CachedResource {
 
     fn prompt(&self) -> &str {
         self.inner.prompt()
+    }
+
+    fn listings_complete(&self) -> bool {
+        self.inner.listings_complete()
     }
 }
 

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -19,7 +19,7 @@ pub mod sandbox;
 #[allow(clippy::module_inception)]
 mod vfs;
 
-pub use accessor::{GDriveConfig, NotionConfig, S3Config};
+pub use accessor::{GDriveConfig, GmailConfig, NotionConfig, S3Config};
 pub use fuse::VfsMount;
 pub use path::VPath;
 pub use resource::{DirEntry, FileKind, FileStat, Resource, S3Resource};

--- a/src/vfs/resource/base.rs
+++ b/src/vfs/resource/base.rs
@@ -83,4 +83,14 @@ pub trait Resource: Send + Sync {
     fn prompt(&self) -> &str {
         ""
     }
+
+    /// Whether `readdir` returns a *complete* listing of a directory. When true,
+    /// a fresh parent listing that lacks a name proves that name doesn't exist,
+    /// so the cache can answer `stat` of a missing child with ENOENT without a
+    /// network probe (negative caching). Gmail caps listings (newest N messages
+    /// per label/date), so a date/message absent from a listing may still exist
+    /// and must be probed — it returns `false`. Default: `true`.
+    fn listings_complete(&self) -> bool {
+        true
+    }
 }

--- a/src/vfs/resource/gmail.rs
+++ b/src/vfs/resource/gmail.rs
@@ -1,0 +1,968 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
+use serde_json::{Value, json};
+
+use crate::vfs::{
+    accessor::{GmailAccessor, GmailConfig, encode_b64url},
+    path::VPath,
+    resource::{DirEntry, FileKind, FileStat, Resource},
+};
+
+/// Listing TTL for the label set (cheap, changes rarely).
+const LABEL_TTL: Duration = Duration::from_secs(60);
+/// Raw-message cache TTL — dedups the per-message fetches that readdir, stat,
+/// read, and unlink all need for the same id.
+const MSG_TTL: Duration = Duration::from_secs(30);
+/// Concurrency for the per-message fetches a directory listing fans out.
+const FETCH_CONCURRENCY: usize = 6;
+/// Messages pulled per label / per date dir.
+const MAX_MESSAGES: u32 = 50;
+/// Over-estimate reported by `stat` for an `.gmail.json` whose processed length
+/// isn't known without fetching. The guest kernel clamps reads at the reported
+/// size even under direct_io, so this must exceed any real email JSON; reads
+/// return the real bytes then empty at EOF (mirrors the gdrive workspace-doc
+/// sentinel). Attachments report their exact size (known from the part).
+const MSG_SENTINEL_SIZE: u64 = 16 * 1024 * 1024;
+
+const GMAIL_SUFFIX: &str = ".gmail.json";
+
+pub struct GmailResource {
+    accessor: GmailAccessor,
+    /// `(display_name, label_id)` for every label, cached briefly.
+    label_cache: tokio::sync::Mutex<Option<(Instant, Vec<(String, String)>)>>,
+    /// Full raw message JSON by id, cached briefly.
+    msg_cache: tokio::sync::Mutex<HashMap<String, (Instant, Value)>>,
+    /// Dates (`yyyy-mm-dd`) per label that have been visited via a direct
+    /// `ls <label>/<date>` and turned out to have mail. The label listing is
+    /// capped at the newest 50 messages, so older dates don't appear on their
+    /// own; folding these visited dates back in makes the listing grow
+    /// incrementally (and lets tab-completion offer them).
+    seen_dates: tokio::sync::Mutex<HashMap<String, std::collections::BTreeSet<String>>>,
+}
+
+impl GmailResource {
+    pub fn new(config: &GmailConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            accessor: GmailAccessor::new(config)?,
+            label_cache: tokio::sync::Mutex::new(None),
+            msg_cache: tokio::sync::Mutex::new(HashMap::new()),
+            seen_dates: tokio::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    // ---- labels -----------------------------------------------------------
+
+    /// `(display_name, id)` for every label. System labels display as their id
+    /// (INBOX, SENT, …); user labels display as their name.
+    async fn labels(&self) -> anyhow::Result<Vec<(String, String)>> {
+        {
+            let c = self.label_cache.lock().await;
+            if let Some((at, v)) = c.as_ref()
+                && at.elapsed() < LABEL_TTL
+            {
+                return Ok(v.clone());
+            }
+        }
+        let raw = self.accessor.list_labels().await?;
+        let mut out = Vec::new();
+        for lb in &raw {
+            let id = lb.get("id").and_then(|x| x.as_str()).unwrap_or("");
+            if id.is_empty() {
+                continue;
+            }
+            let display = if lb.get("type").and_then(|t| t.as_str()) == Some("system") {
+                id.to_string()
+            } else {
+                lb.get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or(id)
+                    .to_string()
+            };
+            out.push((display, id.to_string()));
+        }
+        *self.label_cache.lock().await = Some((Instant::now(), out.clone()));
+        Ok(out)
+    }
+
+    async fn label_id(&self, display: &str) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .labels()
+            .await?
+            .into_iter()
+            .find(|(d, _)| d == display)
+            .map(|(_, id)| id))
+    }
+
+    // ---- message fetch (cached) ------------------------------------------
+
+    async fn message_full(&self, id: &str) -> anyhow::Result<Value> {
+        {
+            let c = self.msg_cache.lock().await;
+            if let Some((at, v)) = c.get(id)
+                && at.elapsed() < MSG_TTL
+            {
+                return Ok(v.clone());
+            }
+        }
+        let v = self.accessor.get_message_full(id).await?;
+        self.msg_cache
+            .lock()
+            .await
+            .insert(id.to_string(), (Instant::now(), v.clone()));
+        Ok(v)
+    }
+
+    async fn fetch_full_many(&self, ids: &[String]) -> Vec<Value> {
+        stream::iter(ids.iter().cloned())
+            .map(|id| async move { self.message_full(&id).await.ok() })
+            .buffer_unordered(FETCH_CONCURRENCY)
+            .filter_map(|x| async move { x })
+            .collect()
+            .await
+    }
+
+    // ---- readdir levels ---------------------------------------------------
+
+    async fn readdir_labels(&self) -> anyhow::Result<Vec<DirEntry>> {
+        Ok(self
+            .labels()
+            .await?
+            .into_iter()
+            .map(|(display, _)| dir_entry(display))
+            .collect())
+    }
+
+    /// Date dirs present in a label: list the label's messages, bucket by the
+    /// (UTC) received date.
+    async fn readdir_dates(&self, label: &str) -> anyhow::Result<Vec<DirEntry>> {
+        let Some(label_id) = self.label_id(label).await? else {
+            anyhow::bail!("no such label: {label}");
+        };
+        let stubs = self
+            .accessor
+            .list_messages(Some(&label_id), None, MAX_MESSAGES)
+            .await?;
+        let ids: Vec<String> = stubs
+            .iter()
+            .filter_map(|m| m.get("id").and_then(|i| i.as_str()).map(String::from))
+            .collect();
+        // Only internalDate is needed here — use the minimal fetch.
+        let dates: Vec<String> = stream::iter(ids)
+            .map(|id| async move {
+                self.accessor
+                    .get_message_minimal(&id)
+                    .await
+                    .ok()
+                    .and_then(|v| {
+                        v.get("internalDate")
+                            .and_then(|d| d.as_str())
+                            .map(String::from)
+                    })
+                    .map(|ms| epoch_ms_to_date(&ms))
+            })
+            .buffer_unordered(FETCH_CONCURRENCY)
+            .filter_map(|x| async move { x })
+            .collect()
+            .await;
+        let mut set: std::collections::BTreeSet<String> = dates.into_iter().collect();
+        // Fold in older dates the user has already visited (capped listing only
+        // covers the newest ~50 messages).
+        if let Some(seen) = self.seen_dates.lock().await.get(label) {
+            set.extend(seen.iter().cloned());
+        }
+        let mut uniq: Vec<String> = set.into_iter().collect();
+        uniq.sort_by(|a, b| b.cmp(a)); // newest first
+        Ok(uniq.into_iter().map(dir_entry).collect())
+    }
+
+    /// Messages (and per-message attachment dirs) within `<label>/<date>`.
+    async fn readdir_messages(&self, label: &str, date: &str) -> anyhow::Result<Vec<DirEntry>> {
+        let Some(query) = date_dir_to_gmail_query(date) else {
+            anyhow::bail!("invalid date dir: {date}");
+        };
+        let Some(label_id) = self.label_id(label).await? else {
+            anyhow::bail!("no such label: {label}");
+        };
+        let stubs = self
+            .accessor
+            .list_messages(Some(&label_id), Some(&query), MAX_MESSAGES)
+            .await?;
+        let ids: Vec<String> = stubs
+            .iter()
+            .filter_map(|m| m.get("id").and_then(|i| i.as_str()).map(String::from))
+            .collect();
+        // Remember a visited date that actually has mail so the (capped) label
+        // listing folds it in next time it's rebuilt.
+        if !ids.is_empty() {
+            self.seen_dates
+                .lock()
+                .await
+                .entry(label.to_string())
+                .or_default()
+                .insert(date.to_string());
+        }
+        let raws = self.fetch_full_many(&ids).await;
+        let mut out = Vec::new();
+        for raw in &raws {
+            let id = raw.get("id").and_then(|i| i.as_str()).unwrap_or("");
+            if id.is_empty() {
+                continue;
+            }
+            let subject = header(raw, "Subject");
+            let subject = if subject.is_empty() {
+                "No Subject".to_string()
+            } else {
+                subject
+            };
+            let size = raw.get("sizeEstimate").and_then(|s| s.as_u64());
+            out.push(DirEntry {
+                name: msg_filename(&subject, id),
+                kind: FileKind::File,
+                size: size.unwrap_or(0),
+                mtime: None,
+            });
+            if !attachments(raw).is_empty() {
+                out.push(dir_entry(attach_dir_name(&subject, id)));
+            }
+        }
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    /// Attachment files within a message's attachment dir.
+    async fn readdir_attachments(&self, msg_id: &str) -> anyhow::Result<Vec<DirEntry>> {
+        let raw = self.message_full(msg_id).await?;
+        Ok(attachments(&raw)
+            .into_iter()
+            .map(|a| DirEntry {
+                name: a.filename,
+                kind: FileKind::File,
+                size: a.size,
+                mtime: None,
+            })
+            .collect())
+    }
+}
+
+#[async_trait]
+impl Resource for GmailResource {
+    async fn read_bytes(
+        &self,
+        path: &VPath,
+        range: Option<std::ops::Range<u64>>,
+    ) -> anyhow::Result<Vec<u8>> {
+        let seg = segments(path);
+        let data = match seg.as_slice() {
+            // <label>/<date>/<file>.gmail.json -> processed email JSON
+            [_label, _date, file] if file.ends_with(GMAIL_SUFFIX) => {
+                let id = id_from_name(file.trim_end_matches(GMAIL_SUFFIX));
+                let raw = self.message_full(&id).await?;
+                serde_json::to_vec(&process_message(&raw))?
+            }
+            // <label>/<date>/<subject>__<id>/<filename> -> attachment bytes
+            [_label, _date, dir, fname] => {
+                let id = id_from_name(dir);
+                let raw = self.message_full(&id).await?;
+                let att = attachments(&raw)
+                    .into_iter()
+                    .find(|a| &a.filename == fname)
+                    .ok_or_else(|| anyhow::anyhow!("no such attachment: {fname}"))?;
+                self.accessor
+                    .get_attachment(&id, &att.attachment_id)
+                    .await?
+            }
+            _ => anyhow::bail!("is a directory or not a file: {}", path.as_str()),
+        };
+        Ok(slice(data, range))
+    }
+
+    async fn write_bytes(&self, path: &VPath, _data: Vec<u8>) -> anyhow::Result<()> {
+        anyhow::bail!(
+            "gmail file writes not supported; use .cmd/send|reply|reply-all|forward (path was {})",
+            path.as_str()
+        )
+    }
+
+    async fn readdir(&self, path: &VPath) -> anyhow::Result<Vec<DirEntry>> {
+        let seg = segments(path);
+        match seg.as_slice() {
+            [] => self.readdir_labels().await,
+            [label] => self.readdir_dates(label).await,
+            [label, date] => self.readdir_messages(label, date).await,
+            // attachment dir: <label>/<date>/<subject>__<id>
+            [_label, _date, dir] if !dir.ends_with(GMAIL_SUFFIX) => {
+                self.readdir_attachments(&id_from_name(dir)).await
+            }
+            _ => anyhow::bail!("not a directory: {}", path.as_str()),
+        }
+    }
+
+    async fn stat(&self, path: &VPath) -> anyhow::Result<FileStat> {
+        let seg = segments(path);
+        match seg.as_slice() {
+            [] => Ok(dir_stat()),
+            // a label: confirm it exists (cheap, cached) — else ENOENT
+            [label] => {
+                if self.label_id(label).await?.is_some() {
+                    Ok(dir_stat())
+                } else {
+                    anyhow::bail!("no such label: {label}")
+                }
+            }
+            // a date dir: a well-formed yyyy-mm-dd is a (possibly empty) dir
+            [_label, date] => {
+                if date_dir_to_gmail_query(date).is_some() {
+                    Ok(dir_stat())
+                } else {
+                    anyhow::bail!("invalid date dir: {date}")
+                }
+            }
+            // a message file (sentinel size — don't fetch just to size it) or
+            // an attachment dir
+            [_label, _date, name] => {
+                if name.ends_with(GMAIL_SUFFIX) {
+                    Ok(FileStat {
+                        kind: FileKind::File,
+                        size: MSG_SENTINEL_SIZE,
+                        ..Default::default()
+                    })
+                } else {
+                    Ok(dir_stat())
+                }
+            }
+            // an attachment file: exact size from the message's part metadata
+            [_label, _date, dir, fname] => {
+                let raw = self.message_full(&id_from_name(dir)).await?;
+                let att = attachments(&raw)
+                    .into_iter()
+                    .find(|a| &a.filename == fname)
+                    .ok_or_else(|| anyhow::anyhow!("no such attachment: {fname}"))?;
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    size: att.size,
+                    ..Default::default()
+                })
+            }
+            _ => anyhow::bail!("not found: {}", path.as_str()),
+        }
+    }
+
+    /// `rm <…>.gmail.json` moves the message to Trash.
+    async fn unlink(&self, path: &VPath) -> anyhow::Result<()> {
+        let seg = segments(path);
+        match seg.as_slice() {
+            [_label, _date, file] if file.ends_with(GMAIL_SUFFIX) => {
+                let id = id_from_name(file.trim_end_matches(GMAIL_SUFFIX));
+                self.accessor.trash(&id).await?;
+                self.msg_cache.lock().await.remove(&id);
+                Ok(())
+            }
+            _ => anyhow::bail!("only .gmail.json files can be removed: {}", path.as_str()),
+        }
+    }
+
+    async fn command(&self, name: &str, body: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let v: Value = serde_json::from_slice(body)
+            .map_err(|e| anyhow::anyhow!("{name}: invalid JSON: {e}"))?;
+        let s = |k: &str| v.get(k).and_then(|x| x.as_str()).map(String::from);
+        let result = match name {
+            "send" => {
+                let to = s("to").ok_or_else(|| anyhow::anyhow!("send: missing to"))?;
+                let subject = s("subject").unwrap_or_default();
+                let body = s("body").unwrap_or_default();
+                let raw = encode_b64url(&build_mime(&to, None, &subject, &body, &[]));
+                self.accessor.send_raw(&raw, None).await?
+            }
+            "reply" | "reply-all" => {
+                let mid =
+                    s("message_id").ok_or_else(|| anyhow::anyhow!("{name}: missing message_id"))?;
+                let body = s("body").unwrap_or_default();
+                let orig = self.message_full(&mid).await?;
+                let thread_id = orig.get("threadId").and_then(|t| t.as_str());
+                let mut subject = header(&orig, "Subject");
+                if !subject.to_lowercase().starts_with("re:") {
+                    subject = format!("Re: {subject}");
+                }
+                let sender = header(&orig, "From");
+                let to = if name == "reply-all" {
+                    let orig_to = header(&orig, "To");
+                    [sender.as_str(), orig_to.as_str()]
+                        .iter()
+                        .filter(|x| !x.is_empty())
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                } else {
+                    sender
+                };
+                let cc = if name == "reply-all" {
+                    let c = header(&orig, "Cc");
+                    if c.is_empty() { None } else { Some(c) }
+                } else {
+                    None
+                };
+                let msg_id_hdr = header(&orig, "Message-ID");
+                let mut extra: Vec<(&str, String)> = Vec::new();
+                if let Some(cc) = &cc {
+                    extra.push(("Cc", cc.clone()));
+                }
+                if !msg_id_hdr.is_empty() {
+                    extra.push(("In-Reply-To", msg_id_hdr.clone()));
+                    extra.push(("References", msg_id_hdr.clone()));
+                }
+                let raw = encode_b64url(&build_mime(&to, None, &subject, &body, &extra));
+                self.accessor.send_raw(&raw, thread_id).await?
+            }
+            "forward" => {
+                let mid = s("message_id")
+                    .ok_or_else(|| anyhow::anyhow!("forward: missing message_id"))?;
+                let to = s("to").ok_or_else(|| anyhow::anyhow!("forward: missing to"))?;
+                let raw_msg = self.message_full(&mid).await?;
+                let p = process_message(&raw_msg);
+                let mut subject = p
+                    .get("subject")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !subject.to_lowercase().starts_with("fwd:") {
+                    subject = format!("Fwd: {subject}");
+                }
+                let from_email = p
+                    .get("from")
+                    .and_then(|f| f.get("email"))
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("");
+                let date = p.get("date").and_then(|d| d.as_str()).unwrap_or("");
+                let orig_subject = p.get("subject").and_then(|s| s.as_str()).unwrap_or("");
+                let body_text = p.get("body_text").and_then(|b| b.as_str()).unwrap_or("");
+                let fwd = format!(
+                    "---------- Forwarded message ----------\nFrom: {from_email}\nDate: {date}\nSubject: {orig_subject}\n\n{body_text}"
+                );
+                let raw = encode_b64url(&build_mime(&to, None, &subject, &fwd, &[]));
+                self.accessor.send_raw(&raw, None).await?
+            }
+            other => anyhow::bail!("unknown gmail command: {other}"),
+        };
+        Ok(serde_json::to_vec(&result)?)
+    }
+
+    fn prompt(&self) -> &str {
+        GMAIL_PROMPT
+    }
+
+    /// Gmail listings are capped (newest 50 per label/date), so a date or message
+    /// missing from a listing may still exist — disable negative caching so the
+    /// cache probes the adapter (e.g. `ls INBOX/2026-05-01` after `ls INBOX`).
+    fn listings_complete(&self) -> bool {
+        false
+    }
+}
+
+// ---- path helpers ---------------------------------------------------------
+
+/// Mount-relative path segments (`/INBOX/2026-05-03/x.gmail.json` -> 3).
+fn segments(path: &VPath) -> Vec<String> {
+    path.as_str()
+        .trim_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// The message id encoded in a `<subject>__<id>` name (last `__`-separated
+/// field; sanitized subjects use single underscores, the separator is `__`).
+fn id_from_name(name: &str) -> String {
+    name.rsplit_once("__")
+        .map(|(_, id)| id)
+        .unwrap_or(name)
+        .to_string()
+}
+
+fn msg_filename(subject: &str, id: &str) -> String {
+    format!("{}__{id}{GMAIL_SUFFIX}", sanitize(subject))
+}
+
+fn attach_dir_name(subject: &str, id: &str) -> String {
+    format!("{}__{id}", sanitize(subject))
+}
+
+const TITLE_MAX: usize = 80;
+
+/// Sanitize a subject for use as a path segment:
+/// keep word chars / spaces / `-._`, collapse the rest to `_`, spaces->`_`,
+/// squeeze repeats, trim, cap length.
+fn sanitize(text: &str) -> String {
+    if text.trim().is_empty() {
+        return "No_Subject".to_string();
+    }
+    let mut s = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+            s.push(ch);
+        } else if ch.is_whitespace() {
+            s.push('_');
+        } else {
+            s.push('_');
+        }
+    }
+    // squeeze repeated underscores
+    let mut squeezed = String::with_capacity(s.len());
+    let mut prev_us = false;
+    for ch in s.chars() {
+        if ch == '_' {
+            if !prev_us {
+                squeezed.push(ch);
+            }
+            prev_us = true;
+        } else {
+            squeezed.push(ch);
+            prev_us = false;
+        }
+    }
+    let trimmed = squeezed.trim_matches('_');
+    let mut out: String = trimmed.chars().collect();
+    if out.chars().count() > TITLE_MAX {
+        out = out.chars().take(TITLE_MAX - 3).collect::<String>() + "...";
+    }
+    if out.is_empty() {
+        "No_Subject".to_string()
+    } else {
+        out
+    }
+}
+
+// ---- message processing ---------------------------------------------------
+
+struct Attach {
+    filename: String,
+    attachment_id: String,
+    size: u64,
+    mime_type: String,
+}
+
+fn header(raw: &Value, name: &str) -> String {
+    raw.get("payload")
+        .and_then(|p| p.get("headers"))
+        .and_then(|h| h.as_array())
+        .into_iter()
+        .flatten()
+        .find(|h| {
+            h.get("name")
+                .and_then(|n| n.as_str())
+                .map(|n| n.eq_ignore_ascii_case(name))
+                .unwrap_or(false)
+        })
+        .and_then(|h| h.get("value").and_then(|v| v.as_str()))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Recursively decode the first text/plain body part.
+fn decode_body(payload: &Value) -> String {
+    if payload.get("mimeType").and_then(|m| m.as_str()) == Some("text/plain") {
+        if let Some(data) = payload
+            .get("body")
+            .and_then(|b| b.get("data"))
+            .and_then(|d| d.as_str())
+            && !data.is_empty()
+        {
+            let trimmed = data.trim_end_matches('=');
+            if let Ok(bytes) =
+                base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, trimmed)
+            {
+                return String::from_utf8_lossy(&bytes).into_owned();
+            }
+        }
+    }
+    if let Some(parts) = payload.get("parts").and_then(|p| p.as_array()) {
+        for part in parts {
+            let t = decode_body(part);
+            if !t.is_empty() {
+                return t;
+            }
+        }
+    }
+    String::new()
+}
+
+fn parse_address(raw: &str) -> Value {
+    let raw = raw.trim();
+    if let (Some(lt), Some(gt)) = (raw.find('<'), raw.find('>'))
+        && lt < gt
+    {
+        let name = raw[..lt].trim().trim_matches('"').to_string();
+        let email = raw[lt + 1..gt].trim().to_string();
+        return json!({ "name": name, "email": email });
+    }
+    json!({ "name": "", "email": raw })
+}
+
+fn parse_address_list(raw: &str) -> Value {
+    if raw.trim().is_empty() {
+        return json!([]);
+    }
+    Value::Array(raw.split(',').map(|a| parse_address(a.trim())).collect())
+}
+
+fn attachments(raw: &Value) -> Vec<Attach> {
+    let mut out = Vec::new();
+    let mut push_part = |part: &Value| {
+        let filename = part.get("filename").and_then(|f| f.as_str()).unwrap_or("");
+        let body = part.get("body");
+        let aid = body
+            .and_then(|b| b.get("attachmentId"))
+            .and_then(|a| a.as_str())
+            .unwrap_or("");
+        if !filename.is_empty() && !aid.is_empty() {
+            out.push(Attach {
+                filename: filename.to_string(),
+                attachment_id: aid.to_string(),
+                size: body
+                    .and_then(|b| b.get("size"))
+                    .and_then(|s| s.as_u64())
+                    .unwrap_or(0),
+                mime_type: part
+                    .get("mimeType")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    };
+    if let Some(parts) = raw
+        .get("payload")
+        .and_then(|p| p.get("parts"))
+        .and_then(|p| p.as_array())
+    {
+        for part in parts {
+            push_part(part);
+            if let Some(subs) = part.get("parts").and_then(|p| p.as_array()) {
+                for sub in subs {
+                    push_part(sub);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build the processed email JSON (the `.gmail.json` content).
+fn process_message(raw: &Value) -> Value {
+    let payload = raw.get("payload").cloned().unwrap_or(Value::Null);
+    let body_text = decode_body(&payload);
+    let atts: Vec<Value> = attachments(raw)
+        .into_iter()
+        .map(|a| {
+            json!({
+                "id": a.attachment_id,
+                "filename": a.filename,
+                "mime_type": a.mime_type,
+                "size": a.size,
+            })
+        })
+        .collect();
+    json!({
+        "id": raw.get("id").and_then(|i| i.as_str()).unwrap_or(""),
+        "thread_id": raw.get("threadId").and_then(|i| i.as_str()).unwrap_or(""),
+        "from": parse_address(&header(raw, "From")),
+        "to": parse_address_list(&header(raw, "To")),
+        "cc": parse_address_list(&header(raw, "Cc")),
+        "subject": header(raw, "Subject"),
+        "date": header(raw, "Date"),
+        "body_text": body_text,
+        "snippet": raw.get("snippet").and_then(|s| s.as_str()).unwrap_or(""),
+        "labels": raw.get("labelIds").cloned().unwrap_or(json!([])),
+        "attachments": atts,
+    })
+}
+
+// ---- MIME build (RFC 2822) ------------------------------------------------
+
+/// Build a minimal text/plain RFC-2822 message. Non-ASCII subjects are RFC-2047
+/// encoded so they survive transport.
+fn build_mime(
+    to: &str,
+    from: Option<&str>,
+    subject: &str,
+    body: &str,
+    extra_headers: &[(&str, String)],
+) -> Vec<u8> {
+    let mut h = String::new();
+    if let Some(f) = from {
+        h.push_str(&format!("From: {f}\r\n"));
+    }
+    h.push_str(&format!("To: {to}\r\n"));
+    h.push_str(&format!("Subject: {}\r\n", encode_header(subject)));
+    for (k, v) in extra_headers {
+        h.push_str(&format!("{k}: {v}\r\n"));
+    }
+    h.push_str("MIME-Version: 1.0\r\n");
+    h.push_str("Content-Type: text/plain; charset=\"utf-8\"\r\n");
+    h.push_str("Content-Transfer-Encoding: 8bit\r\n");
+    h.push_str("\r\n");
+    let mut bytes = h.into_bytes();
+    bytes.extend_from_slice(body.as_bytes());
+    bytes
+}
+
+/// RFC-2047-encode a header value if it contains non-ASCII; else pass through.
+fn encode_header(value: &str) -> String {
+    if value.is_ascii() {
+        return value.to_string();
+    }
+    let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, value.as_bytes());
+    format!("=?UTF-8?B?{b64}?=")
+}
+
+// ---- date helpers (dependency-free civil calendar) ------------------------
+
+/// Gmail `internalDate` (epoch ms, string) -> `YYYY-MM-DD` in UTC.
+fn epoch_ms_to_date(ms: &str) -> String {
+    let ms: i64 = ms.parse().unwrap_or(0);
+    let days = (ms / 1000).div_euclid(86400);
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// `YYYY-MM-DD` date dir -> a one-day Gmail `after:/before:` query (cheap server
+/// -side narrowing), or `None` if not a valid date.
+fn date_dir_to_gmail_query(name: &str) -> Option<String> {
+    let parts: Vec<&str> = name.split('-').collect();
+    if parts.len() != 3 || parts[0].len() != 4 || parts[1].len() != 2 || parts[2].len() != 2 {
+        return None;
+    }
+    let y: i64 = parts[0].parse().ok()?;
+    let m: u32 = parts[1].parse().ok()?;
+    let d: u32 = parts[2].parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    let days = days_from_civil(y, m as i64, d as i64);
+    let (ny, nm, nd) = civil_from_days(days + 1);
+    Some(format!(
+        "after:{y}/{m:02}/{d:02} before:{ny}/{nm:02}/{nd:02}"
+    ))
+}
+
+/// Days since 1970-01-01 -> (year, month, day). Howard Hinnant's algorithm.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = z - era * 146097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// (year, month, day) -> days since 1970-01-01. Howard Hinnant's algorithm.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = (if y >= 0 { y } else { y - 399 }) / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let mp = (m + 9) % 12; // [0, 11]
+    let doy = (153 * mp + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146097 + doe - 719468
+}
+
+// ---- small builders -------------------------------------------------------
+
+fn dir_entry(name: String) -> DirEntry {
+    DirEntry {
+        name,
+        kind: FileKind::Dir,
+        size: 0,
+        mtime: None,
+    }
+}
+
+fn dir_stat() -> FileStat {
+    FileStat {
+        kind: FileKind::Dir,
+        ..Default::default()
+    }
+}
+
+fn slice(data: Vec<u8>, range: Option<std::ops::Range<u64>>) -> Vec<u8> {
+    match range {
+        Some(r) => {
+            let start = (r.start as usize).min(data.len());
+            let end = (r.end as usize).min(data.len());
+            data[start..end].to_vec()
+        }
+        None => data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+
+    use super::*;
+
+    #[test]
+    fn sanitize_subject_rules() {
+        assert_eq!(sanitize("Hello World"), "Hello_World");
+        assert_eq!(sanitize("Re: [urgent] ping!"), "Re_urgent_ping");
+        assert_eq!(sanitize("a / b \\ c"), "a_b_c");
+        assert_eq!(sanitize("   "), "No_Subject");
+        assert_eq!(sanitize(""), "No_Subject");
+        // keeps word chars, dash, dot, underscore
+        assert_eq!(sanitize("file-name.v2_final"), "file-name.v2_final");
+        // length cap (80) with ellipsis
+        let long = "x".repeat(100);
+        let s = sanitize(&long);
+        assert_eq!(s.chars().count(), 80);
+        assert!(s.ends_with("..."));
+    }
+
+    #[test]
+    fn id_parsed_from_last_double_underscore() {
+        assert_eq!(id_from_name("Subject__abc123"), "abc123");
+        // single underscores in the (sanitized) subject don't confuse it
+        assert_eq!(id_from_name("a_b_c__99zz"), "99zz");
+        assert_eq!(id_from_name("Re_urgent_ping__ff00ab"), "ff00ab");
+        // no separator -> the whole name
+        assert_eq!(id_from_name("noseparator"), "noseparator");
+        // round-trips with the filename builders
+        assert_eq!(
+            id_from_name(&msg_filename("Hi there", "ID42").trim_end_matches(GMAIL_SUFFIX)),
+            "ID42"
+        );
+        assert_eq!(id_from_name(&attach_dir_name("Hi there", "ID42")), "ID42");
+    }
+
+    #[test]
+    fn epoch_ms_to_date_anchors() {
+        assert_eq!(epoch_ms_to_date("0"), "1970-01-01");
+        // 2026-05-03T10:00:00Z = 1777800000 s
+        assert_eq!(epoch_ms_to_date("1777802400000"), "2026-05-03");
+        assert_eq!(epoch_ms_to_date("bogus"), "1970-01-01");
+    }
+
+    #[test]
+    fn date_query_narrowing_and_rollover() {
+        assert_eq!(
+            date_dir_to_gmail_query("2026-05-03").as_deref(),
+            Some("after:2026/05/03 before:2026/05/04")
+        );
+        // month rollover
+        assert_eq!(
+            date_dir_to_gmail_query("2026-01-31").as_deref(),
+            Some("after:2026/01/31 before:2026/02/01")
+        );
+        // year rollover
+        assert_eq!(
+            date_dir_to_gmail_query("2026-12-31").as_deref(),
+            Some("after:2026/12/31 before:2027/01/01")
+        );
+        // invalid shapes -> None
+        assert!(date_dir_to_gmail_query("2026-5-3").is_none());
+        assert!(date_dir_to_gmail_query("not-a-date").is_none());
+        assert!(date_dir_to_gmail_query("2026-13-01").is_none());
+    }
+
+    #[test]
+    fn civil_calendar_roundtrips() {
+        for &(y, m, d) in &[
+            (1970, 1, 1),
+            (2000, 2, 29),
+            (2026, 5, 3),
+            (2027, 1, 1),
+            (1999, 12, 31),
+        ] {
+            let days = days_from_civil(y, m, d);
+            assert_eq!(civil_from_days(days), (y, m as u32, d as u32));
+        }
+    }
+
+    #[test]
+    fn process_message_shapes_the_email() {
+        // a minimal raw Gmail message with a plain-text body and one attachment
+        let body_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"hello body");
+        let raw = json!({
+            "id": "m1",
+            "threadId": "t1",
+            "snippet": "hello",
+            "labelIds": ["INBOX", "IMPORTANT"],
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "Alice <alice@example.com>"},
+                    {"name": "To", "value": "bob@example.com, carol@example.com"},
+                    {"name": "Subject", "value": "Hi"},
+                    {"name": "Date", "value": "Mon, 3 May 2026 10:00:00 -0700"}
+                ],
+                "parts": [
+                    {"mimeType": "text/plain", "body": {"data": body_b64}},
+                    {"filename": "a.pdf", "mimeType": "application/pdf",
+                     "body": {"attachmentId": "att1", "size": 12345}}
+                ]
+            }
+        });
+        let p = process_message(&raw);
+        assert_eq!(p["id"], "m1");
+        assert_eq!(p["thread_id"], "t1");
+        assert_eq!(p["from"]["name"], "Alice");
+        assert_eq!(p["from"]["email"], "alice@example.com");
+        assert_eq!(p["to"].as_array().unwrap().len(), 2);
+        assert_eq!(p["subject"], "Hi");
+        assert_eq!(p["body_text"], "hello body");
+        assert_eq!(p["labels"], json!(["INBOX", "IMPORTANT"]));
+        let atts = p["attachments"].as_array().unwrap();
+        assert_eq!(atts.len(), 1);
+        assert_eq!(atts[0]["filename"], "a.pdf");
+        assert_eq!(atts[0]["id"], "att1");
+        assert_eq!(atts[0]["size"], 12345);
+    }
+
+    #[test]
+    fn build_mime_encodes_nonascii_subject() {
+        let bytes = build_mime("to@x.com", None, "안녕 hi", "body", &[]);
+        let s = String::from_utf8_lossy(&bytes);
+        assert!(s.contains("To: to@x.com\r\n"));
+        assert!(
+            s.contains("Subject: =?UTF-8?B?"),
+            "non-ascii subject must be RFC-2047 encoded"
+        );
+        assert!(s.ends_with("body"));
+        // ascii subject passes through
+        let bytes = build_mime("to@x.com", None, "Plain", "b", &[]);
+        assert!(String::from_utf8_lossy(&bytes).contains("Subject: Plain\r\n"));
+    }
+}
+
+const GMAIL_PROMPT: &str = "\
+Gmail (read + send/reply/forward, trash on delete). Layout:
+  <label>/<yyyy-mm-dd>/<subject>__<message-id>.gmail.json   # the email (JSON)
+  <label>/<yyyy-mm-dd>/<subject>__<message-id>/<filename>   # attachments (only if any)
+
+  <label>       INBOX, SENT, DRAFT, IMPORTANT, STARRED, TRASH, SPAM, or a user label
+  <yyyy-mm-dd>  received date; `ls <label>/2026-05-03/` narrows the Gmail query
+                server-side (after:/before:) — far cheaper than scanning the label
+  <subject>     sanitized subject (don't construct it; ls the date dir)
+  <message-id>  Gmail message id (the field after the last `__`)
+
+  cat <…>.gmail.json (keep the suffix) returns:
+    {\"id\",\"thread_id\",\"from\":{\"name\",\"email\"},\"to\":[…],\"cc\":[…],
+     \"subject\",\"date\",\"body_text\",\"snippet\",\"labels\":[…],
+     \"attachments\":[{\"id\",\"filename\",\"mime_type\",\"size\"}]}
+  The sibling dir (same name without .gmail.json) holds attachment bytes; cat a
+  file inside to download it. ENOENT there means the message has no attachments.
+
+  rm <…>.gmail.json    moves the message to Trash (only .gmail.json is removable).
+
+  Write via control-path JSON (echo '{…}' > .cmd/<op>):
+    .cmd/send        {\"to\":\"a@b.com\",\"subject\":\"Hi\",\"body\":\"…\"}
+    .cmd/reply       {\"message_id\":\"<id>\",\"body\":\"…\"}
+    .cmd/reply-all   {\"message_id\":\"<id>\",\"body\":\"…\"}
+    .cmd/forward     {\"message_id\":\"<id>\",\"to\":\"a@b.com\"}";

--- a/src/vfs/resource/mod.rs
+++ b/src/vfs/resource/mod.rs
@@ -1,9 +1,11 @@
 mod base;
 mod gdrive;
+mod gmail;
 mod notion;
 mod s3;
 
 pub use base::{DirEntry, FileKind, FileStat, Resource};
 pub use gdrive::GDriveResource;
+pub use gmail::GmailResource;
 pub use notion::NotionResource;
 pub use s3::S3Resource;

--- a/src/vfs/vfs.rs
+++ b/src/vfs/vfs.rs
@@ -6,10 +6,10 @@ use crate::{
     runenv::RunEnv,
     vfs::{
         VfsMount,
-        accessor::{GDriveConfig, NotionConfig, S3Config},
+        accessor::{GDriveConfig, GmailConfig, NotionConfig, S3Config},
         cache::CachedResource,
         path::VPath,
-        resource::{GDriveResource, NotionResource, Resource, S3Resource},
+        resource::{GDriveResource, GmailResource, NotionResource, Resource, S3Resource},
     },
 };
 
@@ -19,6 +19,7 @@ pub enum ProviderConfig {
     S3(S3Config),
     Notion(NotionConfig),
     GDrive(GDriveConfig),
+    Gmail(GmailConfig),
 }
 
 /// One mount: a virtual top-level prefix bound to a provider config. The same
@@ -77,6 +78,7 @@ impl Vfs {
                 ProviderConfig::S3(c) => Arc::new(S3Resource::new(&c)?),
                 ProviderConfig::Notion(c) => Arc::new(NotionResource::new(&c)?),
                 ProviderConfig::GDrive(c) => Arc::new(GDriveResource::new(&c)?),
+                ProviderConfig::Gmail(c) => Arc::new(GmailResource::new(&c)?),
             };
             // Wrap every provider in the metadata index cache so `stat` after a
             // `readdir` (e.g. `ls -la`) is served from memory in both frontends.

--- a/tests/vfs/common.rs
+++ b/tests/vfs/common.rs
@@ -171,6 +171,16 @@ pub fn all_vfs() -> VfsConfig {
         mounts.push(MountSpec {
             prefix: "/gdrive".into(),
             provider: ProviderConfig::GDrive(ailoy::vfs::GDriveConfig {
+                client_id: client_id.clone(),
+                client_secret: client_secret.clone(),
+                refresh_token: refresh_token.clone(),
+            }),
+        });
+        // Gmail shares the same Google OAuth creds; needs a token whose scope
+        // covers Gmail (e.g. gmail.modify).
+        mounts.push(MountSpec {
+            prefix: "/gmail".into(),
+            provider: ProviderConfig::Gmail(ailoy::vfs::GmailConfig {
                 client_id,
                 client_secret,
                 refresh_token,
@@ -180,10 +190,18 @@ pub fn all_vfs() -> VfsConfig {
     VfsConfig { mounts }
 }
 
-/// Whether a mount prefix ("/s3", "/notion", "/gdrive") is configured in the
-/// current environment — lets a test skip a provider it has no creds for.
+/// Whether a mount prefix ("/s3", "/notion", "/gdrive", "/gmail") is configured
+/// in the current environment — lets a test skip a provider it has no creds for.
 pub fn has_mount(prefix: &str) -> bool {
     all_vfs().mounts.iter().any(|m| m.prefix == prefix)
+}
+
+/// The configured mount prefixes (e.g. `["/s3", "/notion", "/gdrive", "/gmail"]`)
+/// for the current environment, in config order. Lets the inspector hints list
+/// exactly the providers that are actually mounted, derived from [`all_vfs`]
+/// instead of a hardcoded set.
+pub fn mount_prefixes() -> Vec<String> {
+    all_vfs().mounts.iter().map(|m| m.prefix.clone()).collect()
 }
 
 pub fn tail(s: &str, n: usize) -> String {
@@ -201,7 +219,9 @@ pub fn msb_rm(name: &str) {
     let _ = std::process::Command::new("msb")
         .args(["stop", name])
         .status();
-    let _ = std::process::Command::new("msb").args(["rm", name]).status();
+    let _ = std::process::Command::new("msb")
+        .args(["rm", name])
+        .status();
 }
 
 /// Run a shell script in the guest via `msb exec` (60s bound); return stdout.
@@ -302,6 +322,9 @@ pub async fn launch_static_forwarder(h: &RunEnvHandle, port: u16, tok: &str) {
          for _ in $(seq 1 40); do grep -q ' /mnt/vfs ' /proc/mounts && break; sleep 0.25; done; \
          mount | grep -q /mnt/vfs && echo MOUNTED || echo NOT_MOUNTED"
     );
-    let out = h.exec_shell(launch, Some(60)).await.expect("launch forwarder");
+    let out = h
+        .exec_shell(launch, Some(60))
+        .await
+        .expect("launch forwarder");
     println!("launch: {}", out.stdout.trim());
 }

--- a/tests/vfs/host.rs
+++ b/tests/vfs/host.rs
@@ -78,13 +78,21 @@ async fn vfs_inspect_host() {
 
     println!("\n================ VFS INSPECT (HOST FUSE) ================");
     println!("host mount   : {mount}");
-    println!("mounts       : {mount}/{{s3,notion,gdrive}}");
+    let prefixes = mount_prefixes();
+    println!(
+        "mounts       : {}",
+        prefixes
+            .iter()
+            .map(|p| format!("{mount}{p}"))
+            .collect::<Vec<_>>()
+            .join("  ")
+    );
     println!("inspect from another terminal (plain host shell, no sandbox):");
     println!("  mount | grep -i fuse");
     println!("  ls -la {mount}");
-    println!("  ls {mount}/s3");
-    println!("  ls {mount}/notion/pages");
-    println!("  ls {mount}/gdrive | head");
+    for p in &prefixes {
+        println!("  ls {mount}{p}");
+    }
     println!("sleeping 1h. Ctrl-C this process when done, then unmount:");
     println!("  umount {mount}   # or: diskutil unmount {mount}");
     println!("========================================================\n");

--- a/tests/vfs/providers.rs
+++ b/tests/vfs/providers.rs
@@ -522,3 +522,389 @@ async fn gdrive_read_and_command_smoke() {
         }
     }
 }
+
+/// Direct smoke test of the Gmail adapter: list labels, descend a label into its
+/// date dirs, read an email `.gmail.json` (asserting the processed shape),
+/// and best-effort read one attachment. A scope/enablement problem (the token
+/// lacking Gmail access) is reported and treated as a soft skip — it's an
+/// external-config issue, not an adapter bug.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: needs GOOGLE_* refresh token with a Gmail scope (gmail.modify)"]
+async fn gmail_labels_dates_and_read_smoke() {
+    dotenvy::dotenv().ok();
+    if !has_mount("/gmail") {
+        eprintln!("no google creds — skipping");
+        return;
+    }
+    let vfs = Vfs::from_config(all_vfs()).unwrap();
+
+    // Labels (root readdir). A 403 here means the refresh token has no Gmail
+    // scope — surface it clearly and skip (not an adapter failure).
+    let (res, vp) = vfs.route("/gmail").expect("route gmail");
+    let labels = match res.readdir(&vp).await {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!(
+                "NOTE: gmail readdir failed — likely the refresh token lacks a \
+                 Gmail scope (re-issue with gmail.modify): {e}"
+            );
+            return;
+        }
+    };
+    let names: Vec<&str> = labels.iter().map(|e| e.name.as_str()).collect();
+    println!("gmail labels: {names:?}");
+    assert!(
+        labels.iter().all(|e| e.kind == FileKind::Dir),
+        "labels must be directories"
+    );
+    assert!(
+        names.contains(&"INBOX"),
+        "expected the INBOX system label, got {names:?}"
+    );
+
+    // Dates within INBOX.
+    let (res, vp) = vfs.route("/gmail/INBOX").expect("route INBOX");
+    let dates = res.readdir(&vp).await.expect("readdir INBOX");
+    println!(
+        "INBOX dates ({}, newest first): {:?}",
+        dates.len(),
+        dates.iter().take(5).map(|e| &e.name).collect::<Vec<_>>()
+    );
+    let Some(date) = dates.first() else {
+        println!("NOTE: INBOX is empty — read/attachment checks skipped");
+        return;
+    };
+    // Date dirs must be yyyy-mm-dd and sorted newest-first.
+    assert!(
+        date.name.len() == 10 && date.name.as_bytes()[4] == b'-',
+        "date dir should be yyyy-mm-dd, got {}",
+        date.name
+    );
+
+    // Messages within that date.
+    let (res, vp) = vfs
+        .route(&format!("/gmail/INBOX/{}", date.name))
+        .expect("route date");
+    let entries = res.readdir(&vp).await.expect("readdir date");
+    let msg = entries
+        .iter()
+        .find(|e| e.name.ends_with(".gmail.json"))
+        .expect("a date dir must contain at least one .gmail.json");
+    println!("first message file: {}", msg.name);
+
+    // Read the email JSON and assert the processed schema.
+    let (res, vp) = vfs
+        .route(&format!("/gmail/INBOX/{}/{}", date.name, msg.name))
+        .expect("route msg");
+    let data = res.read_bytes(&vp, None).await.expect("read .gmail.json");
+    let email: serde_json::Value = serde_json::from_slice(&data).expect("valid email JSON");
+    for k in [
+        "id",
+        "thread_id",
+        "from",
+        "to",
+        "cc",
+        "subject",
+        "date",
+        "body_text",
+        "snippet",
+        "labels",
+        "attachments",
+    ] {
+        assert!(email.get(k).is_some(), ".gmail.json missing key `{k}`");
+    }
+    assert!(
+        email.get("from").and_then(|f| f.get("email")).is_some(),
+        "from must be {{name,email}}"
+    );
+    println!(
+        "read email: from={:?} subject={:?}",
+        email["from"]["email"], email["subject"]
+    );
+
+    // A ranged read must slice (direct_io reads aren't clamped to stat size).
+    let head = res.read_bytes(&vp, Some(0..1)).await.expect("ranged read");
+    assert_eq!(head, b"{", "email JSON should start with '{{'");
+
+    // Best-effort: if this message has attachments, list + read the first.
+    let atts = email["attachments"].as_array().cloned().unwrap_or_default();
+    if !atts.is_empty() {
+        let dir = msg.name.trim_end_matches(".gmail.json");
+        let (res, vp) = vfs
+            .route(&format!("/gmail/INBOX/{}/{}", date.name, dir))
+            .expect("route attach dir");
+        let files = res.readdir(&vp).await.expect("readdir attachments");
+        assert!(!files.is_empty(), "attachment dir should list files");
+        let f = &files[0];
+        let (res, vp) = vfs
+            .route(&format!("/gmail/INBOX/{}/{}/{}", date.name, dir, f.name))
+            .expect("route attachment");
+        let bytes = res.read_bytes(&vp, None).await.expect("read attachment");
+        println!(
+            "attachment {} -> {} bytes (stat size {})",
+            f.name,
+            bytes.len(),
+            f.size
+        );
+        assert_eq!(
+            bytes.len() as u64,
+            f.size,
+            "attachment bytes should match its stat size"
+        );
+    } else {
+        println!("(message has no attachments — attachment read skipped)");
+    }
+}
+
+/// Direct smoke test of the Gmail `.cmd/send` control write. Gated on
+/// `GMAIL_TEST_TO` so it never emails a random address; sends a one-off message
+/// and asserts the API returns a message id.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: sends a real email — needs GOOGLE_* (gmail.send/modify) + GMAIL_TEST_TO"]
+async fn gmail_command_send_smoke() {
+    dotenvy::dotenv().ok();
+    if !has_mount("/gmail") {
+        eprintln!("no google creds — skipping");
+        return;
+    }
+    let Ok(to) = std::env::var("GMAIL_TEST_TO") else {
+        eprintln!("set GMAIL_TEST_TO=you@example.com to exercise gmail send — skipping");
+        return;
+    };
+    let vfs = Vfs::from_config(all_vfs()).unwrap();
+    let (res, _) = vfs.route("/gmail/.cmd/send").expect("route .cmd/send");
+    let body = serde_json::json!({
+        "to": to,
+        "subject": format!("ailoy vfs gmail smoke {}", stamp()),
+        "body": "Sent by the ailoy vfs gmail adapter test.\n",
+    });
+    match res.command("send", body.to_string().as_bytes()).await {
+        Ok(result) => {
+            let v: serde_json::Value = serde_json::from_slice(&result).unwrap();
+            let id = v.get("id").and_then(|x| x.as_str());
+            assert!(id.is_some(), "send response should carry a message id: {v}");
+            println!(
+                "gmail send OK -> id={:?} thread={:?}",
+                id,
+                v.get("threadId")
+            );
+        }
+        Err(e) => {
+            println!(
+                "NOTE: gmail send reached the API but failed (token gmail.send \
+                 scope / enablement): {e}"
+            );
+        }
+    }
+}
+
+/// Live test of the Gmail reply / reply-all / forward control writes. Seeds a
+/// message to `GMAIL_TEST_TO` (use your own address), then drives each threaded
+/// send off that seed's id and asserts the API returns an id — and that reply /
+/// reply-all stay in the seed's thread. Sends real email; gated on GMAIL_TEST_TO.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: sends real emails — needs GOOGLE_* (gmail.modify) + GMAIL_TEST_TO"]
+async fn gmail_reply_forward_smoke() {
+    dotenvy::dotenv().ok();
+    if !has_mount("/gmail") {
+        eprintln!("no google creds — skipping");
+        return;
+    }
+    let Ok(to) = std::env::var("GMAIL_TEST_TO") else {
+        eprintln!("set GMAIL_TEST_TO=you@example.com to exercise reply/forward — skipping");
+        return;
+    };
+    let vfs = Vfs::from_config(all_vfs()).unwrap();
+    let (res, _) = vfs.route("/gmail/.cmd/send").expect("route gmail .cmd");
+
+    let cmd = |op: &'static str, body: serde_json::Value| {
+        let res = res.clone();
+        async move {
+            let out = res
+                .command(op, body.to_string().as_bytes())
+                .await
+                .unwrap_or_else(|e| panic!("{op} failed: {e}"));
+            serde_json::from_slice::<serde_json::Value>(&out).expect("json result")
+        }
+    };
+
+    // Seed a message we own, so reply/forward have a real original to thread off.
+    let seed = cmd(
+        "send",
+        serde_json::json!({
+            "to": to,
+            "subject": format!("ailoy reply/fwd seed {}", stamp()),
+            "body": "seed for reply/forward smoke\n",
+        }),
+    )
+    .await;
+    let seed_id = seed["id"].as_str().expect("seed id").to_string();
+    let seed_thread = seed["threadId"].as_str().map(String::from);
+    println!("seed id={seed_id} thread={seed_thread:?}");
+
+    // reply — must carry an id and stay in the seed's thread.
+    let r = cmd(
+        "reply",
+        serde_json::json!({"message_id": seed_id, "body": "live reply\n"}),
+    )
+    .await;
+    assert!(r["id"].as_str().is_some(), "reply must return an id: {r}");
+    if let Some(t) = &seed_thread {
+        assert_eq!(
+            r["threadId"].as_str(),
+            Some(t.as_str()),
+            "reply must stay in-thread"
+        );
+    }
+    println!("reply id={:?} thread={:?}", r["id"], r["threadId"]);
+
+    // reply-all — same threading guarantee.
+    let ra = cmd(
+        "reply-all",
+        serde_json::json!({"message_id": seed_id, "body": "live reply-all\n"}),
+    )
+    .await;
+    assert!(
+        ra["id"].as_str().is_some(),
+        "reply-all must return an id: {ra}"
+    );
+    if let Some(t) = &seed_thread {
+        assert_eq!(
+            ra["threadId"].as_str(),
+            Some(t.as_str()),
+            "reply-all must stay in-thread"
+        );
+    }
+    println!("reply-all id={:?} thread={:?}", ra["id"], ra["threadId"]);
+
+    // forward — a fresh message (new thread) to the recipient.
+    let f = cmd(
+        "forward",
+        serde_json::json!({"message_id": seed_id, "to": to}),
+    )
+    .await;
+    assert!(f["id"].as_str().is_some(), "forward must return an id: {f}");
+    println!("forward id={:?} thread={:?}", f["id"], f["threadId"]);
+    println!("gmail reply / reply-all / forward OK ✅");
+}
+
+/// Regression: Gmail listings are capped (newest 50), so a date dir absent from
+/// the label-level listing must still be reachable. Reproduces the host-mount
+/// flow — list the parent (populating the cache), then `stat`/`readdir` an older
+/// date — which previously hit the cache's negative-ENOENT shortcut and failed
+/// with "No such file or directory". A far-past date keeps this independent of
+/// the live mailbox's contents.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: needs GOOGLE_* with a Gmail scope (gmail.modify)"]
+async fn gmail_capped_listing_does_not_hide_older_dates() {
+    dotenvy::dotenv().ok();
+    if !has_mount("/gmail") {
+        eprintln!("no google creds — skipping");
+        return;
+    }
+    let vfs = Vfs::from_config(all_vfs()).unwrap();
+
+    // Populate the cache exactly like `ls /gmail/INBOX` does (capped listing).
+    let (res, vp) = vfs.route("/gmail/INBOX").expect("route INBOX");
+    if let Err(e) = res.readdir(&vp).await {
+        eprintln!("NOTE: gmail readdir failed (token Gmail scope?): {e} — skipping");
+        return;
+    }
+
+    // A date not in that capped listing must NOT be negative-cached as absent:
+    // stat must resolve it as a directory (the mount's `lookup` step), and
+    // readdir must succeed (date-narrowed query), not ENOENT.
+    let (res, vp) = vfs
+        .route("/gmail/INBOX/2020-01-01")
+        .expect("route old date");
+    let st = res
+        .stat(&vp)
+        .await
+        .expect("stat of an older date dir must not be negative-cached to ENOENT");
+    assert_eq!(st.kind, FileKind::Dir, "a valid date path is a directory");
+    // The date-narrowed listing resolves (likely empty for a far-past day).
+    let entries = res
+        .readdir(&vp)
+        .await
+        .expect("readdir of an older date dir");
+    println!(
+        "/gmail/INBOX/2020-01-01 reachable after capped INBOX listing: {} entries",
+        entries.len()
+    );
+}
+
+/// Once an older date dir has been visited via `ls <label>/<date>` and turned
+/// out to have mail, it should be folded into the (capped) label listing on the
+/// next `ls <label>` — incrementally, and so tab-completion can offer it. Uses
+/// the same Vfs instance so the cache is shared, mirroring a live shell session.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: needs GOOGLE_* with a Gmail scope (gmail.modify)"]
+async fn gmail_visited_dates_fold_into_label_listing() {
+    dotenvy::dotenv().ok();
+    if !has_mount("/gmail") {
+        eprintln!("no google creds — skipping");
+        return;
+    }
+    let vfs = Vfs::from_config(all_vfs()).unwrap();
+    let inbox_dates = || {
+        let vfs = &vfs;
+        async move {
+            let (res, vp) = vfs.route("/gmail/INBOX").unwrap();
+            res.readdir(&vp)
+                .await
+                .map(|e| e.into_iter().map(|d| d.name).collect::<Vec<_>>())
+        }
+    };
+
+    let before = match inbox_dates().await {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("NOTE: gmail readdir failed (token Gmail scope?): {e} — skipping");
+            return;
+        }
+    };
+    println!("INBOX before: {before:?}");
+
+    // Find an older date (not already shown) that has mail, and visit it.
+    let candidates = [
+        "2026-06-01",
+        "2026-05-15",
+        "2026-05-01",
+        "2026-04-15",
+        "2026-04-01",
+        "2026-03-01",
+    ];
+    let mut visited: Option<String> = None;
+    for d in candidates {
+        if before.iter().any(|x| x == d) {
+            continue;
+        }
+        let (res, vp) = vfs.route(&format!("/gmail/INBOX/{d}")).unwrap();
+        let msgs = res
+            .readdir(&vp)
+            .await
+            .map(|e| e.iter().filter(|x| x.name.ends_with(".gmail.json")).count())
+            .unwrap_or(0);
+        if msgs > 0 {
+            println!("visited older date {d} -> {msgs} message(s)");
+            visited = Some(d.to_string());
+            break;
+        }
+    }
+    let Some(d) = visited else {
+        println!("no older date with mail among candidates — skipping incremental assert");
+        return;
+    };
+
+    // Re-list INBOX: the visited older date must now be folded in.
+    let after = inbox_dates().await.expect("readdir INBOX again");
+    println!("INBOX after: {after:?}");
+    assert!(
+        after.contains(&d),
+        "visited older date {d} should now appear in the INBOX listing: {after:?}"
+    );
+    assert!(
+        after.len() > before.len() || before.contains(&d),
+        "listing should have grown to include {d}"
+    );
+}

--- a/tests/vfs/sandbox.rs
+++ b/tests/vfs/sandbox.rs
@@ -603,10 +603,9 @@ async fn vfs_cmd_write_through_forwarder() {
 }
 
 /// Holds a NAMED sandbox (`ailoy-vfs-inspect`) with every configured provider
-/// mounted under /mnt/vfs, so you can poke it from another terminal:
+/// mounted under /mnt/vfs, so you can poke it from another terminal (the test
+/// prints one `ls` hint per configured mount on startup, e.g.):
 ///   msb exec ailoy-vfs-inspect -- sh -c 'ls /mnt/vfs/s3'
-///   msb exec ailoy-vfs-inspect -- sh -c 'ls /mnt/vfs/notion/pages'
-///   msb exec ailoy-vfs-inspect -- sh -c 'ls /mnt/vfs/gdrive | head'
 ///
 /// Starts clean before booting: a VM from a prior run can outlive its process
 /// (the sandbox supervisor survives a non-graceful exit), and the fixed name
@@ -628,26 +627,53 @@ async fn vfs_inspect_sandbox() {
     // Clear any stale instance from a prior run so we always boot fresh (see above).
     msb_rm(name);
 
-    let agent = attach_mounted_agent(name).await;
+    // Install the Ctrl-C teardown BEFORE the (slow) boot, so even a Ctrl-C during
+    // setup tears the VM down. The VM is hosted by a separate `msb sandbox`
+    // supervisor that outlives this process, so cleanup must run `msb stop`+`rm`.
+    // That takes ~10-18s; we detach it into its own process group and do NOT wait,
+    // so a second Ctrl-C (or this process being killed) cannot abort it mid-way —
+    // it completes independently. A non-detached, in-process teardown was the leak.
+    tokio::spawn({
+        let name = name.to_string();
+        async move {
+            let _ = tokio::signal::ctrl_c().await;
+            eprintln!("\n[inspect] Ctrl-C — tearing down {name} (detached; ~15s)…");
+            use std::os::unix::process::CommandExt;
+            let _ = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(format!(
+                    "msb stop {name} >/dev/null 2>&1; msb rm {name} >/dev/null 2>&1"
+                ))
+                .process_group(0) // own group: tty Ctrl-C cannot kill it
+                .spawn(); // not awaited: survives this process exiting
+            std::process::exit(130);
+        }
+    });
 
+    let _agent = attach_mounted_agent(name).await;
+
+    let prefixes = mount_prefixes();
     println!("\n================ VFS INSPECT READY ================");
     println!("sandbox name : {name}");
-    println!("guest mounts : /mnt/vfs/{{s3,notion,gdrive}} (configured providers)");
+    println!(
+        "guest mounts : {} (configured providers)",
+        prefixes
+            .iter()
+            .map(|p| format!("/mnt/vfs{p}"))
+            .collect::<Vec<_>>()
+            .join("  ")
+    );
     println!("inspect from another terminal:");
     println!("  msb exec {name} -- sh -c 'ls -la /mnt/vfs'");
-    println!("  msb exec {name} -- sh -c 'ls /mnt/vfs/s3'");
-    println!("  msb exec {name} -- sh -c 'ls /mnt/vfs/notion/pages'");
-    println!("  msb exec {name} -- sh -c 'ls /mnt/vfs/gdrive | head'");
-    println!("Ctrl-C to tear down (cleans up the sandbox automatically).");
+    for p in &prefixes {
+        println!("  msb exec {name} -- sh -c 'ls /mnt/vfs{p}'");
+    }
+    println!(
+        "Ctrl-C to tear down (detached cleanup — the VM is removed even if you Ctrl-C again)."
+    );
     println!("===================================================\n");
 
-    // Hold the VM + host forward server up until Ctrl-C, then tear the sandbox
-    // down so it doesn't leak — a SIGINT-killed process would otherwise orphan
-    // the VM (its supervisor outlives the process). `tokio::signal::ctrl_c`
-    // intercepts the first Ctrl-C; cleanup runs, then the test returns.
-    let _ = tokio::signal::ctrl_c().await;
-    println!("\n[inspect] Ctrl-C — tearing down {name}…");
-    drop(agent); // AgentVfs Drop stops the VM + host forward server
-    msb_rm(name); // ensure it's stopped + removed (no orphan)
-    println!("[inspect] done.");
+    // Hold the VM + host forward server up; Ctrl-C is handled by the detached
+    // teardown task installed above.
+    std::future::pending::<()>().await;
 }


### PR DESCRIPTION
## Summary

Adds **Gmail** as a VFS provider. Stacked on #432 (introduces `src/vfs`); base is `feat/vfs-provider-mounts`.

Agents use the existing `shell`/`read`/`write` tools on a Gmail path tree — no custom tools.

## Layout
```
<label>/<yyyy-mm-dd>/<subject>__<message-id>.gmail.json   # the email (processed JSON)
<label>/<yyyy-mm-dd>/<subject>__<message-id>/<filename>   # attachments (only if any)
```
- `cat <…>.gmail.json` → processed email (`from`/`to`/`cc`/`subject`/`date`/`body_text`/`snippet`/`labels`/`attachments`); attachment bytes from the sibling dir.
- A date dir narrows the Gmail query server-side (`after:/before:`); message-id is encoded in the filename (no shared index).
- `rm <…>.gmail.json` → Trash. Writes via control path: `.cmd/send`, `.cmd/reply`, `.cmd/reply-all`, `.cmd/forward`.

## How it works
- `accessor/gmail.rs` — Google OAuth (token refresh + 401 retry, mirroring gdrive) over the Gmail API.
- `resource/gmail.rs` — readdir/read/stat/unlink/command. Cheap stat (label cache; message files use a direct_io sentinel size; attachments report exact size). Dependency-free date math.
- Listings are capped at the newest 50, so `Resource::listings_complete()` (gmail = `false`) disables the cache's negative-ENOENT shortcut, and visited date dirs fold into the label listing incrementally (so older dates stay reachable and tab-completion offers them).

## Tests
- **Unit** (no creds): sanitize, message-id parse, date math, `process_message` shape, MIME encoding.
- **Live** (`tests/vfs/providers.rs`): labels/dates/read, send, reply/reply-all/forward, capped-listing negative-cache regression, incremental date folding.

Verified end-to-end with a `gmail.modify`-scoped token through the host FUSE mount: read, send, reply, reply-all, forward, older-date navigation, incremental folding.

## Note
Requires a refresh token whose scope includes Gmail (e.g. `https://www.googleapis.com/auth/gmail.modify`) — enabling the Gmail API alone is not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
