### PR TITLE
chore(deps): migrate schemars and refresh stable dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,25 +182,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -649,35 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boring-sys2"
-version = "4.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
-dependencies = [
- "autocfg",
- "bindgen",
- "cmake",
- "fs_extra",
- "fslock",
-]
-
-[[package]]
-name = "boring2"
-version = "4.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
-dependencies = [
- "bitflags 2.13.1",
- "boring-sys2",
- "brotli",
- "flate2",
- "foreign-types",
- "libc",
- "openssl-macros",
- "zstd",
-]
-
-[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +658,31 @@ checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "btls"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e60b8c8d282c86360cab651ded04ab0335a7b5390c8d34145cbeab8cacf5f"
+dependencies = [
+ "bitflags 2.13.1",
+ "btls-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "btls-sys"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1b8638a2e1c38a5ae4efa90ae57e643baec35a30d03fc5b399b893adc4954b"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -859,7 +840,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2208,7 +2189,7 @@ dependencies = [
  "bitflags 2.13.1",
  "html-escape",
  "html5ever",
- "lru 0.18.1",
+ "lru",
  "memchr",
  "once_cell",
  "phf 0.14.0",
@@ -2287,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.4.21"
+version = "0.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
+checksum = "92d3114be2f413b2e491e686b93a28cda30c355cffc8d091a57f8be4b1342896"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2299,6 +2280,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
+ "smallvec",
  "tokio",
  "tokio-util",
 ]
@@ -2378,32 +2360,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
- "system-configuration 0.7.0",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
-]
-
-[[package]]
-name = "hyper2"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "http2",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2693,7 +2655,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2931,7 +2893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2961,21 +2923,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3020,12 +2967,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru"
@@ -3152,7 +3093,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "typed-builder 0.23.2",
+ "typed-builder",
  "typed-path",
  "which",
  "windows-sys 0.61.2",
@@ -3269,7 +3210,7 @@ dependencies = [
  "httparse",
  "ipnetwork",
  "libc",
- "lru 0.18.1",
+ "lru",
  "microsandbox-protocol",
  "microsandbox-types",
  "microsandbox-utils",
@@ -3285,8 +3226,8 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "smoltcp",
- "socket2 0.6.5",
- "system-configuration 0.7.0",
+ "socket2",
+ "system-configuration",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -3505,7 +3446,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.18.1",
+ "lru",
  "msb-imago",
  "msb_krun_arch",
  "msb_krun_hvf",
@@ -4003,7 +3944,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4296,7 +4237,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4335,7 +4276,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4754,7 +4695,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
- "webpki-root-certs 1.0.9",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -4775,7 +4716,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
- "webpki-root-certs 1.0.9",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -5368,16 +5309,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -5747,17 +5678,6 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
@@ -5958,19 +5878,18 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "tokio-boring2"
-version = "4.15.15"
+name = "tokio-btls"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
+checksum = "2e1fd638ec35427faf3b8f412e0fdd6fae76591d79dba40f38fa667d22bc44dd"
 dependencies = [
- "boring-sys2",
- "boring2",
+ "btls",
  "tokio",
 ]
 
@@ -6084,12 +6003,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6179,31 +6103,11 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
-dependencies = [
- "typed-builder-macro 0.21.2",
-]
-
-[[package]]
-name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
 dependencies = [
- "typed-builder-macro 0.23.2",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "typed-builder-macro",
 ]
 
 [[package]]
@@ -6602,15 +6506,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.9",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
@@ -6715,9 +6610,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6727,7 +6622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -6755,12 +6650,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -6772,18 +6661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -6792,18 +6670,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6812,16 +6681,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6830,7 +6690,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6884,7 +6744,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6939,7 +6799,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -6956,7 +6816,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7156,53 +7016,81 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wreq"
-version = "5.3.0"
+version = "6.0.0-rc.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137ed11c4c418fb3dc41db7323ebc49aa9b6fe6a24ce152e6b2de9d6fadd9c8f"
+checksum = "3f0eba5f5814a94e5f1a99156f187133464e525b66bdbc69a9627d46530af2e1"
 dependencies = [
- "antidote",
- "arc-swap",
- "async-compression",
- "base64 0.22.1",
- "boring2",
+ "btls",
+ "btls-sys",
  "bytes",
  "encoding_rs",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "hyper2",
+ "http2",
+ "httparse",
  "ipnet",
- "linked_hash_set",
- "log",
- "lru 0.13.0",
+ "libc",
+ "lru",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde",
- "serde_urlencoded",
- "socket2 0.5.10",
+ "socket2",
  "sync_wrapper",
- "system-configuration 0.6.1",
  "tokio",
- "tokio-boring2",
+ "tokio-btls",
  "tokio-util",
  "tower",
- "tower-service",
- "typed-builder 0.21.2",
+ "tower-http",
  "url",
- "webpki-root-certs 0.26.11",
- "windows-registry 0.5.3",
+ "webpki-root-certs",
+ "wreq-proto",
+ "wreq-rt",
+]
+
+[[package]]
+name = "wreq-proto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43942f024bb303f1042c9aa3c87fa1d9149f507c65db6e5220a11ccdb207387"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http2",
+ "httparse",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "want",
+]
+
+[[package]]
+name = "wreq-rt"
+version = "0.2.2-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e9bce67a3fa3dd3f1503f066d86661c9caf399a763d3bd184da7afaf886c8b"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "wreq-proto",
 ]
 
 [[package]]
 name = "wreq-util"
-version = "2.2.6"
+version = "3.0.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28b3585973a8923c32c2f916e60b7b0d1cb4dd53e8cb2d7422c0ac001ef2487"
+checksum = "1d8d73c75be86fbde675988dbe5cb15f02567025c13f6ffab910361ad1ba6c89"
 dependencies = [
- "typed-builder 0.21.2",
+ "brotli",
+ "flate2",
+ "typed-builder",
  "wreq",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
  "hex",
  "html-to-markdown-rs",
  "image",
- "indexmap 2.14.0",
+ "indexmap",
  "infer",
  "jsonschema",
  "log",
@@ -2020,7 +2020,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2046,12 +2046,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2298,7 +2292,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2564,17 +2558,6 @@ checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -4825,12 +4808,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
- "indexmap 1.9.3",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4839,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5150,7 +5133,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -5433,7 +5416,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -6042,7 +6025,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.23.0",
  "dedent",
  "derive_builder",
  "dirs",
@@ -414,7 +414,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -519,6 +519,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -783,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -906,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -928,14 +934,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1500,7 +1506,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
  "serde_json",
 ]
