### PR TITLE
fix(agent): seed the system message into a resumed history

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -136,8 +136,8 @@ impl AgentBuilder {
     }
 
     /// Seed the agent's [`AgentState::history`] (e.g. for resuming a prior session).
-    /// When non-empty, this overrides the system message that the spec's instruction
-    /// would otherwise produce.
+    /// A system message here overrides the one the spec's instruction would produce;
+    /// otherwise the instruction is still seeded, at the front of this history.
     pub fn history(mut self, history: impl IntoIterator<Item = Message>) -> Self {
         self.history = history.into_iter().collect();
         self
@@ -495,5 +495,47 @@ mod tests {
             .build()
             .unwrap();
         assert!(agent.get_context_manager().is_some());
+    }
+
+    fn msg(role: Role, text: &str) -> Message {
+        Message::new(role).with_contents([crate::message::Part::text(text)])
+    }
+
+    #[tokio::test]
+    async fn test_instruction_seeded_into_history_without_system_message() {
+        ensure_dummy_provider();
+        let agent = AgentBuilder::new(TEST_MODEL)
+            .agent_provider(TEST_PROVIDER_NAME)
+            .instruction("You are a test agent.")
+            .history([msg(Role::User, "hello"), msg(Role::Assistant, "hi")])
+            .build()
+            .unwrap();
+
+        let history = agent.get_history();
+        assert_eq!(history.len(), 3);
+        assert_eq!(
+            system_text(&agent).as_deref(),
+            Some("You are a test agent.")
+        );
+        assert_eq!(history[1].role, Role::User);
+        assert_eq!(history[2].role, Role::Assistant);
+    }
+
+    #[tokio::test]
+    async fn test_existing_system_message_is_not_replaced() {
+        ensure_dummy_provider();
+        let agent = AgentBuilder::new(TEST_MODEL)
+            .agent_provider(TEST_PROVIDER_NAME)
+            .instruction("spec instruction")
+            .history([
+                msg(Role::System, "stored instruction"),
+                msg(Role::User, "hello"),
+            ])
+            .build()
+            .unwrap();
+
+        let history = agent.get_history();
+        assert_eq!(history.len(), 2);
+        assert_eq!(system_text(&agent).as_deref(), Some("stored instruction"));
     }
 }

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -136,8 +136,8 @@ impl AgentBuilder {
     }
 
     /// Seed the agent's [`AgentState::history`] (e.g. for resuming a prior session).
