### PR TITLE
chore(deps): bump microsandbox to v0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "log",
  "microsandbox",
  "microsandbox-network",
+ "microsandbox-types",
  "ordered-float 5.3.0",
  "parking_lot",
  "png",
@@ -1586,24 +1587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,48 +2119,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-client"
-version = "0.26.0-alpha.1"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b710cd52bde69b58137785a5d2b1ec1b20980a3ca0d5f959eab8c45a72e92d"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "hickory-proto",
- "once_cell",
- "radix_trie",
- "rand 0.9.5",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62d7684f766b0f96344be88c023f9b6650039aea09d526b4974cce302eb61b1"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.5",
- "ring",
+ "jni 0.22.4",
+ "rand 0.10.2",
  "rustls",
  "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -3121,9 +3103,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "microsandbox"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa03c41f28e68bab010ec2561028cb50be97bd0d262aeb4799d8c2835cd5d9c"
+checksum = "e89d0cd740babe0d758559898eb4c94528e0303ae1b3bc3545c71addae09ed48"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3167,6 +3149,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "typed-builder 0.23.2",
+ "typed-path",
  "which",
  "windows-sys 0.61.2",
  "zeroize",
@@ -3174,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cd961939b459ca2f080b605e6e4fdb2cc0b59f1483c70a05a6c7ca3ff05b4f"
+checksum = "5ed2ba20581564863ac915af6cfbea7d276422d3abd56816ebc42243a03f5a8d"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3188,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ecaac5f8e06a89b25dc04367a17cfbc8d5d0c08027ecebd699da5a5113cd"
+checksum = "f1b934e5767f3ac1db9461d7f1f894e9f58cce26eadcda51a39db0d379c37650"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3201,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efc6f97053fb7da3e143bed74cc072a51acac92cb8d851eac33aafebdb6c261"
+checksum = "81cf205e6a63320d74e994efa70aaca0ee27e0b0723f347c0e579f6e3548f7c7"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3215,12 +3198,13 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ef995f2be7ee6dc850bb933dca1b7f63e9acbde794f457deee9ae17838faff"
+checksum = "694367d2d1c5f809f721b9b08c44bdebeb01387b71c6b2dcf766d8c06fece816"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
+ "chrono",
  "futures",
  "hex",
  "libc",