@@ -1555,9 +1561,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -1636,11 +1642,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1760,13 +1765,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2004,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -2193,13 +2198,13 @@ checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
 
 [[package]]
 name = "html-to-markdown-rs"
-version = "3.9.0"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72131a643f3b9c379f5080626f1e7774b6abef974424f3f01fd952fcd23b60f3"
+checksum = "ac9408651be7d7f6a6f51d7bebe5f30815ef2fe620314ad5713f989cee7d70d0"
 dependencies = [
  "ahash",
  "astral-tl",
- "base64",
+ "base64 0.23.0",
  "bitflags 2.13.1",
  "html-escape",
  "html5ever",
@@ -2321,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2362,7 +2367,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2589,7 +2594,7 @@ checksum = "bee2c455ca60511a054699102d40ce7153621cb2429558f9eaa600e4499b5984"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2755,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baf521a926fd1e6f94af6922be9686b61c8a89a5fb7e14d6a1e21b79738d4cc"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2769,6 +2774,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2776,17 +2782,32 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum 0.28.0",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d668f4775619127513d9a4f190704d20a66d20ccf0efc258f8ed42548e5fd7cd"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2796,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "serde",
@@ -2889,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -3092,7 +3113,7 @@ checksum = "e89d0cd740babe0d758559898eb4c94528e0303ae1b3bc3545c71addae09ed48"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "ciborium",
@@ -3236,7 +3257,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cf93ffc20b70f4da59a95e11273cc0101da6b6dc37ce42c1dc1c29136375aac"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "core-foundation 0.9.4",
  "crossbeam-queue",
@@ -3991,7 +4012,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -4487,14 +4508,14 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.48.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df843f41f0cb459649f64a8b6b10579cf454f7a7420dc702767c81a26f23d780"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4554,7 +4575,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4708,9 +4729,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5113,7 +5134,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5129,9 +5150,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5160,7 +5181,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5403,7 +5424,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -5479,7 +5500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
@@ -5522,7 +5543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "chrono",
@@ -5695,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5791,9 +5812,9 @@ dependencies = [
 
 [[package]]
 name = "test-with"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964c2c219d0e7658fc3cd7354826e9e8d997c1e7d592cc32f349fc1125b64a84"
+checksum = "577e034de553ad1a2f3a62c711080f5095afb875da2e482646c7ad89e3c88428"
 dependencies = [
  "test-with-derive",
  "which",
@@ -5801,14 +5822,14 @@ dependencies = [
 
 [[package]]
 name = "test-with-derive"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52884ff2163f79cd0a7af841fd2e9aca103f2ff1207092d317bf00565abdc59c"
+checksum = "c7b0d3f97e986691b2c1c63d6f3de480f203eac42e51eb0bbb7e98abb897b06d"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.119",
+ "syn 3.0.3",
  "which",
 ]
 
@@ -5849,7 +5870,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5863,9 +5884,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5883,9 +5904,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5927,9 +5948,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5976,9 +5997,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5999,13 +6020,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -6033,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -6299,7 +6321,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -6317,7 +6339,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -7141,7 +7163,7 @@ dependencies = [
  "antidote",
  "arc-swap",
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "boring2",
  "bytes",
  "encoding_rs",
@@ -7324,18 +7346,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,6 +7038,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-btls",
  "tokio-util",
@@ -7045,6 +7046,7 @@ dependencies = [
  "tower-http",
  "url",
  "webpki-root-certs",
+ "windows-registry",
  "wreq-proto",
  "wreq-rt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,13 @@ unicode-segmentation = "1.12.0"
 url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1"
 uuid = { version = "1.18.0", features = ["v4"] }
-wreq = { version = "=6.0.0-rc.29", features = ["brotli", "charset", "deflate", "gzip", "stream", "zstd"] }
+# wreq 6 trimmed its default feature set down to webpki-roots and tokio-rt, so
+# everything else this crate relies on has to be requested by name. charset and
+# system-proxy were in wreq 5's defaults; the decompression features and stream
+# were already explicit; emulation-compression restores the content-encoding
+# profile that wreq-util 2.x applied on its own. Re-check this list whenever the
+# pin moves, since a feature leaving default is a silent behavior change.
+wreq = { version = "=6.0.0-rc.29", features = ["brotli", "charset", "deflate", "gzip", "stream", "system-proxy", "zstd"] }
 wreq-util = { version = "=3.0.0-rc.14", features = ["emulation-compression"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sandbox = ["dep:microsandbox", "dep:microsandbox-network", "dep:microsandbox-typ
 anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1"
-base64 = "0.22"
+base64 = "0.23"
 dedent = "0.1.1"
 derive_builder = "0.20.2"
 fancy-regex = "0.18"
@@ -54,7 +54,7 @@ parking_lot = "0.12.4"
 png = "0.18"
 reqwest = { version = "0.13", features = ["form", "json", "stream"] }
 scraper = "0.27"
-jsonschema = { version = "0.48", default-features = false }
+jsonschema = { version = "0.49", default-features = false }
 schemars = { version = "0.9", features = ["preserve_order", "url2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
@@ -79,7 +79,7 @@ wreq-util = "2.2.6"
 [dev-dependencies]
 axum = "0.8"
 dotenvy = "0.15"
-test-with = { version = "0.16.1", default-features = false, features = ["executable"] }
+test-with = { version = "0.17", default-features = false, features = ["executable"] }
 tokio = { version = "1.0", features = ["net"] }
 
 # microsandbox 0.6.7 computes a sparse-sha256 integrity digest over the upper

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,8 @@ unicode-segmentation = "1.12.0"
 url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1"
 uuid = { version = "1.18.0", features = ["v4"] }
-wreq = { version = "5.3.0", features = ["stream"] }
-wreq-util = "2.2.6"
+wreq = { version = "=6.0.0-rc.29", features = ["brotli", "charset", "deflate", "gzip", "stream", "zstd"] }
+wreq-util = { version = "=3.0.0-rc.14", features = ["emulation-compression"] }
 
 [dev-dependencies]
 axum = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ exclude = [
 [workspace.package]
 version = "0.3.0"
 edition = "2024"
+rust-version = "1.95.0"
 license = "Apache-2.0"
 repository = "https://github.com/brekkylab/ailoy"
 
@@ -16,6 +17,7 @@ repository = "https://github.com/brekkylab/ailoy"
 name = "ailoy"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ png = "0.18"
 reqwest = { version = "0.13", features = ["form", "json", "stream"] }
 scraper = "0.27"
 jsonschema = { version = "0.48", default-features = false }
-schemars = { version = "0.8", features = ["preserve_order", "url"] }
+schemars = { version = "0.9", features = ["preserve_order", "url2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -226,13 +226,11 @@ impl Agent {
                         *value = crate::datatype::Value::string(truncated);
                     }
                 }
-                Part::Text { text } => {
-                    if text.len() > Self::MAX_TOOL_RESULT_CHARS {
-                        *text = crate::util::truncate::middle_truncate(
-                            std::mem::take(text),
-                            Self::MAX_TOOL_RESULT_CHARS,
-                        );
-                    }
+                Part::Text { text } if text.len() > Self::MAX_TOOL_RESULT_CHARS => {
+                    *text = crate::util::truncate::middle_truncate(
+                        std::mem::take(text),
+                        Self::MAX_TOOL_RESULT_CHARS,
+                    );
                 }
                 _ => {}
             }
@@ -358,7 +356,7 @@ impl Agent {
                             // against the parent's tool batch.
                             let dummy = Local::default();
                             let mut stream =
-                                tool.call(call_args, call_id_for_call, dummy.into_dummy_console());
+                                tool.call(call_args, call_id_for_call, dummy.dummy_console());
                             let mut last: Option<MessageOutput> = None;
                             while let Some(item) = stream.next().await {
                                 if let Some(mut prev) = last.replace(item) {
@@ -658,12 +656,12 @@ impl Agent {
 /// Test-only extension: produce a `&dyn Console` cheaply from a default `Local`
 /// without going through `Machine::start`. This dummy is only passed to Pure
 /// `ToolFunc`s — they never actually use it.
-trait IntoDummyConsole {
-    fn into_dummy_console(&self) -> &dyn Console;
+trait DummyConsoleExt {
+    fn dummy_console(&self) -> &dyn Console;
 }
 
-impl IntoDummyConsole for Local {
-    fn into_dummy_console(&self) -> &dyn Console {
+impl DummyConsoleExt for Local {
+    fn dummy_console(&self) -> &dyn Console {
         // `Local` always holds a `LocalConsole`; expose it as a trait object.
         // SAFETY: This relies on `Local`'s public `start()` returning the same
         // console after `&mut self` is released — we just read through `&self`.
@@ -917,7 +915,7 @@ mod tests {
             )
             .subagent(sub_spec);
 
-        let mut main_agent = Agent::try_with_provider(main_spec, &provider).unwrap();
+        let mut main_agent = Agent::try_with_provider(main_spec, provider).unwrap();
 
         let query =
             Message::new(Role::User).with_contents([Part::text("What is 123 multiplied by 7?")]);
@@ -967,7 +965,7 @@ mod tests {
 
         let main_spec = AgentSpec::new("openai/gpt-4o-mini").subagent(sub_spec);
 
-        let mut main_agent = Agent::try_with_provider(main_spec, &provider).unwrap();
+        let mut main_agent = Agent::try_with_provider(main_spec, provider).unwrap();
 
         let query = Message::new(Role::User).with_contents([Part::text("What is 99 plus 1?")]);
 

--- a/src/datatype/bytes.rs
+++ b/src/datatype/bytes.rs
@@ -1,8 +1,6 @@
-use schemars::{
-    JsonSchema,
-    r#gen::SchemaGenerator,
-    schema::{InstanceType, Schema, SchemaObject},
-};
+use std::borrow::Cow;
+
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
@@ -10,17 +8,15 @@ use serde_bytes::ByteBuf;
 pub struct Bytes(ByteBuf);
 
 impl JsonSchema for Bytes {
-    fn schema_name() -> String {
+    fn schema_name() -> Cow<'static, str> {
         "Bytes".into()
     }
 
     fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
-        SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            format: Some("base64".into()),
-            ..Default::default()
-        }
-        .into()
+        schemars::json_schema!({
+            "type": "string",
+            "format": "base64"
+        })
     }
 }
 
@@ -46,5 +42,25 @@ impl AsRef<[u8]> for Bytes {
 impl std::fmt::Debug for Bytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Bytes(({} bytes total))", self.0.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use schemars::JsonSchema;
+
+    use super::Bytes;
+
+    #[test]
+    fn json_schema_preserves_base64_string_contract() {
+        let schema = Bytes::json_schema(&mut schemars::SchemaGenerator::default());
+
+        assert_eq!(
+            serde_json::to_value(schema).unwrap(),
+            serde_json::json!({
+                "type": "string",
+                "format": "base64"
+            })
+        );
     }
 }

--- a/src/datatype/value.rs
+++ b/src/datatype/value.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use indexmap::IndexMap;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
@@ -42,15 +44,15 @@ pub enum Value {
 }
 
 impl schemars::JsonSchema for Value {
-    fn schema_name() -> String {
+    fn schema_name() -> Cow<'static, str> {
         "Value".into()
     }
 
-    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Empty SchemaObject produces `{}`, which in JSON Schema accepts any value.
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // An empty schema (`{}`) accepts any value.
         // This is intentional: `Value` is a free-form type that can hold any JSON-
         // compatible value (null, bool, number, string, array, or object).
-        schemars::schema::SchemaObject::default().into()
+        schemars::json_schema!({})
     }
 }
 
@@ -849,4 +851,18 @@ pub enum ValueError {
     InvalidType,
     InvalidValue,
     MissingField,
+}
+
+#[cfg(test)]
+mod tests {
+    use schemars::JsonSchema;
+
+    use super::Value;
+
+    #[test]
+    fn json_schema_accepts_any_value() {
+        let schema = Value::json_schema(&mut schemars::SchemaGenerator::default());
+
+        assert_eq!(serde_json::to_value(schema).unwrap(), serde_json::json!({}));
+    }
 }

--- a/src/lang_model/impl/api/anthropic.rs
+++ b/src/lang_model/impl/api/anthropic.rs
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_marshal_max_tokens_set() {
         with_req("claude-haiku-4-5", Some(512), |req| {
-            let val = AnthropicMarshal::default().marshal(req);
+            let val = AnthropicMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
             assert_eq!(max_tokens.as_integer().unwrap(), 512);
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn test_marshal_max_tokens_default() {
         with_req("claude-haiku-4-5", None, |req| {
-            let val = AnthropicMarshal::default().marshal(req);
+            let val = AnthropicMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let max_tokens = body.as_object().unwrap().get("max_tokens").unwrap();
             // Falls back to 8192 when not configured
@@ -642,14 +642,14 @@ mod tests {
         };
 
         // stream: false → no "stream" body key, no accept header.
-        let val = AnthropicMarshal::default().marshal(&req);
+        let val = AnthropicMarshal.marshal(&req);
         assert!(val.pointer("/body/stream").is_none());
         assert!(val.pointer("/header/accept").is_none());
 
         // stream: true → body "stream": true (the SSE trigger), plus an
         // `Accept: text/event-stream` header so intermediaries don't buffer.
         req.stream = true;
-        let val = AnthropicMarshal::default().marshal(&req);
+        let val = AnthropicMarshal.marshal(&req);
         assert_eq!(
             val.pointer("/body/stream").and_then(|v| v.as_bool()),
             Some(true)
@@ -697,7 +697,8 @@ mod tests {
         // A mid-stream `error` event must fail with the server's own type +
         // message, not a generic "unknown event type".
         let mut u = AnthropicUnmarshal;
-        let event = r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#;
+        let event =
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#;
         let err = u.unmarshal_event(event).unwrap_err().to_string();
         assert!(err.contains("overloaded_error"), "got: {err}");
         assert!(err.contains("Overloaded"), "got: {err}");
@@ -800,8 +801,9 @@ mod tests {
         let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set");
 
         let model = build_anthropic_model("test_run_stream_text", "claude-haiku-4-5", api_key);
-        let messages =
-            vec![Message::new(Role::User).with_contents([Part::text("Reply with a short greeting.")])];
+        let messages = vec![
+            Message::new(Role::User).with_contents([Part::text("Reply with a short greeting.")]),
+        ];
 
         let mut stream = model.run_stream(&messages, &[], &LangModelOptions::default());
         let mut acc = MessageDeltaOutput::new();
@@ -811,7 +813,10 @@ mod tests {
             chunks += 1;
         }
 
-        assert!(chunks > 1, "expected multiple streamed deltas, got {chunks}");
+        assert!(
+            chunks > 1,
+            "expected multiple streamed deltas, got {chunks}"
+        );
         let out = acc.finish().unwrap();
         assert_eq!(out.finish_reason, FinishReason::Stop {});
         assert!(
@@ -842,10 +847,7 @@ mod tests {
                 "cache_read_input_tokens": 10
             }
         });
-        let usage = AnthropicUnmarshal::default()
-            .unmarshal(response)
-            .unwrap()
-            .usage;
+        let usage = AnthropicUnmarshal.unmarshal(response).unwrap().usage;
         assert_eq!(
             usage,
             Some(TokenUsage {
@@ -863,10 +865,7 @@ mod tests {
             "content": [],
             "usage": {"input_tokens": 30, "output_tokens": 15}
         });
-        let usage = AnthropicUnmarshal::default()
-            .unmarshal(response)
-            .unwrap()
-            .usage;
+        let usage = AnthropicUnmarshal.unmarshal(response).unwrap().usage;
         assert_eq!(
             usage,
             Some(TokenUsage {
@@ -999,7 +998,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_absent() {
         with_req("claude-haiku-4-5", None, |req| {
-            let val = AnthropicMarshal::default().marshal(req);
+            let val = AnthropicMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("output_config").is_none());
         });
@@ -1008,7 +1007,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_json_schema() {
         let schema = to_value!({"type": "object", "properties": {"name": {"type": "string"}}});
-        let fmt = ResponseFormat::json_schema(schema.clone().into()).unwrap();
+        let fmt = ResponseFormat::json_schema(schema.clone()).unwrap();
         let messages: Vec<Message> = vec![];
         let tools: Vec<ToolDesc> = vec![];
         let provider = LangModelProviderElem::API {
@@ -1028,7 +1027,7 @@ mod tests {
             options: &options,
             stream: false,
         };
-        let val = AnthropicMarshal::default().marshal(&req);
+        let val = AnthropicMarshal.marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let fmt_type = body
             .pointer("/output_config/format/type")

--- a/src/lang_model/impl/api/chat_completion.rs
+++ b/src/lang_model/impl/api/chat_completion.rs
@@ -582,13 +582,13 @@ mod tests {
         };
 
         // stream: false → no stream / stream_options.
-        let val = ChatCompletionMarshal::default().marshal(&req);
+        let val = ChatCompletionMarshal.marshal(&req);
         assert!(val.pointer("/body/stream").is_none());
         assert!(val.pointer("/body/stream_options").is_none());
 
         // stream: true → stream + stream_options.include_usage so usage is reported.
         req.stream = true;
-        let val = ChatCompletionMarshal::default().marshal(&req);
+        let val = ChatCompletionMarshal.marshal(&req);
         assert_eq!(
             val.pointer("/body/stream").and_then(|v| v.as_bool()),
             Some(true)
@@ -708,11 +708,7 @@ mod tests {
     /// Register a one-off [`LangModelProvider`] under `provider_name` in the
     /// global registry and build the [`LangModel`] via
     /// [`LangModel::try_from_provider`].  Test fixtures only.
-    fn build_chat_completion_model(
-        provider_name: &str,
-        model: &str,
-        api_key: String,
-    ) -> LangModel {
+    fn build_chat_completion_model(provider_name: &str, model: &str, api_key: String) -> LangModel {
         let elem = LangModelProviderElem::API {
             schema: LangModelAPISchema::ChatCompletion,
             url: Url::parse("https://api.openai.com/v1/chat/completions").unwrap(),
@@ -753,7 +749,7 @@ mod tests {
     #[test]
     fn test_marshal_max_tokens_set() {
         with_req("gpt-4.1-mini", Some(256), |req| {
-            let val = ChatCompletionMarshal::default().marshal(req);
+            let val = ChatCompletionMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let max_tokens = body
                 .as_object()
@@ -767,7 +763,7 @@ mod tests {
     #[test]
     fn test_marshal_max_tokens_absent_when_none() {
         with_req("gpt-4.1-mini", None, |req| {
-            let val = ChatCompletionMarshal::default().marshal(req);
+            let val = ChatCompletionMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(
                 body.as_object()
@@ -781,7 +777,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_absent() {
         with_req("gpt-4.1-mini", None, |req| {
-            let val = ChatCompletionMarshal::default().marshal(req);
+            let val = ChatCompletionMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("response_format").is_none());
         });
@@ -790,7 +786,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_json_schema() {
         let schema = to_value!({"type": "object", "properties": {"score": {"type": "integer"}}});
-        let fmt = ResponseFormat::json_schema(schema.clone().into()).unwrap();
+        let fmt = ResponseFormat::json_schema(schema.clone()).unwrap();
         let messages: Vec<Message> = vec![];
         let tools: Vec<ToolDesc> = vec![];
         let provider = LangModelProviderElem::API {
@@ -810,7 +806,7 @@ mod tests {
             options: &options,
             stream: false,
         };
-        let val = ChatCompletionMarshal::default().marshal(&req);
+        let val = ChatCompletionMarshal.marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let rf = body.as_object().unwrap().get("response_format").unwrap();
         assert_eq!(

--- a/src/lang_model/impl/api/gemini.rs
+++ b/src/lang_model/impl/api/gemini.rs
@@ -781,7 +781,7 @@ mod tests {
         };
 
         // stream: false → non-streaming endpoint, no accept header.
-        let val = GeminiMarshal::default().marshal(&req);
+        let val = GeminiMarshal.marshal(&req);
         let endpoint = val.pointer("/url").and_then(|v| v.as_str()).unwrap();
         assert!(endpoint.ends_with(":generateContent"), "got {endpoint}");
         assert!(val.pointer("/header/accept").is_none());
@@ -790,7 +790,7 @@ mod tests {
         // streaming trigger), plus an `Accept: text/event-stream` header so
         // intermediaries don't buffer.
         req.stream = true;
-        let val = GeminiMarshal::default().marshal(&req);
+        let val = GeminiMarshal.marshal(&req);
         let endpoint = val.pointer("/url").and_then(|v| v.as_str()).unwrap();
         assert!(
             endpoint.ends_with(":streamGenerateContent?alt=sse"),
@@ -814,10 +814,7 @@ mod tests {
                 "candidatesTokenCount": 60
             }
         });
-        let usage = GeminiUnmarshal::default()
-            .unmarshal(response)
-            .unwrap()
-            .usage;
+        let usage = GeminiUnmarshal.unmarshal(response).unwrap().usage;
         assert_eq!(
             usage,
             Some(TokenUsage {
@@ -958,7 +955,7 @@ mod tests {
     #[test]
     fn test_marshal_max_output_tokens_set() {
         with_req("gemini-2.5-flash-lite", Some(2048), |req| {
-            let val = GeminiMarshal::default().marshal(req);
+            let val = GeminiMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let gen_config = body.as_object().unwrap().get("generationConfig").unwrap();
             let max_tokens = gen_config
@@ -973,7 +970,7 @@ mod tests {
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
         with_req("gemini-2.5-flash-lite", None, |req| {
-            let val = GeminiMarshal::default().marshal(req);
+            let val = GeminiMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("generationConfig").is_none());
         });
@@ -982,7 +979,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_absent() {
         with_req("gemini-2.5-flash-lite", None, |req| {
-            let val = GeminiMarshal::default().marshal(req);
+            let val = GeminiMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("generationConfig").is_none());
         });
@@ -991,7 +988,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_json_schema() {
         let schema = to_value!({"type": "object", "properties": {"city": {"type": "string"}}});
-        let fmt = ResponseFormat::json_schema(schema.clone().into()).unwrap();
+        let fmt = ResponseFormat::json_schema(schema.clone()).unwrap();
         let messages: Vec<Message> = vec![];
         let tools: Vec<ToolDesc> = vec![];
         let provider = LangModelProviderElem::API {
@@ -1011,7 +1008,7 @@ mod tests {
             options: &options,
             stream: false,
         };
-        let val = GeminiMarshal::default().marshal(&req);
+        let val = GeminiMarshal.marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
         let gen_cfg = body.as_object().unwrap().get("generationConfig").unwrap();
         assert_eq!(
@@ -1084,8 +1081,11 @@ mod tests {
         dotenvy::dotenv().ok();
         let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
 
-        let model =
-            build_gemini_model("gemini_test_run_max_tokens", "gemini-2.5-flash-lite", api_key);
+        let model = build_gemini_model(
+            "gemini_test_run_max_tokens",
+            "gemini-2.5-flash-lite",
+            api_key,
+        );
         let messages = vec![
             Message::new(Role::User)
                 .with_contents([Part::text("Tell me a long story about a dragon.")]),

--- a/src/lang_model/impl/api/mod.rs
+++ b/src/lang_model/impl/api/mod.rs
@@ -7,7 +7,6 @@ pub use anthropic::{AnthropicMarshal, AnthropicUnmarshal};
 pub use chat_completion::{ChatCompletionMarshal, ChatCompletionUnmarshal};
 pub use gemini::{GeminiMarshal, GeminiUnmarshal};
 pub use openai::{OpenAIMarshal, OpenAIUnmarshal};
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,8 +18,10 @@ use crate::{
 /// Wire protocol used when calling a language model API.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum LangModelAPISchema {
     /// OpenAI-compatible `/v1/chat/completions` format
+    #[default]
     ChatCompletion,
 
     /// Anthropic Messages API format
@@ -32,12 +33,6 @@ pub enum LangModelAPISchema {
     /// OpenAI Responses API format
     #[serde(rename = "openai")]
     OpenAI,
-}
-
-impl Default for LangModelAPISchema {
-    fn default() -> Self {
-        LangModelAPISchema::ChatCompletion
-    }
 }
 
 /// Classifies a 429 body as permanent quota exhaustion (don't retry) vs a

--- a/src/lang_model/impl/api/openai.rs
+++ b/src/lang_model/impl/api/openai.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_marshal_response_format_absent() {
         with_req("gpt-4o", None, |req| {
-            let val = OpenAIMarshal::default().marshal(req);
+            let val = OpenAIMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(
                 body.as_object().unwrap().get("text").is_none(),
@@ -758,7 +758,7 @@ mod tests {
             stream: false,
         };
 
-        let val = OpenAIMarshal::default().marshal(&req);
+        let val = OpenAIMarshal.marshal(&req);
         let body = val.as_object().unwrap().get("body").unwrap();
 
         assert_eq!(
@@ -787,10 +787,7 @@ mod tests {
             "output": [],
             "usage": {"input_tokens": 200, "output_tokens": 75}
         });
-        let usage = OpenAIUnmarshal::default()
-            .unmarshal(response)
-            .unwrap()
-            .usage;
+        let usage = OpenAIUnmarshal.unmarshal(response).unwrap().usage;
         assert_eq!(
             usage,
             Some(TokenUsage {
@@ -913,7 +910,7 @@ mod tests {
     #[test]
     fn test_marshal_max_output_tokens_set() {
         with_req("gpt-5.4-mini", Some(1024), |req| {
-            let val = OpenAIMarshal::default().marshal(req);
+            let val = OpenAIMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             let max_tokens = body.as_object().unwrap().get("max_output_tokens").unwrap();
             assert_eq!(max_tokens.as_integer().unwrap(), 1024);
@@ -923,7 +920,7 @@ mod tests {
     #[test]
     fn test_marshal_max_output_tokens_absent_when_none() {
         with_req("gpt-5.4-mini", None, |req| {
-            let val = OpenAIMarshal::default().marshal(req);
+            let val = OpenAIMarshal.marshal(req);
             let body = val.as_object().unwrap().get("body").unwrap();
             assert!(body.as_object().unwrap().get("max_output_tokens").is_none());
         });
@@ -1027,8 +1024,11 @@ mod tests {
         .unwrap()
         .to_vec();
 
-        let model =
-            build_openai_model("openai_test_tool_result_with_image", "gpt-5.4-mini", api_key);
+        let model = build_openai_model(
+            "openai_test_tool_result_with_image",
+            "gpt-5.4-mini",
+            api_key,
+        );
 
         let messages = vec![
             Message::new(Role::User).with_contents([Part::text(

--- a/src/lang_model/options.rs
+++ b/src/lang_model/options.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -74,20 +76,35 @@ impl ResponseFormat {
 }
 
 impl schemars::JsonSchema for ResponseFormat {
-    fn schema_name() -> String {
+    fn schema_name() -> Cow<'static, str> {
         "ResponseFormat".into()
     }
 
-    fn json_schema(_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        use schemars::schema::{InstanceType, ObjectValidation, SchemaObject, SingleOrVec};
-        SchemaObject {
-            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
-            object: Some(Box::new(ObjectValidation {
-                required: ["type".to_owned()].into(),
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-        .into()
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "object",
+            "required": ["type"]
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use schemars::JsonSchema;
+
+    use super::ResponseFormat;
+
+    #[test]
+    fn json_schema_preserves_tagged_object_contract() {
+        let schema =
+            <ResponseFormat as JsonSchema>::json_schema(&mut schemars::SchemaGenerator::default());
+
+        assert_eq!(
+            serde_json::to_value(schema).unwrap(),
+            serde_json::json!({
+                "type": "object",
+                "required": ["type"]
+            })
+        );
     }
 }

--- a/src/skill/skill.rs
+++ b/src/skill/skill.rs
@@ -178,7 +178,7 @@ mod tests {
             "/workspace/skills/greet_dir_name/SKILL.md",
             b"---\nname: greet\ndescription: say hello\n---\nbody\n".to_vec(),
         )];
-        let metas = scan_declared_skills(&files, &[dir.clone()]).unwrap();
+        let metas = scan_declared_skills(&files, std::slice::from_ref(&dir)).unwrap();
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].name, "greet");
         assert_eq!(metas[0].description, "say hello");

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -75,7 +75,7 @@ async fn download(
         .await
         .map_err(|e| format!("request failed: {e}"))?;
     let status = resp.status().as_u16();
-    let final_url = resp.url().to_string();
+    let final_url = resp.uri().to_string();
     let content_type = resp
         .headers()
         .get(wreq::header::CONTENT_TYPE)

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use html_to_markdown_rs::{ConversionOptions, OutputFormat};
 use parking_lot::Mutex;
@@ -554,7 +556,7 @@ mod tests {
         assert!(
             body.to_ascii_lowercase().contains("accuweather") || body.contains("분당구"),
             "body should mention AccuWeather or 분당구, got first 200 chars: {:?}",
-            &body.chars().take(200).collect::<String>()
+            body.chars().take(200).collect::<String>()
         );
         assert!(retrieved_at.ends_with('Z'), "retrieved_at: {retrieved_at}");
     }
@@ -580,7 +582,7 @@ mod tests {
         assert!(
             body.contains("<html") || body.contains("<HTML"),
             "html format should preserve markup, got first 200 chars: {:?}",
-            &body.chars().take(200).collect::<String>()
+            body.chars().take(200).collect::<String>()
         );
     }
 }

--- a/src/tool/impl/builtins/web_search/engines/bing.rs
+++ b/src/tool/impl/builtins/web_search/engines/bing.rs
@@ -272,12 +272,11 @@ mod tests {
             .select(&engine.sel_caption)
             .flat_map(|p| {
                 p.children().filter_map(|child| {
-                    if let Some(el) = child.value().as_element() {
-                        if el.name() == "span" {
-                            if el.attr("class").unwrap_or("").contains("algoSlug_icon") {
-                                return None;
-                            }
-                        }
+                    if let Some(el) = child.value().as_element()
+                        && el.name() == "span"
+                        && el.attr("class").unwrap_or("").contains("algoSlug_icon")
+                    {
+                        return None;
                     }
                     Some(
                         scraper::ElementRef::wrap(child)

--- a/src/tool/impl/builtins/web_search/engines/brave.rs
+++ b/src/tool/impl/builtins/web_search/engines/brave.rs
@@ -74,11 +74,7 @@ impl SearchEngine for Brave {
         let cookie_header = if server_cookies.is_empty() {
             brave_default_cookies().to_string()
         } else {
-            format!(
-                "{}; {}",
-                server_cookies.join("; "),
-                brave_default_cookies()
-            )
+            format!("{}; {}", server_cookies.join("; "), brave_default_cookies())
         };
 
         // spellcheck=0 prevents silent query rewrites (e.g. "ailoy" → "alloy").
@@ -185,9 +181,7 @@ mod tests {
                     .select(&engine.result_link)
                     .find_map(|a| a.value().attr("href").map(str::to_owned))?;
                 let parsed = url::Url::parse(&href).ok()?;
-                if parsed.host().is_none() {
-                    return None;
-                }
+                parsed.host()?;
                 let title = snippet
                     .select(&engine.result_title)
                     .next()

--- a/src/tool/impl/builtins/web_search/engines/duckduckgo.rs
+++ b/src/tool/impl/builtins/web_search/engines/duckduckgo.rs
@@ -232,8 +232,7 @@ mod tests {
         // `#links .web-result` selector naturally skips them.
         let engine = DuckDuckGo::new().expect("Failed to create DuckDuckGo engine");
         // Ad lives outside #links
-        let html = format!(
-            r#"<html><body>
+        let html = r#"<html><body>
               <div class="result result--ad">
                 <h2 class="result__title">
                   <a class="result__a" href="https://ads.example.com">Sponsored Result</a>
@@ -248,8 +247,7 @@ mod tests {
                   <a class="result__snippet" href="https://legit.com/">Real description</a>
                 </div>
               </div>
-            </body></html>"#
-        );
+            </body></html>"#.to_string();
         let document = Html::parse_document(&html);
 
         let results = engine

--- a/src/tool/impl/builtins/web_search/engines/yahoo.rs
+++ b/src/tool/impl/builtins/web_search/engines/yahoo.rs
@@ -102,7 +102,13 @@ mod tests {
     fn test_build_sb_cookie_includes_all_pairs() {
         let c = build_sb_cookie();
         for required in [
-            "v=1", "vm=p", "fl=1", "vl=lang_en", "pn=10", "rw=new", "userset=1",
+            "v=1",
+            "vm=p",
+            "fl=1",
+            "vl=lang_en",
+            "pn=10",
+            "rw=new",
+            "userset=1",
         ] {
             assert!(
                 c.contains(required),
@@ -154,7 +160,7 @@ mod tests {
             el.select(&engine.parser.result_url)
                 .next()
                 .and_then(|a| a.value().attr("href"))
-                .map(|href| Yahoo::extract_redirect_url(href))
+                .map(Yahoo::extract_redirect_url)
                 .filter(|url| !url.is_empty())
         });
 


### PR DESCRIPTION
## Summary

This PR performs the Ailoy side of the dependency modernization tracked by #422:

- migrates `schemars` from 0.8.22 to 0.9.0 and ports the three manual `JsonSchema` implementations;
- preserves the existing `Value`, `Bytes`, and `ResponseFormat` schema payloads with regression coverage;
- updates the remaining compatible direct dependencies, including `base64` 0.23, `jsonschema` 0.49, and `test-with` 0.17;
- resolves the existing Rust 1.97 Clippy warning baseline;
- migrates the actively used web client from `wreq` 5.3 / `wreq-util` 2.2 to exact v6 release-candidate pins;
- removes the advisory-affected `lru` 0.13 path from the resolved dependency graph.

The wreq migration is the only prerelease exception. After publishing wreq 5.3.0, upstream has continued publishing the active client line as successive v6.0 release candidates rather than cutting another stable 5.x or 6.0 release. Current development and the `lru` fix are available on that RC line. Both RC dependencies are pinned exactly so the lock graph cannot move to a later candidate without review.

Refs #422

## Dependency audit

| Dependency | Before | After | Migration notes | Verification |
| --- | --- | --- | --- | --- |
| `schemars` | 0.8.22 | 0.9.0 | Ports manual schemas to `Schema`, `SchemaGenerator`, and `json_schema!`; changes the URL feature from `url` to `url2`. | Schema contract tests and full test suite |
| `base64` | 0.22 | 0.23 | Compatible stable API refresh. | Check, Clippy, and tests |
| `jsonschema` | 0.48 | 0.49 | Compatible stable validator refresh. | Schema and response-format tests |
| `test-with` | 0.16 | 0.17 | Updates the test environment helper. | Full test suite |
| `wreq` | 5.3.0 | `=6.0.0-rc.29` | Adopts `Response::uri()` and explicitly preserves charset, OS-level proxy detection (`system-proxy`), plus gzip, Brotli, deflate, zstd, and streaming support. | Check, warnings-denied Clippy, `cargo tree -e features`, existing web fetch/search tests |
| `wreq-util` | 2.2.6 | `=3.0.0-rc.14` | Enables `emulation-compression`; v3 no longer enables the old compression behavior implicitly. | Full test suite and dependency-tree inspection |
| `lru` through wreq | 0.13.0 | 0.18.1 | Removes the active `IterMut` advisory path. The remaining `lru` instance is shared by wreq and `html-to-markdown-rs`. | `cargo tree -i lru`; RustSec scan |
| compatible transitive graph | older patches | current compatible patches | Refreshes html-to-markdown, Tokio, serde_json, tar, quinn, and the wreq transport stack. | Lockfile resolution, check, Clippy, tests |

No dependency declaration is removed.

## Commits

### [`3b5d943`](https://github.com/brekkylab/ailoy/commit/3b5d9436d443bf5ba51b1c05a5f45bb73ab92aac) — chore(deps): migrate schemars from 0.8 to 0.9

- ports the manual `JsonSchema` implementations away from public 0.8 schema internals;
- preserves the serialized schema contracts:
  - `Value`: `{}`;
  - `Bytes`: `{"type":"string","format":"base64"}`;
  - `ResponseFormat`: `{"type":"object","required":["type"]}`;
- updates the Schemars URL feature to the 0.9-compatible `url2` name.

### [`f1a042a`](https://github.com/brekkylab/ailoy/commit/f1a042a54f32faebc2e0d417095e8f5bb9c2c5ff) — chore: resolve clippy warnings on Rust 1.97

- resolves the 42-warning lib-test baseline reported by current stable Clippy;
- applies mechanical idiom updates without removing behavior or tests;
- makes the warnings-denied gate pass.

### [`c2163c4`](https://github.com/brekkylab/ailoy/commit/c2163c4b27228cdbed3c0bd65c84a403462be3e1) — chore(deps): refresh remaining stable dependencies

- updates `base64`, `jsonschema`, and `test-with`;
- refreshes compatible transitive patches;
- retains Schemars 0.9 because the current stable Aide line used by agent-k still depends on it.

### [`6aca191`](https://github.com/brekkylab/ailoy/commit/6aca191dbf8f4a862ff9415102af564ad4ea5070) — chore(deps): migrate wreq stack to v6 RC

- pins `wreq =6.0.0-rc.29` and `wreq-util =3.0.0-rc.14` exactly;
- replaces the removed `Response::url()` accessor with `Response::uri()`;
- explicitly enables the compression and charset features previously supplied implicitly by wreq-util 2.x;
- enables `emulation-compression` so Firefox emulation continues to advertise a matching content-encoding profile;
- replaces the active `lru` 0.13 dependency with 0.18.1.

This commit changes no test source.

### [`6ed0447`](https://github.com/brekkylab/ailoy/commit/6ed04478b56784ea8e8ae39ad2c1b2ff8fa8c108) — chore: declare rust-version 1.95.0

Addresses review feedback. `test-with` 0.17 raises its own `rust-version` to 1.95.0, up from 1.88.0 in 0.16.x, and is the only crate in the resolved graph above 1.91. Building the test targets on an older toolchain failed with no declared minimum to point at, so cargo surfaced it as a compile error inside the dependency. Declares the requirement on `[workspace.package]` and inherits it into `[package]` via `rust-version.workspace = true`.

### [`53039e7`](https://github.com/brekkylab/ailoy/commit/53039e7905c2e43aba85af04433379df2407140c) — fix(deps): restore OS-level proxy detection under wreq 6

Addresses review feedback, and fixes a behavior regression introduced by `6aca191`. wreq 5 read the macOS network configuration through `macos-system-configuration`, which its `default` set enabled, and read the Windows registry unconditionally. wreq 6 gates both behind a single `system-proxy` feature absent from `default`, so the v6 pin silently dropped OS-level proxy detection on both platforms.

The path stays live regardless: `ClientBuilder` still defaults `auto_sys_proxy` to true and pushes a system proxy matcher. `Matcher::from_system` continues to read `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`, so only the OS-configured case was affected. Since this crate never sets a proxy explicitly, `web_fetch` and `web_search` would have failed with plain connection errors for anyone whose proxy is configured only through macOS System Settings or the Windows registry.

Enables `system-proxy`, and records above the line why each wreq feature is listed by name so a future pin bump can be audited against the default set. The lockfile gains only two dependency edges on `wreq` itself; no new package or version resolves, as `system-configuration` 0.7.0 and `windows-registry` 0.6.1 were already in the graph.

## Compatibility decisions

| Item | Selected | Newer candidate | Decision |
| --- | --- | --- | --- |
| Schemars | 0.9.0 | 1.x | Wait for a stable Aide release supporting Schemars 1; forcing it now would split or break the shared schema graph. |
| wreq | `=6.0.0-rc.29` | unreleased 6.0 stable | Since 5.3.0, upstream releases have continued on the v6.0 RC line; stable 5.3 retains the active `lru` advisory, whose fix is present in the maintained RC line. |
| wreq-util | `=3.0.0-rc.14` | unreleased 3.0 stable | Kept on the matching RC line and pinned exactly. |
| microsandbox | 0.6.7 | current stable | Retains upstream `bincode` and `rustls-pemfile` warnings until their owning projects migrate. |

No alpha, beta, nightly, or canary dependency is introduced.

## Security audit

The wreq migration removes the active `lru 0.13` unsoundness warning.

| Finding at PR head | Reachability | Disposition |
| --- | --- | --- |
| `rsa 0.9.10` timing-side-channel advisory | Lockfile-only; absent from the all-features inverse dependency tree | No patched stable release is available |
| `bincode 2.0.1` unmaintained | Active through microsandbox / msb-imago | Requires a versioned QCOW2 metadata migration upstream |
| `rustls-pemfile 2.2.0` unmaintained | Active through microsandbox image/network TLS handling | Requires an upstream microsandbox migration |

Current RustSec result:

- 1 vulnerability finding: `rsa`, lockfile-only;
- 2 warnings: `bincode` and `rustls-pemfile`, both unmaintained;
- no remaining `lru` advisory.

## Verification

- `cargo check --all-features --all-targets`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
  - lib tests: 327 passed, 0 failed, 17 ignored
  - integration target: 11 passed, 0 failed, 4 ignored
  - doctests: 0 passed, 0 failed, 3 ignored
  - whole suite: 338 passed, 0 failed, 24 ignored
- RustSec scan: 1 vulnerability, 2 unmaintained warnings
- `cargo tree -i lru`: only `lru 0.18.1`
- `cargo tree --all-features -e features`: `wreq feature "system-proxy"` present
- `cargo metadata --no-deps`: `ailoy` reports `rust_version = 1.95.0`