-    /// A system message here overrides the one the spec's instruction would produce;
-    /// otherwise the instruction is still seeded, at the front of this history.
+    /// A leading system message here overrides the one the spec's instruction would
+    /// produce; otherwise the instruction is still seeded, at the front of this history.
     pub fn history(mut self, history: impl IntoIterator<Item = Message>) -> Self {
         self.history = history.into_iter().collect();
         self

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -106,10 +106,10 @@ impl Agent {
     /// skill paths are **not** rewritten, so sub-agent skills are portable
     /// across parents.
     ///
-    /// If `state.history` is empty, a system message synthesised from
-    /// `spec.instruction` and the declared skills table is seeded as the first
-    /// entry.  When `state.history` is non-empty (e.g. resuming a prior
-    /// session) it is taken as-is and no system message is synthesised.
+    /// Unless `state.history` already carries a [`Role::System`] message, one
+    /// synthesised from `spec.instruction` and the declared skills table is
+    /// inserted at the front; a history that carries one is taken as-is, so the
+    /// caller's own system message wins.
     pub fn try_with_provider_and_state(
         spec: AgentSpec,
         provider: impl AsRef<str>,
@@ -167,8 +167,9 @@ impl Agent {
         }
 
         // Build the system message: instruction + (optionally) skills table.
-        // Only seeded when the caller didn't supply a pre-existing history.
-        if state.history.is_empty() {
+        // `any`, not `history[0]`: a system message anywhere means the caller
+        // manages it, and the providers resolve theirs by first match.
+        if !state.history.iter().any(|m| m.role == Role::System) {
             let declared_skills = scan_declared_skills(&spec.files, &spec.skills)?;
             let skills_block = render_skills_table(&declared_skills);
             let system_text = match (spec.instruction.as_deref(), skills_block) {
@@ -178,9 +179,12 @@ impl Agent {
                 (None, None) => None,
             };
             if let Some(text) = system_text {
-                state
-                    .history
-                    .push(Message::new(Role::System).with_contents([Part::text(text)]));
+                // Front: the providers read the first system message, and
+                // `ContextManager` only pins `history[0]` against eviction.
+                state.history.insert(
+                    0,
+                    Message::new(Role::System).with_contents([Part::text(text)]),
+                );
             }
         }
 

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -167,8 +167,8 @@ impl Agent {
         }
 
         // Build the system message: instruction + (optionally) skills table.
-        // `any`, not `history[0]`: a system message anywhere means the caller
-        // manages it, and the providers resolve theirs by first match.
+        // `any`, not `history[0]`: a system message anywhere means the caller manages
+        // it, and seeding a second one would either shadow theirs or ship both.
         if !state.history.iter().any(|m| m.role == Role::System) {
             let declared_skills = scan_declared_skills(&spec.files, &spec.skills)?;
             let skills_block = render_skills_table(&declared_skills);
@@ -179,8 +179,8 @@ impl Agent {
                 (None, None) => None,
             };
             if let Some(text) = system_text {
-                // Front: the providers read the first system message, and
-                // `ContextManager` only pins `history[0]` against eviction.
+                // Front: that is where every schema expects a system message, whether
+                // it extracts the first one or sends them in place.
                 state.history.insert(
                     0,
                     Message::new(Role::System).with_contents([Part::text(text)]),

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -106,10 +106,10 @@ impl Agent {
     /// skill paths are **not** rewritten, so sub-agent skills are portable
     /// across parents.
     ///
-    /// Unless `state.history` already carries a [`Role::System`] message, one
-    /// synthesised from `spec.instruction` and the declared skills table is
-    /// inserted at the front; a history that carries one is taken as-is, so the
-    /// caller's own system message wins.
+    /// Unless `state.history` already leads with a [`Role::System`] message, one
+    /// synthesised from `spec.instruction` and the declared skills table is inserted
+    /// at the front; a history that leads with one is taken as-is, so the caller's
+    /// own system message wins.
     pub fn try_with_provider_and_state(
         spec: AgentSpec,
         provider: impl AsRef<str>,
@@ -167,8 +167,8 @@ impl Agent {
         }
 
         // Build the system message: instruction + (optionally) skills table.
-        // `any`, not `history[0]`: a system message anywhere means the caller manages
-        // it, and seeding a second one would either shadow theirs or ship both.
+        // A system message is expected only at index 0; `any` covers a stray one too,
+        // since seeding a second would either shadow theirs or ship both.
         if !state.history.iter().any(|m| m.role == Role::System) {
             let declared_skills = scan_declared_skills(&spec.files, &spec.skills)?;
             let skills_block = render_skills_table(&declared_skills);


### PR DESCRIPTION
## Description

The instruction + skills table was synthesised only when `state.history` was empty, so a host that rebuilds the `Agent` each turn from a spec plus a persisted conversation — which stores only the user/assistant turns — ran with no system message from the second turn onward. Seed it whenever the history does not lead with a `Role::System` message instead, inserted at the front.

Persisting the system message is not the alternative: its text is derived from the spec, so a stored copy goes stale whenever the instruction or skill set changes.

## Behaviour change

```rust
AgentBuilder::new(model)
    .instruction("...")                 // spec carries an instruction
    .history([user_msg, assistant_msg]) // non-empty, no system message
    .build()
```

- Before: seeding was skipped, and the agent ran with no system message.
- After: a system message is inserted at index 0.

That is the only case affected. A host doing this deliberately — inlining its instruction into the first user message, or keeping `spec.instruction` as display metadata it never sends — now gets a system message it did not ask for. Hosts that round-trip `get_history()` in full are unaffected, since the returned history includes the seeded system message and the condition never fires. A history leading with its own system message is still taken as-is, and its text still wins over `spec.instruction`.

## Changes

- `src/agent/rt.rs` — `Agent::try_with_provider_and_state`: condition `state.history.is_empty()` → `!state.history.iter().any(|m| m.role == Role::System)`, and `push` → `insert(0, …)`. Front, because that is where every schema expects a system message — Anthropic, Gemini and OpenAI extract the first one, and ChatCompletion sends them in place.
- The predicate is `any`, one step wider than the documented leading-position contract: a stray system message past index 0 still suppresses seeding, where a `history[0]` check would seed a second one and let the first-match lookup drop the caller's.
- `src/agent/builder.rs` — two regression tests.
- Doc comments on the call sites updated to the new contract.

Sub-agents are unaffected — `subagent.rs` builds each invocation with a fresh `AgentState::new()`.

## Tests

- Instruction seeded into a history lacking a system message — `[User, Assistant]` yields length 3, system message at index 0, original turns preserved.
- Existing system message neither replaced nor duplicated — `[System, User]` stays at length 2 and keeps its own text despite a differing `spec.instruction`.
- Suite: `cargo test --lib agent::` — 39 passed, 0 failed, 0 ignored (7 of them need API keys from `.env`).