@@ -3242,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c8c1fdae5aca874b6f51642a7906683ab75d5d8b73988c366e04f7863ec0"
+checksum = "168384b97a508d9668f74082728a800b6d5c1fb01b6bffa62c7fe3ffe2bdefdf"
 dependencies = [
  "chrono",
  "libc",
@@ -3255,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc6bae48ebde3d449bca82cf219debdd8c15816eb052b92d523c2ec02460b8"
+checksum = "f7d992df19d57016cb7bd83919e6fb3e11dd001497a5b2d872389f20bfaa19f1"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3265,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bb04b4a138cef7e313136fbe25d35a900dab888e9f832bf9772dca33cd1c07"
+checksum = "4cf93ffc20b70f4da59a95e11273cc0101da6b6dc37ce42c1dc1c29136375aac"
 dependencies = [
  "base64",
  "bytes",
@@ -3275,7 +3259,7 @@ dependencies = [
  "crossbeam-queue",
  "dirs",
  "futures",
- "hickory-client",
+ "hickory-net",
  "hickory-proto",
  "httlib-hpack",
  "httparse",
@@ -3310,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534afd6e375810eb47da050aee4d5d022bd6caf48b011e3e45b943c09c59e49a"
+checksum = "3c1dbe9787a6ac1f8622b42c4eef811d7e94ad8783da1676ccfac22e24f3e07b"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3326,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c99d4fbcdcbec3614fc7e66809073f1fa947538c4c3e99e794e4a79d0d716a"
+checksum = "d7e59a15602eac0171806728b08a24c7f1bcc36cafbeb97ba913834977416aff"
 dependencies = [
  "bytes",
  "chrono",
@@ -3359,11 +3343,12 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e8186a7919d954d289606a136bd1388e1036e0701258a5a37435a0a64a295"
+checksum = "7dedfe491fe4a2b03edaea149294b0a02430999f7ab134813830bc94daec986e"
 dependencies = [
  "chrono",
+ "ipnetwork",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3373,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ffaab467bb5b6178edb24ebba4cb55707d725b40afcf7d73884d426fb766c"
+checksum = "ea2108ca822ab20afed3d099b21d5f075435db6189f9b40aceb9e04060711aaf"
 dependencies = [
  "dirs",
  "libc",
@@ -3621,15 +3606,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -4380,16 +4356,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -6245,6 +6211,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,17 @@ axum = "0.8"
 dotenvy = "0.15"
 test-with = { version = "0.16.1", default-features = false, features = ["executable"] }
 tokio = { version = "1.0", features = ["net"] }
+
+# microsandbox 0.6.7 computes a sparse-sha256 integrity digest over the upper
+# layer's full logical size (default 4 GiB) on snapshot create, save, and load,
+# so sandbox snapshot tests hash ~12 GiB per round trip. Unoptimized sha2 runs
+# at ~130 MB/s, which turns that into ~32 s per pass under the dev profile.
+# Optimizing just the hash crates restores hardware-speed hashing (~2.6 GB/s).
+# Applies only when this workspace is built directly; release builds and
+# crates depending on ailoy are unaffected.
+[profile.dev.package.sha2]
+opt-level = 3
+[profile.dev.package.digest]
+opt-level = 3
+[profile.dev.package.block-buffer]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-sandbox = ["dep:microsandbox", "dep:microsandbox-network"]
+sandbox = ["dep:microsandbox", "dep:microsandbox-network", "dep:microsandbox-types"]
 
 [dependencies]
 anyhow = "1"
@@ -42,10 +42,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.22"
 log = "0.4"
-microsandbox = { version = "0.6.1", optional = true }
+microsandbox = { version = "0.6.7", optional = true }
 # `microsandbox` facade does not re-export the network policy builder types;
 # used directly to build per-variant SandboxNetwork egress policies.
-microsandbox-network = { version = "0.6.1", optional = true }
+microsandbox-network = { version = "0.6.7", optional = true }
+# The wire-format `NetworkPolicy` that `SandboxSpec` stores also lacks a
+# facade re-export (the facade's `NetworkPolicy` is the engine-side type).
+microsandbox-types = { version = "0.6.7", optional = true }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 parking_lot = "0.12.4"
 png = "0.18"

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use microsandbox::{
     ExecOutput, MicrosandboxError, NetworkPolicy, Sandbox as MsbSandbox, SandboxConfig, Snapshot,
     sandbox::{ExecOptionsBuilder, IntoImage, MountBuilder, PullPolicy, validate_sandbox_name},
-    snapshot::ExportOpts,
+    snapshot::SaveOpts,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -145,10 +145,13 @@ pub struct SandboxBuilder {
     build_error: Option<String>,
 }
 
-/// Serialize a [`NetworkPolicy`] into the `Option<Value>` form the 0.6.x
-/// `SandboxConfig` network spec stores (round-trips via serde; infallible).
-fn network_policy_value(policy: NetworkPolicy) -> serde_json::Value {
-    serde_json::to_value(policy).expect("NetworkPolicy serializes to JSON")
+/// Convert an engine-side [`NetworkPolicy`] into the wire-format policy the
+/// `SandboxSpec` stores. The two types share one JSON schema (microsandbox
+/// converts its engine config into the spec through the same serde
+/// round-trip), so the conversion is infallible.
+fn wire_network_policy(policy: NetworkPolicy) -> microsandbox_types::NetworkPolicy {
+    let value = serde_json::to_value(policy).expect("NetworkPolicy serializes to JSON");
+    serde_json::from_value(value).expect("engine and wire NetworkPolicy share one JSON schema")
 }
 
 /// Guest network reachability. The sandbox host
@@ -211,7 +214,7 @@ impl Default for SandboxBuilder {
         config.spec.pull_policy = PullPolicy::IfMissing;
         // Default network posture: host + public internet (see SandboxNetwork).
         config.spec.network.enabled = true;
-        config.spec.network.policy = Some(network_policy_value(SandboxNetwork::default().policy()));
+        config.spec.network.policy = Some(wire_network_policy(SandboxNetwork::default().policy()));
         Self {
             config,
             default_timeout_secs: 60,
@@ -267,7 +270,7 @@ impl SandboxBuilder {
     /// see [`SandboxNetwork`]. Defaults to [`SandboxNetwork::Public`].
     pub fn network(mut self, network: SandboxNetwork) -> Self {
         self.config.spec.network.enabled = true;
-        self.config.spec.network.policy = Some(network_policy_value(network.policy()));
+        self.config.spec.network.policy = Some(wire_network_policy(network.policy()));
         self
     }
 
@@ -416,10 +419,10 @@ impl Sandbox {
     ) -> anyhow::Result<Self> {
         ensure_msb().await?;
 
-        let handle = Snapshot::import(path.as_ref(), None)
+        let handle = Snapshot::load(path.as_ref(), None)
             .await
-            .context("import snapshot archive")?;
-        let snap = handle.open().await.context("open imported snapshot")?;
+            .context("load snapshot archive")?;
+        let snap = handle.open().await.context("open loaded snapshot")?;
         let snap_path = snap.path().to_path_buf();
 
         // The imported artifact directory is content-addressed (`sha256-…`),
@@ -467,19 +470,19 @@ impl Sandbox {
     /// call is cleaned up before returning (success or failure).
     pub async fn archive(&mut self, path: impl AsRef<Path>) -> anyhow::Result<()> {
         let snap = Snapshot::builder(&self.name)
-            .name(&self.name)
+            .from_sandbox(&self.name)
             .create()
             .await
             .context("create snapshot")?;
         let snap_path = snap.path().to_path_buf();
 
-        let result = Snapshot::export(
+        let result = Snapshot::save(
             snap_path.to_string_lossy().as_ref(),
             path.as_ref(),
-            ExportOpts::default(),
+            SaveOpts::default(),
         )
         .await
-        .context("export snapshot archive");
+        .context("save snapshot archive");
 
         cleanup_snapshot_dir(&snap_path);
 


### PR DESCRIPTION
Bumps the `microsandbox` and `microsandbox-network` pins from 0.6.1 to 0.6.7 and adapts `runenv/sandbox.rs` to the API changes that landed in between. The lockfile was already resolving to 0.6.6, so the manifest pins were stale; this moves both the pins and the lock to 0.6.7.

## Notable upstream changes between 0.6.1 and 0.6.7

- **Snapshot API contract finalized** (superradcompany/microsandbox#1118): `Snapshot::export`/`Snapshot::import` became `Snapshot::save`/`Snapshot::load`, and the builder signature changed. This is what breaks our `Sandbox::archive` / `try_from_archive` path (adaptation below).
- **Sparse snapshot export** (superradcompany/microsandbox#1150): files with holes are stored as GNU sparse tar entries on export, so the `.tar.zst` archives our `Sandbox::archive` produces no longer materialize the empty regions of the upper layer. That PR reports a 4 GiB mostly-empty upper going from ~6.5 s to ~0.02 s to bundle, with the archive shrinking from ~2 MB to ~7 KB. superradcompany/microsandbox#1166 and superradcompany/microsandbox#1200 follow up with an owned sparse codec and a bidirectional v0.6.6 format migration, so archives written by 0.6.6 still load.
- **Typed sandbox spec** (superradcompany/microsandbox#1144): `spec.network.policy` changed from `Option<serde_json::Value>` to a typed wire-format `NetworkPolicy` (adaptation below).
- **Network fixes and features**: IPv6 DNS edge cases (superradcompany/microsandbox#1083), scoped upstream TLS verification (superradcompany/microsandbox#1073), fragmented UDP / PMTU relay traffic (superradcompany/microsandbox#1086), composable network profiles (superradcompany/microsandbox#1198).
- **Runtime and lifecycle**: live modify/resize for running sandboxes (superradcompany/microsandbox#1099), exec kills the whole process group instead of just the direct child (superradcompany/microsandbox#1104), faster `msb load`/`pull` via an early cache gate and zlib-rs decode (superradcompany/microsandbox#1075).
- **Dependency hygiene**: hickory bumped to 0.26.1, migrating the discontinued `hickory-client` 0.26.0-alpha.1 to `hickory-net` (superradcompany/microsandbox#1186); this clears the hickory RustSec advisories from our lockfile as well.

## API adaptations in this PR

**Snapshot archive API rename** (`export`/`import` → `save`/`load`): `Snapshot::export(name_or_path, out, ExportOpts)` is now `Snapshot::save(name_or_path, out, SaveOpts)` and `Snapshot::import(archive_path, dest)` is now `Snapshot::load(archive_path, dest)`. The signatures and option fields are otherwise identical, so `Sandbox::archive` / `try_from_archive` keep their exact behavior.

**Snapshot builder argument order**: `Snapshot::builder(source_sandbox).name(name)` became `Snapshot::builder(name).from_sandbox(source_sandbox)`. `Sandbox::archive` passes the sandbox's own name for both, as before.

**Typed network policy in the spec**: `spec.network.policy` now stores `Option<microsandbox_types::NetworkPolicy>`, a wire-format type distinct from the engine-side `microsandbox_network::policy::NetworkPolicy` that `SandboxNetwork` builds (and that the sandbox builder's `.network(|n| n.policy(...))` closure still takes). The old `network_policy_value` serde helper is replaced by `wire_network_policy`, which converts engine → wire through the same serde round-trip microsandbox itself uses between its engine config and spec types. Since the facade re-exports neither the wire `NetworkPolicy` nor the `microsandbox-types` crate, `microsandbox-types` is added as an optional dependency of the `sandbox` feature, mirroring the existing `microsandbox-network` direct-dependency rationale documented in `Cargo.toml`.

## Snapshot integrity hashing cost and dev-profile mitigation

v0.6.7 also made the snapshot integrity digest mandatory (superradcompany/microsandbox#1200): create, save, and load each compute or verify a `sparse-sha256-v1` digest over the upper layer's full logical size, with holes hashed as synthesized zeros. The cost is O(logical size) CPU regardless of how much data the sandbox actually wrote — about 1.7 s per pass for the default 4 GiB upper on an M4 Pro in release builds. Filed upstream as superradcompany/microsandbox#1220: the save-time re-verification is redundant in the immediate create-then-save flow, and the docs still describe the hash as opt-in.

Under the dev profile this dominated test time: unoptimized sha2 hashes at ~130 MB/s, so `test_archive_and_restore` went from ~11 s on 0.6.1 to ~99 s on 0.6.7 (three ~32 s passes). This PR adds `[profile.dev.package.{sha2,digest,block-buffer}] opt-level = 3` to Cargo.toml, which restores hardware-speed hashing and brings the test back to ~5-7 s. Profile overrides only take effect when this workspace is built directly, so release builds and crates depending on ailoy are unaffected.

## Verification

- `cargo build --features sandbox`: passes.
- `cargo clippy` and `cargo clippy --features sandbox`: no new warnings (the two existing lib warnings in `agent/rt.rs` and `lang_model/impl/api/mod.rs` are untouched by this PR).
- `cargo test --features sandbox --lib` against the installed msb 0.6.7 runtime: effectively all tests pass (324/324 counting a flaky rerun; 17 ignored). All sandbox e2e tests pass, including the paths this PR touches (`test_archive_and_restore`, `test_fork`, `test_host_only_blocks_public_egress`, `test_public_allows_public_egress`, `test_exec`, `test_stop`). Known flake: `agent::rt::tests::test_delegate_to_subagent` (a live-LLM test gated on `OPENAI_API_KEY`, no overlap with this change) failed once in the full run and passed on a standalone rerun.
- `cargo test --features sandbox runenv::sandbox::tests::test_archive_and_restore` with the dev-profile override: 5.48 s (was ~99 s on 0.6.7 without it; ~11 s on 0.6.1).
