### PR TITLE
fix(sandbox): gate host-side web_fetch egress and scope guest host reach per port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ infer = "0.22"
 log = "0.4"
 microsandbox = { version = "0.6.7", optional = true }
 # `microsandbox` facade does not re-export the network policy builder types;
-# used directly to build per-variant SandboxNetwork egress policies.
+# used directly to build the per-posture egress rules in `runenv::sandbox`.
 microsandbox-network = { version = "0.6.7", optional = true }
 # The wire-format `NetworkPolicy` that `SandboxSpec` stores also lacks a
 # facade re-export (the facade's `NetworkPolicy` is the engine-side type).

--- a/src/runenv/mod.rs
+++ b/src/runenv/mod.rs
@@ -39,6 +39,12 @@
 //! # Ok(()) }
 //! ```
 //!
+//! A sandbox built that way reaches nothing outside itself: the default
+//! posture is `SandboxNetwork::HostOnly` with no host ports, so the guest gets
+//! gateway DNS and no more. Outbound reach is opt-in through
+//! `SandboxBuilder::network` — `SandboxNetwork::Public` for the whole
+//! internet, or `with_domain_suffixes` to name only the hosts needed.
+//!
 //! # Lifecycle
 //!
 //! [`Machine::start`] starts the backend on the first call and returns a

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -154,46 +154,149 @@ fn wire_network_policy(policy: NetworkPolicy) -> microsandbox_types::NetworkPoli
     serde_json::from_value(value).expect("engine and wire NetworkPolicy share one JSON schema")
 }
 
-/// Guest network reachability. The sandbox host
-/// (`host.microsandbox.internal`, e.g. an ailoy VFS forward server) is
-/// reachable in **every** variant; they differ only in outside reach. There is
-/// no fully-offline variant. All map to a [`NetworkPolicy`] with
-/// `default_ingress: Allow` (published-port behavior).
+/// How far outside itself the guest can reach. There is no fully-offline
+/// variant; every variant permits DNS to the sandbox gateway so the guest can
+/// resolve names at all.
+///
+/// Reaching a service on the host is a separate grant, expressed per port
+/// through [`NetworkPosture::host_ports`]. That split is deliberate: a posture
+/// on its own says nothing about which host services are exposed, so widening
+/// the outside reach cannot silently widen host reach too.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxNetwork {
-    /// Host only — no public internet, LAN, loopback, or metadata.
-    /// Least-privilege for VFS-in-sandbox.
-    HostOnly,
-    /// Host + public internet, but not private LAN, loopback, link-local,
-    /// cloud-metadata, or multicast. The default.
+    /// Nothing but the host ports explicitly granted, plus gateway DNS. The
+    /// default, and the least-privilege posture for VFS-in-sandbox.
     #[default]
+    HostOnly,
+    /// The public internet, but not private LAN, loopback, link-local,
+    /// cloud-metadata, or multicast.
     Public,
-    /// Unrestricted egress/ingress — `Public` plus LAN, loopback, link-local,
-    /// cloud-metadata, and multicast. Grant deliberately (reopens SSRF).
+    /// Unrestricted egress *and* ingress — `Public` plus LAN, loopback,
+    /// link-local, cloud-metadata, multicast, and every host port regardless of
+    /// [`NetworkPosture::host_ports`]. Grant deliberately; it reopens SSRF.
     Full,
 }
 
 impl SandboxNetwork {
-    /// The microsandbox policy for this variant.
-    fn policy(self) -> NetworkPolicy {
-        use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
-        // `allow_egress(Host)` permits any port to the host — including :53, so
-        // the guest's `host.microsandbox.internal` DNS lookup works.
-        let host = || Rule::allow_egress(Destination::Group(DestinationGroup::Host));
-        let public = || Rule::allow_egress(Destination::Group(DestinationGroup::Public));
-        match self {
-            SandboxNetwork::HostOnly => NetworkPolicy {
-                default_egress: Action::Deny,
-                default_ingress: Action::Allow,
-                rules: vec![host()],
-            },
-            SandboxNetwork::Public => NetworkPolicy {
-                default_egress: Action::Deny,
-                default_ingress: Action::Allow,
-                rules: vec![public(), host()],
-            },
-            SandboxNetwork::Full => NetworkPolicy::allow_all(),
+    /// This posture plus egress to the listed host TCP ports.
+    pub fn with_host_ports(self, ports: impl IntoIterator<Item = u16>) -> NetworkPosture {
+        NetworkPosture::from(self).with_host_ports(ports)
+    }
+
+    /// This posture plus egress to the listed domain suffixes.
+    pub fn with_domain_suffixes(
+        self,
+        suffixes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> NetworkPosture {
+        NetworkPosture::from(self).with_domain_suffixes(suffixes)
+    }
+}
+
+/// A guest network posture: how far out the guest can reach, and which host TCP
+/// ports it may open.
+///
+/// `host_ports` has to be named explicitly because the convenience constructor
+/// for a host rule (`Rule::allow_egress(Group(Host))`) leaves the port set
+/// empty, and an empty port set means every port. A guest that needs one host
+/// service would otherwise be handed the whole host: SSH, a database, a
+/// container daemon, anything bound to `0.0.0.0`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct NetworkPosture {
+    /// Outside reach.
+    pub network: SandboxNetwork,
+    /// Host TCP ports the guest may connect to. Gateway DNS is always allowed
+    /// and does not need to be listed.
+    #[serde(default)]
+    pub host_ports: Vec<u16>,
+    /// Domain suffixes the guest may reach, matching the apex and any
+    /// subdomain. Lets a session that has to install packages name its
+    /// registries instead of taking [`SandboxNetwork::Public`] and the whole
+    /// internet with it.
+    ///
+    /// Matching works through the gateway resolver's hostname cache, so it
+    /// covers names the guest looked up there — which is every name it can
+    /// resolve under these postures.
+    #[serde(default)]
+    pub domain_suffixes: Vec<String>,
+}
+
+impl From<SandboxNetwork> for NetworkPosture {
+    fn from(network: SandboxNetwork) -> Self {
+        Self {
+            network,
+            host_ports: Vec::new(),
+            domain_suffixes: Vec::new(),
+        }
+    }
+}
+
+impl NetworkPosture {
+    /// Grant egress to these host TCP ports, replacing any already set.
+    pub fn with_host_ports(mut self, ports: impl IntoIterator<Item = u16>) -> Self {
+        self.host_ports = ports.into_iter().collect();
+        self
+    }
+
+    /// Grant egress to these domain suffixes, replacing any already set.
+    pub fn with_domain_suffixes(
+        mut self,
+        suffixes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.domain_suffixes = suffixes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// The microsandbox policy for this posture.
+    fn policy(&self) -> NetworkPolicy {
+        use std::str::FromStr as _;
+
+        use microsandbox_network::policy::{
+            Action, Destination, DestinationGroup, Direction, DomainName, PortRange, Protocol, Rule,
+        };
+
+        if matches!(self.network, SandboxNetwork::Full) {
+            return NetworkPolicy::allow_all();
+        }
+
+        // `Rule::allow_dns()` is narrow: UDP/TCP :53 to the gateway addresses
+        // only, not to arbitrary resolvers the guest might aim at. It has to
+        // come first, because under deny-by-default a policy without it refuses
+        // every DNS query, including the one for `host.microsandbox.internal`.
+        let mut rules = vec![Rule::allow_dns()];
+        if matches!(self.network, SandboxNetwork::Public) {
+            rules.push(Rule::allow_egress(Destination::Group(
+                DestinationGroup::Public,
+            )));
+        }
+        rules.extend(self.host_ports.iter().map(|&port| Rule {
+            direction: Direction::Egress,
+            destination: Destination::Group(DestinationGroup::Host),
+            protocols: vec![Protocol::Tcp],
+            ports: vec![PortRange::single(port)],
+            action: Action::Allow,
+        }));
+        rules.extend(self.domain_suffixes.iter().filter_map(|suffix| {
+            match DomainName::from_str(suffix) {
+                Ok(name) => Some(Rule::allow_egress(Destination::DomainSuffix(name))),
+                // Dropping the entry means the domain simply is not reachable,
+                // so a typo costs a failed install rather than an unintended
+                // grant. Logged loudly because the failure is otherwise opaque.
+                Err(e) => {
+                    log::warn!("sandbox network: ignoring invalid domain suffix '{suffix}': {e}");
+                    None
+                }
+            }
+        }));
+
+        NetworkPolicy {
+            default_egress: Action::Deny,
+            // microsandbox's own serde default. It only governs connections
+            // inbound to a published guest port, and nothing here publishes
+            // one, so this is fail-closed for a capability that does not exist
+            // yet rather than a restriction on anything in use.
+            default_ingress: Action::Deny,
+            rules,
         }
     }
 }
@@ -212,9 +315,11 @@ impl Default for SandboxBuilder {
         config.spec.resources.memory_mib = 2048;
         config.spec.runtime.workdir = Some("/root".to_string());
         config.spec.pull_policy = PullPolicy::IfMissing;
-        // Default network posture: host + public internet (see SandboxNetwork).
+        // Default posture: gateway DNS and nothing else (see SandboxNetwork).
+        // Anything wider is opt-in, so a caller that never thinks about the
+        // network does not get outbound reach by accident.
         config.spec.network.enabled = true;
-        config.spec.network.policy = Some(wire_network_policy(SandboxNetwork::default().policy()));
+        config.spec.network.policy = Some(wire_network_policy(NetworkPosture::default().policy()));
         Self {
             config,
             default_timeout_secs: 60,
@@ -266,11 +371,14 @@ impl SandboxBuilder {
         self
     }
 
-    /// Set the guest network posture. The host is reachable in every variant;
-    /// see [`SandboxNetwork`]. Defaults to [`SandboxNetwork::Public`].
-    pub fn network(mut self, network: SandboxNetwork) -> Self {
+    /// Set the guest network posture. Accepts a bare [`SandboxNetwork`] for
+    /// outside reach alone, or [`SandboxNetwork::with_host_ports`] to also grant
+    /// specific host TCP ports. Defaults to [`SandboxNetwork::HostOnly`] with no
+    /// host ports.
+    pub fn network(mut self, posture: impl Into<NetworkPosture>) -> Self {
+        let posture = posture.into();
         self.config.spec.network.enabled = true;
-        self.config.spec.network.policy = Some(wire_network_policy(network.policy()));
+        self.config.spec.network.policy = Some(wire_network_policy(posture.policy()));
         self
     }
 
@@ -400,22 +508,23 @@ impl Sandbox {
     /// snapshot directory unpacked by this call is cleaned up before
     /// returning (success or failure).
     pub async fn try_from_archive(path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        Self::try_from_archive_inner(path, SandboxNetwork::default()).await
+        Self::try_from_archive_inner(path, NetworkPosture::default()).await
     }
 
     /// Like [`try_from_archive`](Self::try_from_archive) but with an explicit
-    /// [`SandboxNetwork`]. An archive is only a filesystem snapshot and doesn't
-    /// carry the network policy, so the desired posture is re-applied here.
+    /// posture. An archive is only a filesystem snapshot and doesn't carry the
+    /// network policy, so the desired posture is re-applied here — including its
+    /// host ports, which are otherwise lost across the round trip.
     pub async fn try_from_archive_with_network(
         path: impl AsRef<Path>,
-        network: SandboxNetwork,
+        posture: impl Into<NetworkPosture>,
     ) -> anyhow::Result<Self> {
-        Self::try_from_archive_inner(path, network).await
+        Self::try_from_archive_inner(path, posture.into()).await
     }
 
     async fn try_from_archive_inner(
         path: impl AsRef<Path>,
-        network: SandboxNetwork,
+        posture: NetworkPosture,
     ) -> anyhow::Result<Self> {
         ensure_msb().await?;
 
@@ -429,17 +538,16 @@ impl Sandbox {
         // so its file name is not the original sandbox name. The manifest's
         // `source_sandbox` records the name the snapshot was taken from; reuse
         // that. Fall back to a fresh generated name for name-less snapshots.
-        let name = snap
-            .manifest()
-            .source_sandbox
-            .clone()
-            .unwrap_or_else(|| format!("ailoy-{}", hex::encode(&Uuid::new_v4().as_bytes()[..8])));
+        let name =
+            snap.manifest().source_sandbox.clone().unwrap_or_else(|| {
+                format!("ailoy-{}", hex::encode(&Uuid::new_v4().as_bytes()[..8]))
+            });
 
         let result = microsandbox::Sandbox::builder(&name)
             .from_snapshot(snap_path.to_string_lossy().into_owned())
             .pull_policy(PullPolicy::IfMissing)
             .replace()
-            .network(|n| n.policy(network.policy()))
+            .network(|n| n.policy(posture.policy()))
             .create()
             .await
             .context("create sandbox from snapshot");
@@ -851,8 +959,8 @@ mod tests {
             .exit_code
     }
 
-    /// `SandboxNetwork::HostOnly` grants egress to the sandbox host only —
-    /// public egress stays blocked (the least-privilege VFS posture).
+    /// `SandboxNetwork::HostOnly` grants gateway DNS and whatever host ports
+    /// were asked for, nothing else — public egress stays blocked.
     #[tokio::test]
     async fn test_host_only_blocks_public_egress() {
         assert_ne!(
@@ -862,14 +970,288 @@ mod tests {
         );
     }
 
-    /// Contrast: `SandboxNetwork::Public` (the default) allows public egress,
-    /// confirming HostOnly's block is the policy — not a broken network.
+    /// Contrast: `SandboxNetwork::Public` allows public egress, confirming
+    /// HostOnly's block is the policy — not a broken network.
     #[tokio::test]
     async fn test_public_allows_public_egress() {
         assert_eq!(
             public_egress_exit_code(SandboxNetwork::Public).await,
             0,
             "public TCP connect (1.1.1.1:443) must succeed under Public"
+        );
+    }
+
+    /// The port set has to be enforced by microsandbox, not merely recorded in
+    /// the spec. Two host listeners, one port granted and one not: the guest
+    /// must reach exactly one of them. This is the grant a host-side forward
+    /// server depends on, so it is worth proving against a real VM rather than
+    /// only against the evaluator.
+    #[tokio::test]
+    async fn test_host_ports_are_enforced_from_inside_the_guest() {
+        // Bound on all interfaces because the guest arrives via the gateway
+        // address, not loopback.
+        let granted = tokio::net::TcpListener::bind("0.0.0.0:0")
+            .await
+            .expect("bind granted port");
+        let ungranted = tokio::net::TcpListener::bind("0.0.0.0:0")
+            .await
+            .expect("bind ungranted port");
+        let granted_port = granted.local_addr().expect("granted addr").port();
+        let ungranted_port = ungranted.local_addr().expect("ungranted addr").port();
+        // Keep accepting, so a connect the policy permits actually completes.
+        tokio::spawn(async move { while granted.accept().await.is_ok() {} });
+        tokio::spawn(async move { while ungranted.accept().await.is_ok() {} });
+
+        let mut sandbox = SandboxBuilder::new()
+            .image("alpine:latest")
+            .network(SandboxNetwork::HostOnly.with_host_ports([granted_port]))
+            .build()
+            .await
+            .expect("build");
+        let console = sandbox.start().await.expect("start");
+        let probe = |port: u16| format!("nc -zw5 host.microsandbox.internal {port} 2>/dev/null");
+
+        let allowed = console
+            .exec_shell(probe(granted_port), Some(15))
+            .await
+            .expect("exec granted probe")
+            .exit_code;
+        let blocked = console
+            .exec_shell(probe(ungranted_port), Some(15))
+            .await
+            .expect("exec ungranted probe")
+            .exit_code;
+
+        assert_eq!(
+            allowed, 0,
+            "host port {granted_port} was granted and must be reachable"
+        );
+        assert_ne!(
+            blocked, 0,
+            "host port {ungranted_port} was not granted and must be unreachable"
+        );
+    }
+
+    // ── network policy, evaluated directly ─────────────────────────────────────
+    //
+    // The tests above boot a VM to observe the policy's effect, which is slow
+    // and can only probe one destination per run. These ask microsandbox's own
+    // evaluator what a posture decides, so a rule that is wider than intended
+    // shows up as a failing assertion rather than as an open port nobody looked
+    // at.
+
+    /// Shared state carrying a gateway IP, which is what `DestinationGroup::Host`
+    /// rules match against.
+    fn policy_test_state() -> microsandbox_network::shared::SharedState {
+        let shared = microsandbox_network::shared::SharedState::new(8);
+        shared.set_gateway_ips(Some(std::net::Ipv4Addr::new(10, 0, 2, 2)), None);
+        shared
+    }
+
+    /// Decide one guest → host TCP connect under `posture`.
+    fn host_port_action(
+        posture: &NetworkPosture,
+        port: u16,
+    ) -> microsandbox_network::policy::Action {
+        use microsandbox_network::policy::Protocol;
+
+        let shared = policy_test_state();
+        posture.policy().evaluate_egress(
+            std::net::SocketAddr::from((std::net::Ipv4Addr::new(10, 0, 2, 2), port)),
+            Protocol::Tcp,
+            &shared,
+        )
+    }
+
+    /// A posture that grants one host port must grant only that port. Every
+    /// other host service — SSH, a database, a container daemon — has to stay
+    /// out of reach, which is what an empty port set in a host rule would give
+    /// away.
+    #[test]
+    fn host_ports_grant_only_the_listed_port() {
+        use microsandbox_network::policy::Action;
+
+        let posture = SandboxNetwork::HostOnly.with_host_ports([9000]);
+        assert_eq!(host_port_action(&posture, 9000), Action::Allow);
+        for port in [22, 2375, 5432, 9200, 11434] {
+            assert_eq!(
+                host_port_action(&posture, port),
+                Action::Deny,
+                "host port {port} must not be reachable"
+            );
+        }
+    }
+
+    /// No posture reaches a host port that was not asked for, `Public` included
+    /// — widening outside reach must not widen host reach.
+    #[test]
+    fn no_posture_reaches_unlisted_host_ports() {
+        use microsandbox_network::policy::Action;
+
+        for network in [SandboxNetwork::HostOnly, SandboxNetwork::Public] {
+            let posture = NetworkPosture::from(network);
+            for port in [22, 2375, 5432, 9200, 11434] {
+                assert_eq!(
+                    host_port_action(&posture, port),
+                    Action::Deny,
+                    "{network:?} must not reach host port {port}"
+                );
+            }
+        }
+    }
+
+    /// Gateway DNS survives the narrowing. Without it a deny-by-default policy
+    /// refuses every lookup, including the one for `host.microsandbox.internal`,
+    /// and the guest has no working network at all.
+    #[test]
+    fn every_posture_allows_gateway_dns() {
+        use microsandbox_network::policy::{Action, Protocol};
+
+        for network in [SandboxNetwork::HostOnly, SandboxNetwork::Public] {
+            let policy = NetworkPosture::from(network).policy();
+            let shared = policy_test_state();
+            for protocol in [Protocol::Udp, Protocol::Tcp] {
+                assert_eq!(
+                    policy.evaluate_egress(
+                        std::net::SocketAddr::from((std::net::Ipv4Addr::new(10, 0, 2, 2), 53)),
+                        protocol,
+                        &shared,
+                    ),
+                    Action::Allow,
+                    "{network:?} must allow gateway DNS over {protocol:?}"
+                );
+            }
+        }
+    }
+
+    /// Inbound connections are refused unless a rule says otherwise. Nothing
+    /// publishes a guest port today; this keeps the first one that does from
+    /// being reachable by every peer on the LAN by default.
+    #[test]
+    fn unmatched_ingress_is_denied() {
+        use microsandbox_network::policy::{Action, Protocol};
+
+        for network in [SandboxNetwork::HostOnly, SandboxNetwork::Public] {
+            let policy = NetworkPosture::from(network).policy();
+            let shared = policy_test_state();
+            assert_eq!(
+                policy.evaluate_ingress(
+                    std::net::SocketAddr::from((std::net::Ipv4Addr::new(192, 168, 0, 14), 54321)),
+                    8080,
+                    Protocol::Tcp,
+                    &shared,
+                ),
+                Action::Deny,
+                "{network:?} must refuse an unmatched inbound connection"
+            );
+        }
+    }
+
+    /// The default posture is the narrow one, so a caller that never mentions
+    /// the network gets no outbound reach beyond DNS.
+    #[test]
+    fn default_posture_is_host_only_with_no_host_ports() {
+        use microsandbox_network::policy::Action;
+
+        let posture = NetworkPosture::default();
+        assert_eq!(posture.network, SandboxNetwork::HostOnly);
+        assert!(posture.host_ports.is_empty());
+
+        let shared = policy_test_state();
+        assert_eq!(
+            posture.policy().evaluate_egress(
+                "1.1.1.1:443".parse().expect("literal socket address"),
+                microsandbox_network::policy::Protocol::Tcp,
+                &shared,
+            ),
+            Action::Deny,
+            "the default posture must not reach the public internet"
+        );
+    }
+
+    /// A domain allowlist reaches the named registry and its subdomains without
+    /// opening the rest of the internet. The evaluator matches these through the
+    /// resolver's hostname cache, so the test seeds the cache the way a guest
+    /// lookup would.
+    #[test]
+    fn domain_suffixes_allow_only_the_named_domains() {
+        use std::{net::IpAddr, time::Duration};
+
+        use microsandbox_network::{
+            policy::{Action, Protocol},
+            shared::ResolvedHostnameFamily,
+        };
+
+        let posture = SandboxNetwork::HostOnly.with_domain_suffixes(["pypi.org"]);
+        let policy = posture.policy();
+        let shared = policy_test_state();
+
+        let allowed: IpAddr = "151.101.0.223".parse().expect("literal address");
+        let denied: IpAddr = "203.0.114.5".parse().expect("literal address");
+        shared.cache_resolved_hostname(
+            "files.pythonhosted.pypi.org",
+            ResolvedHostnameFamily::Ipv4,
+            [allowed],
+            Duration::from_secs(60),
+        );
+        shared.cache_resolved_hostname(
+            "registry.evil.example",
+            ResolvedHostnameFamily::Ipv4,
+            [denied],
+            Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            policy.evaluate_egress(
+                std::net::SocketAddr::from((allowed, 443)),
+                Protocol::Tcp,
+                &shared
+            ),
+            Action::Allow,
+            "a subdomain of an allowlisted suffix must be reachable"
+        );
+        assert_eq!(
+            policy.evaluate_egress(
+                std::net::SocketAddr::from((denied, 443)),
+                Protocol::Tcp,
+                &shared
+            ),
+            Action::Deny,
+            "a domain outside the allowlist must stay blocked"
+        );
+    }
+
+    /// An unparseable suffix must not become a wider grant. It is dropped, so
+    /// the posture behaves as if it had never been listed.
+    #[test]
+    fn invalid_domain_suffix_is_dropped_rather_than_widening_the_policy() {
+        let bad = SandboxNetwork::HostOnly.with_domain_suffixes(["not a domain"]);
+        assert_eq!(
+            bad.policy().rules.len(),
+            NetworkPosture::from(SandboxNetwork::HostOnly)
+                .policy()
+                .rules
+                .len(),
+            "an invalid suffix must add no rule"
+        );
+    }
+
+    /// `Full` stays the deliberate escape hatch: everything allowed, in both
+    /// directions, host ports included.
+    #[test]
+    fn full_allows_everything() {
+        use microsandbox_network::policy::Action;
+
+        let posture = NetworkPosture::from(SandboxNetwork::Full);
+        assert_eq!(host_port_action(&posture, 22), Action::Allow);
+        let shared = policy_test_state();
+        assert_eq!(
+            posture.policy().evaluate_egress(
+                "1.1.1.1:443".parse().expect("literal socket address"),
+                microsandbox_network::policy::Protocol::Tcp,
+                &shared,
+            ),
+            Action::Allow
         );
     }
 

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -203,7 +203,10 @@ impl SandboxNetwork {
 /// container daemon, anything bound to `0.0.0.0`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct NetworkPosture {
-    /// Outside reach.
+    /// Outside reach. Defaulted so a config that names only the fields it
+    /// cares about — `{"host_ports": [8080]}`, or `{}` — deserializes to the
+    /// narrow posture instead of failing on a missing field.
+    #[serde(default)]
     pub network: SandboxNetwork,
     /// Host TCP ports the guest may connect to. Gateway DNS is always allowed
     /// and does not need to be listed.
@@ -1167,6 +1170,27 @@ mod tests {
             Action::Deny,
             "the default posture must not reach the public internet"
         );
+    }
+
+    /// A stored posture that omits a field falls back to the narrow default
+    /// rather than failing to parse. `network` is the field worth pinning: it
+    /// is the one that decides outside reach, so a config which only lists
+    /// host ports must still come back as `HostOnly`.
+    #[test]
+    fn omitted_posture_fields_deserialize_to_the_narrow_default() {
+        let empty: NetworkPosture = serde_json::from_str("{}").expect("`{}` must deserialize");
+        assert_eq!(empty, NetworkPosture::default());
+
+        let ports_only: NetworkPosture =
+            serde_json::from_str(r#"{"host_ports":[8080]}"#).expect("host_ports alone must parse");
+        assert_eq!(ports_only.network, SandboxNetwork::HostOnly);
+        assert_eq!(ports_only.host_ports, vec![8080]);
+        assert!(ports_only.domain_suffixes.is_empty());
+
+        // An explicit value still wins over the default.
+        let explicit: NetworkPosture =
+            serde_json::from_str(r#"{"network":"public"}"#).expect("explicit network must parse");
+        assert_eq!(explicit.network, SandboxNetwork::Public);
     }
 
     /// A domain allowlist reaches the named registry and its subdomains without

--- a/src/runenv/sandbox.rs
+++ b/src/runenv/sandbox.rs
@@ -154,6 +154,13 @@ fn wire_network_policy(policy: NetworkPolicy) -> microsandbox_types::NetworkPoli
     serde_json::from_value(value).expect("engine and wire NetworkPolicy share one JSON schema")
 }
 
+/// The inverse of [`wire_network_policy`]: read a stored wire-format policy back
+/// as the engine-side one. Same shared schema, so also infallible.
+fn engine_network_policy(policy: &microsandbox_types::NetworkPolicy) -> NetworkPolicy {
+    let value = serde_json::to_value(policy).expect("NetworkPolicy serializes to JSON");
+    serde_json::from_value(value).expect("engine and wire NetworkPolicy share one JSON schema")
+}
+
 /// How far outside itself the guest can reach. There is no fully-offline
 /// variant; every variant permits DNS to the sandbox gateway so the guest can
 /// resolve names at all.
@@ -478,6 +485,15 @@ pub struct Sandbox {
     name: String,
     default_timeout_secs: u64,
     max_output_chars: usize,
+    /// The network policy this sandbox was created with, kept so [`fork`] can
+    /// put the child under the same one. A snapshot carries a filesystem and
+    /// nothing else, so a child built from one starts with microsandbox's own
+    /// default — which is `Public` egress and `default_ingress: Allow` — unless
+    /// the policy is re-applied. `None` means the config named no policy, in
+    /// which case the child inherits that same default the parent ran under.
+    ///
+    /// [`fork`]: Self::fork
+    network_policy: Option<NetworkPolicy>,
     console: Option<SandboxConsole>,
 }
 
@@ -488,6 +504,14 @@ impl Sandbox {
         max_output_chars: usize,
     ) -> anyhow::Result<Sandbox> {
         let name = config.spec.name.clone();
+        // Read off the config before it is consumed: whatever policy this
+        // sandbox runs under is what a fork of it has to run under too.
+        let network_policy = config
+            .spec
+            .network
+            .policy
+            .as_ref()
+            .map(engine_network_policy);
         let inner = microsandbox::Sandbox::create(config)
             .await
             .context("sandbox create")?;
@@ -495,6 +519,7 @@ impl Sandbox {
             name,
             default_timeout_secs,
             max_output_chars,
+            network_policy,
             console: Some(SandboxConsole {
                 inner,
                 default_timeout_secs,
@@ -562,6 +587,7 @@ impl Sandbox {
             name,
             default_timeout_secs: 60,
             max_output_chars: 30_000,
+            network_policy: Some(posture.policy()),
             console: Some(SandboxConsole {
                 inner,
                 default_timeout_secs: 60,
@@ -625,12 +651,15 @@ impl Sandbox {
             .map_err(|e| anyhow::anyhow!("fork: snapshot failed: {e}"))?;
         let snap_path = snap.path().to_path_buf();
 
-        let result = microsandbox::Sandbox::builder(&new_name)
+        let mut builder = microsandbox::Sandbox::builder(&new_name)
             .from_snapshot(snap_path.to_string_lossy().into_owned())
-            .pull_policy(PullPolicy::IfMissing)
-            .create()
-            .await
-            .context("fork: create from snapshot");
+            .pull_policy(PullPolicy::IfMissing);
+        // Without this the child falls back to microsandbox's default policy,
+        // so forking a narrow sandbox would silently widen it.
+        if let Some(policy) = self.network_policy.clone() {
+            builder = builder.network(|n| n.policy(policy));
+        }
+        let result = builder.create().await.context("fork: create from snapshot");
 
         // Clean up the temp snapshot regardless of outcome.
         if let Err(e) = Snapshot::remove(&snap_name, true).await {
@@ -650,6 +679,7 @@ impl Sandbox {
             name: new_name,
             default_timeout_secs: self.default_timeout_secs,
             max_output_chars: self.max_output_chars,
+            network_policy: self.network_policy.clone(),
             console: Some(SandboxConsole {
                 inner,
                 default_timeout_secs: self.default_timeout_secs,
@@ -1169,6 +1199,66 @@ mod tests {
             ),
             Action::Deny,
             "the default posture must not reach the public internet"
+        );
+    }
+
+    /// A snapshot carries a filesystem and no policy, so a child built from one
+    /// starts under microsandbox's default — `Public` egress and
+    /// `default_ingress: Allow` — unless the parent's policy is put back. That
+    /// would quietly undo both halves of the narrowing for anyone who forks, so
+    /// the child is probed the same way `test_host_only_blocks_public_egress`
+    /// probes a fresh one.
+    ///
+    /// `alpine` for busybox `nc`, and a raw IP rather than a name because
+    /// microsandbox answers :53 itself, so only a raw-IP connect reaches egress
+    /// policy at all.
+    #[tokio::test]
+    async fn fork_keeps_the_parent_network_posture() {
+        let mut parent = SandboxBuilder::new()
+            .image("alpine:latest")
+            .network(SandboxNetwork::HostOnly)
+            .build()
+            .await
+            .expect("build parent");
+        parent.stop().await.expect("stop parent");
+
+        let mut child = parent.fork().await.expect("fork");
+        let console = child.start().await.expect("start fork");
+        let exit_code = console
+            .exec_shell("nc -zw5 1.1.1.1 443 2>/dev/null".to_string(), Some(10))
+            .await
+            .expect("exec probe")
+            .exit_code;
+
+        assert_ne!(
+            exit_code, 0,
+            "a fork of a HostOnly sandbox must not reach the public internet"
+        );
+    }
+
+    /// The other direction, so the test above cannot pass on a fork whose
+    /// network is simply broken: a fork of a `Public` parent still gets out.
+    #[tokio::test]
+    async fn fork_of_a_public_parent_still_reaches_the_internet() {
+        let mut parent = SandboxBuilder::new()
+            .image("alpine:latest")
+            .network(SandboxNetwork::Public)
+            .build()
+            .await
+            .expect("build parent");
+        parent.stop().await.expect("stop parent");
+
+        let mut child = parent.fork().await.expect("fork");
+        let console = child.start().await.expect("start fork");
+        let exit_code = console
+            .exec_shell("nc -zw5 1.1.1.1 443 2>/dev/null".to_string(), Some(10))
+            .await
+            .expect("exec probe")
+            .exit_code;
+
+        assert_eq!(
+            exit_code, 0,
+            "a fork of a Public sandbox must still reach the public internet"
         );
     }
 

--- a/src/skill/skill.rs
+++ b/src/skill/skill.rs
@@ -242,7 +242,7 @@ mod tests {
             agent::{AgentBuilder, AgentProvider, get_agent_providers_mut},
             lang_model::{LangModelProvider, get_lm_providers_mut},
             message::{FinishReason, Message, Part, Role},
-            runenv::SandboxBuilder,
+            runenv::{SandboxBuilder, SandboxNetwork},
             tool::{ToolProvider, get_tool_providers_mut},
         };
 
@@ -397,8 +397,21 @@ Render numbers to **3 significant figures** (e.g. `0.142`, `12.3`,
             );
         }
 
+        // `python_repl` is one of the tools below, and its setup fetches uv and
+        // any wheel it installs, so the guest needs those destinations named.
+        // The image already ships python3, so the apt step is skipped and
+        // `ubuntu.com` is not among them. Which tool the model reaches for is
+        // its own choice -- today it follows the skill to `python -m timeit` in
+        // the shell -- so this is what keeps the other choice from failing on a
+        // posture the test never mentioned.
         let sandbox = SandboxBuilder::new()
             .image("python:3.12-slim")
+            .network(SandboxNetwork::HostOnly.with_domain_suffixes([
+                "github.com",            // the uv release
+                "githubusercontent.com", // where that release redirects to
+                "pypi.org",              // uv pip install
+                "pythonhosted.org",      // where the wheels live
+            ]))
             .build()
             .await
             .expect("sandbox creation failed");

--- a/src/tool/impl/builtins/mod.rs
+++ b/src/tool/impl/builtins/mod.rs
@@ -2,6 +2,7 @@ mod apply_patch;
 mod edit;
 mod glob;
 mod grep;
+mod net_guard;
 mod python_repl;
 mod read;
 mod shell;

--- a/src/tool/impl/builtins/net_guard.rs
+++ b/src/tool/impl/builtins/net_guard.rs
@@ -16,6 +16,44 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use wreq::dns::{Addrs, GaiResolver, Name, Resolve, Resolving};
 
+/// A destination this module refused.
+///
+/// A concrete type rather than a string because a refusal raised inside the
+/// resolver has to be recognized again after the connector has wrapped it,
+/// which [`blocked_reason`] does by downcast. Matching on the message text
+/// would work today and break the moment someone rewords it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blocked(String);
+
+impl std::fmt::Display for Blocked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "blocked: {}", self.0)
+    }
+}
+
+impl std::error::Error for Blocked {}
+
+/// Find a [`Blocked`] in an error's source chain.
+///
+/// `Display` on a client error stops one level in, while a refusal from
+/// [`PublicOnlyResolver`] sits three deep — under the connect error and the
+/// DNS error the connector wraps it in. Formatting the outer error therefore
+/// reports a plain connection failure, which reads as a target that happens to
+/// be down rather than one that will never be reachable. A model told the first
+/// retries; told the second it stops. Walking the chain is what keeps a name
+/// refused by the resolver reporting the same way as an IP literal refused
+/// before the connection.
+pub fn blocked_reason(err: &(dyn std::error::Error + 'static)) -> Option<String> {
+    let mut source = Some(err);
+    while let Some(e) = source {
+        if let Some(blocked) = e.downcast_ref::<Blocked>() {
+            return Some(blocked.to_string());
+        }
+        source = e.source();
+    }
+    None
+}
+
 /// Reject a host that is written as an IP literal pointing anywhere other than
 /// the public internet. A host written as a name returns `Ok` here and is
 /// gated later by [`PublicOnlyResolver`], which is the only place its actual
@@ -24,13 +62,13 @@ use wreq::dns::{Addrs, GaiResolver, Name, Resolve, Resolving};
 /// Strips the brackets an IPv6 literal is written with. Both callers hand them
 /// over — `url::Url::host_str` and `http::Uri::host` each return `[::1]` rather
 /// than `::1` — and `IpAddr` parses neither spelling with them attached.
-pub fn check_host(host: &str) -> Result<(), String> {
+pub fn check_host(host: &str) -> Result<(), Blocked> {
     let bare = host
         .strip_prefix('[')
         .and_then(|h| h.strip_suffix(']'))
         .unwrap_or(host);
     match bare.parse::<IpAddr>() {
-        Ok(ip) if !is_public(ip) => Err(format!("blocked: {ip} is not a public address")),
+        Ok(ip) if !is_public(ip) => Err(Blocked(format!("{ip} is not a public address"))),
         _ => Ok(()),
     }
 }
@@ -38,34 +76,35 @@ pub fn check_host(host: &str) -> Result<(), String> {
 /// Reject a redirect hop by scheme and host. Separate from [`check_host`] so
 /// the per-hop rule — including the scheme, which a `Location` header controls
 /// just as freely as the host — is one testable function.
-pub fn check_redirect_target(scheme: Option<&str>, host: Option<&str>) -> Result<(), String> {
+pub fn check_redirect_target(scheme: Option<&str>, host: Option<&str>) -> Result<(), Blocked> {
     match scheme {
         Some("http") | Some("https") => {}
-        Some(other) => return Err(format!("blocked: unsupported redirect scheme: {other}")),
-        None => return Err("blocked: redirect target has no scheme".to_string()),
+        Some(other) => return Err(Blocked(format!("unsupported redirect scheme: {other}"))),
+        None => return Err(Blocked("redirect target has no scheme".to_string())),
     }
     match host {
         Some(h) => check_host(h),
-        None => Err("blocked: redirect target has no host".to_string()),
+        None => Err(Blocked("redirect target has no host".to_string())),
     }
 }
 
 /// Keep only the globally routable addresses in `addrs`. Returns `Err` when
-/// nothing survives, so the caller reports a blocked host rather than an
-/// opaque connection failure.
+/// nothing survives, which the connector buries under two layers of its own
+/// error; [`blocked_reason`] is what digs it back out so the caller reports a
+/// blocked host rather than an opaque connection failure.
 fn filter_public(
     host: &str,
     addrs: impl Iterator<Item = SocketAddr>,
-) -> Result<Vec<SocketAddr>, String> {
+) -> Result<Vec<SocketAddr>, Blocked> {
     let (kept, dropped): (Vec<_>, Vec<_>) = addrs.partition(|addr| is_public(addr.ip()));
     if !dropped.is_empty() {
         let ips: Vec<IpAddr> = dropped.iter().map(|addr| addr.ip()).collect();
         log::warn!("net_guard: dropped non-public address(es) for '{host}': {ips:?}");
     }
     if kept.is_empty() {
-        return Err(format!(
-            "blocked: '{host}' resolves only to non-public addresses"
-        ));
+        return Err(Blocked(format!(
+            "'{host}' resolves only to non-public addresses"
+        )));
     }
     Ok(kept)
 }
@@ -316,7 +355,46 @@ mod tests {
         ];
         let err = filter_public("rebind.example", addrs.into_iter())
             .expect_err("all-internal answer must be refused");
-        assert!(err.contains("rebind.example"), "error text: {err}");
+        let text = err.to_string();
+        assert!(text.contains("rebind.example"), "error text: {text}");
+    }
+
+    /// The recovery `web_fetch` depends on: a refusal wrapped by layers that do
+    /// not print their source has to stay findable. Two synthetic wrappers stand
+    /// in for the connector's connect-and-DNS pair, so this holds the contract
+    /// even if wreq restructures its errors.
+    #[test]
+    fn blocked_reason_digs_a_refusal_out_of_a_source_chain() {
+        #[derive(Debug)]
+        struct Opaque(Box<dyn std::error::Error + Send + Sync>);
+        impl std::fmt::Display for Opaque {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // Deliberately drops the source, which is what hides the
+                // refusal in the real chain.
+                write!(f, "client error (Connect)")
+            }
+        }
+        impl std::error::Error for Opaque {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(self.0.as_ref())
+            }
+        }
+
+        let refusal = check_host("127.0.0.1").expect_err("loopback must be refused");
+        let wrapped = Opaque(Box::new(Opaque(Box::new(refusal))));
+        assert_eq!(
+            blocked_reason(&wrapped).as_deref(),
+            Some("blocked: 127.0.0.1 is not a public address")
+        );
+        assert_eq!(wrapped.to_string(), "client error (Connect)");
+    }
+
+    /// An unrelated failure must not be reported as a policy refusal — a target
+    /// that is genuinely down is worth retrying, and a blocked one is not.
+    #[test]
+    fn blocked_reason_ignores_an_ordinary_error() {
+        let err = std::io::Error::other("connection reset");
+        assert_eq!(blocked_reason(&err), None);
     }
 
     #[test]

--- a/src/tool/impl/builtins/net_guard.rs
+++ b/src/tool/impl/builtins/net_guard.rs
@@ -1,0 +1,325 @@
+//! Egress guard for host-side tools.
+//!
+//! Tools registered as *pure* run in the ailoy host process rather than inside
+//! the sandbox VM, so the guest network policy never sees their requests. A
+//! model — or a prompt-injected page a model reads — can otherwise aim such a
+//! tool at loopback, the LAN, or the cloud-metadata address and read the answer
+//! back into the conversation. This module decides whether a destination is on
+//! the public internet.
+//!
+//! There are two entry points because a URL names its destination in two ways:
+//! [`check_host`] for a host written as an IP literal, where the address is
+//! known before connecting, and [`PublicOnlyResolver`] for a host written as a
+//! name, where the addresses are known only once DNS answers.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use wreq::dns::{Addrs, GaiResolver, Name, Resolve, Resolving};
+
+/// Reject a host that is written as an IP literal pointing anywhere other than
+/// the public internet. A host written as a name returns `Ok` here and is
+/// gated later by [`PublicOnlyResolver`], which is the only place its actual
+/// addresses are known.
+///
+/// Accepts both spellings of an IPv6 literal: `http::Uri::host` keeps the
+/// brackets (`[::1]`), `url::Url::host_str` strips them.
+pub fn check_host(host: &str) -> Result<(), String> {
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    match bare.parse::<IpAddr>() {
+        Ok(ip) if !is_public(ip) => Err(format!("blocked: {ip} is not a public address")),
+        _ => Ok(()),
+    }
+}
+
+/// Reject a redirect hop by scheme and host. Separate from [`check_host`] so
+/// the per-hop rule — including the scheme, which a `Location` header controls
+/// just as freely as the host — is one testable function.
+pub fn check_redirect_target(scheme: Option<&str>, host: Option<&str>) -> Result<(), String> {
+    match scheme {
+        Some("http") | Some("https") => {}
+        Some(other) => return Err(format!("blocked: unsupported redirect scheme: {other}")),
+        None => return Err("blocked: redirect target has no scheme".to_string()),
+    }
+    match host {
+        Some(h) => check_host(h),
+        None => Err("blocked: redirect target has no host".to_string()),
+    }
+}
+
+/// Keep only the globally routable addresses in `addrs`. Returns `Err` when
+/// nothing survives, so the caller reports a blocked host rather than an
+/// opaque connection failure.
+fn filter_public(
+    host: &str,
+    addrs: impl Iterator<Item = SocketAddr>,
+) -> Result<Vec<SocketAddr>, String> {
+    let (kept, dropped): (Vec<_>, Vec<_>) = addrs.partition(|addr| is_public(addr.ip()));
+    if !dropped.is_empty() {
+        let ips: Vec<IpAddr> = dropped.iter().map(|addr| addr.ip()).collect();
+        log::warn!("net_guard: dropped non-public address(es) for '{host}': {ips:?}");
+    }
+    if kept.is_empty() {
+        return Err(format!(
+            "blocked: '{host}' resolves only to non-public addresses"
+        ));
+    }
+    Ok(kept)
+}
+
+/// DNS resolver that drops every answer outside the public internet before the
+/// connector can use it.
+///
+/// Filtering here rather than checking the addresses up front is what closes
+/// the DNS-rebinding window: the connector reaches only the addresses this
+/// filter returned, so there is no gap between a check and the connect for a
+/// second, inward-pointing answer to land in.
+///
+/// One case stays uncovered: with an HTTP proxy configured, the connector
+/// resolves the proxy's host and the proxy resolves the target, so the target's
+/// addresses never pass through here. That configuration comes from the host
+/// environment rather than from anything a model can set, and [`check_host`]
+/// still applies to the URL itself.
+#[derive(Clone, Default)]
+pub struct PublicOnlyResolver {
+    inner: GaiResolver,
+}
+
+impl Resolve for PublicOnlyResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        let resolving = self.inner.resolve(name);
+        Box::pin(async move {
+            let addrs = resolving.await?;
+            let kept = filter_public(&host, addrs)?;
+            Ok(Box::new(kept.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// Is `ip` a globally routable unicast address, i.e. somewhere on the public
+/// internet rather than on this host, this network, or in a special-use range?
+///
+/// Written as a blocklist of the IANA special-purpose ranges because
+/// `Ipv4Addr::is_global` is still unstable. Reserved ranges count as
+/// non-public, which errs toward refusing a fetch rather than allowing an
+/// internal one.
+fn is_public(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_public_v4(v4),
+        IpAddr::V6(v6) => {
+            // An IPv4 address embedded in an IPv6 one is still that IPv4
+            // address at the far end: `::ffff:127.0.0.1` reaches loopback, and
+            // `64:ff9b::127.0.0.1` does too wherever a NAT64 gateway sits in
+            // the path. Judge the embedded address, not the wrapper.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_public_v4(v4);
+            }
+            if let Some(v4) = nat64_embedded_v4(v6) {
+                return is_public_v4(v4);
+            }
+            is_public_v6(v6)
+        }
+    }
+}
+
+fn is_public_v4(ip: Ipv4Addr) -> bool {
+    // The ranges std already has a predicate for. `is_link_local` is the one
+    // that matters most here: 169.254.0.0/16 is where the cloud-metadata
+    // address 169.254.169.254 lives.
+    if ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+    {
+        return false;
+    }
+    // The remaining special-purpose ranges, spelled out because their
+    // predicates are unstable. In order: 0.0.0.0/8 "this network", 100.64/10
+    // carrier-grade NAT, 192.0.0/24 IETF protocol assignments, 192.88.99/24
+    // 6to4 relay anycast, 198.18/15 benchmarking, and 240/4 reserved.
+    let [a, b, c, _] = ip.octets();
+    !(a == 0
+        || (a == 100 && (64..128).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 88 && c == 99)
+        || (a == 198 && (b == 18 || b == 19))
+        || a >= 240)
+}
+
+fn is_public_v6(ip: Ipv6Addr) -> bool {
+    if ip.is_unspecified() || ip.is_loopback() || ip.is_multicast() {
+        return false;
+    }
+    // In order: the whole of ::/64, which also covers the deprecated
+    // IPv4-compatible form `::a.b.c.d`; fc00::/7 unique-local; fe80::/10
+    // link-local; fec0::/10 deprecated site-local; 2001:db8::/32
+    // documentation; 2001::/23 IETF protocol assignments; and 2002::/16 6to4.
+    // The last two are worth blocking because Teredo and 6to4 each embed an
+    // IPv4 address, so an internal target can ride inside one.
+    let s = ip.segments();
+    !((s[0] == 0 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+        || (s[0] & 0xfe00) == 0xfc00
+        || (s[0] & 0xffc0) == 0xfe80
+        || (s[0] & 0xffc0) == 0xfec0
+        || (s[0] == 0x2001 && s[1] == 0x0db8)
+        || (s[0] == 0x2001 && s[1] < 0x0200)
+        || s[0] == 0x2002)
+}
+
+/// The IPv4 address embedded in a NAT64 well-known-prefix address
+/// (`64:ff9b::/96`, RFC 6052), if this is one.
+fn nat64_embedded_v4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let s = ip.segments();
+    let is_nat64 =
+        s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0;
+    is_nat64.then(|| Ipv4Addr::from(((s[6] as u32) << 16) | s[7] as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+
+    /// The addresses an SSRF attempt actually aims at. Every one of these must
+    /// be refused before a connection is opened.
+    #[test]
+    fn check_host_rejects_non_public_literals() {
+        for host in [
+            "127.0.0.1",
+            "0.0.0.0",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254", // IMDSv1
+            "100.64.0.1",
+            "192.0.2.1",
+            "198.18.0.1",
+            "224.0.0.1",
+            "240.0.0.1",
+            "255.255.255.255",
+            "[::1]",
+            "::1",
+            "[::ffff:127.0.0.1]",
+            "[64:ff9b::7f00:1]", // NAT64-wrapped 127.0.0.1
+            "[fd00::1]",
+            "[fe80::1]",
+            "[fec0::1]",
+            "[2001:db8::1]",
+            "[2001::1]",        // Teredo
+            "[2002:7f00:1::1]", // 6to4-wrapped 127.0.0.1
+            "[::7f00:1]",       // IPv4-compatible loopback
+        ] {
+            assert!(
+                check_host(host).is_err(),
+                "{host} must be refused as non-public"
+            );
+        }
+    }
+
+    #[test]
+    fn check_host_allows_public_literals() {
+        for host in ["1.1.1.1", "8.8.8.8", "[2606:4700:4700::1111]"] {
+            assert!(check_host(host).is_ok(), "{host} must be allowed");
+        }
+    }
+
+    /// A name passes this stage even when it is known to resolve inward —
+    /// `PublicOnlyResolver` is what refuses it, once the answer is in hand.
+    /// Freezing the split here keeps a future edit from moving the check to a
+    /// place where a rebinding answer would have a window.
+    #[test]
+    fn check_host_defers_names_to_the_resolver() {
+        for host in ["localhost", "example.com", "metadata.google.internal"] {
+            assert!(check_host(host).is_ok(), "{host} must reach the resolver");
+        }
+    }
+
+    /// Obfuscated spellings of loopback. `std`'s `IpAddr` parser rejects all of
+    /// these outright, so the literal check only recognizes them because `url`
+    /// normalizes them to a dotted quad first and `fetch_one` checks the parsed
+    /// host rather than the raw input. That ordering is what makes them safe.
+    #[test]
+    fn obfuscated_loopback_urls_are_rejected_after_parsing() {
+        for raw in [
+            "http://2130706433/", // decimal
+            "http://0177.0.0.1/", // octal
+            "http://0x7f.0.0.1/", // hex
+            "http://127.1/",      // shorthand
+            "http://127.0.0.1.:8080/",
+        ] {
+            let bare = raw.trim_start_matches("http://").trim_end_matches('/');
+            assert!(
+                bare.parse::<IpAddr>().is_err(),
+                "{bare} parses as an address on its own, so this case does not \
+                 exercise the normalization path it exists to cover"
+            );
+            let url = Url::parse(raw).unwrap_or_else(|e| panic!("parse {raw}: {e}"));
+            let host = url
+                .host_str()
+                .unwrap_or_else(|| panic!("{raw} has no host"));
+            assert!(
+                check_host(host).is_err(),
+                "{raw} normalized to host {host}, which must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn redirect_target_requires_http_scheme_and_public_host() {
+        assert!(check_redirect_target(Some("https"), Some("example.com")).is_ok());
+        assert!(check_redirect_target(Some("http"), Some("1.1.1.1")).is_ok());
+        assert!(check_redirect_target(Some("http"), Some("127.0.0.1")).is_err());
+        assert!(check_redirect_target(Some("file"), Some("example.com")).is_err());
+        assert!(check_redirect_target(None, Some("example.com")).is_err());
+        assert!(check_redirect_target(Some("https"), None).is_err());
+    }
+
+    /// A split answer — one public address, one internal — must connect only to
+    /// the public one rather than being refused outright or, worse, allowed
+    /// through wholesale.
+    #[test]
+    fn filter_public_keeps_public_and_drops_internal() {
+        let addrs = vec![
+            "1.1.1.1:443".parse::<SocketAddr>().unwrap(),
+            "127.0.0.1:443".parse::<SocketAddr>().unwrap(),
+            "169.254.169.254:80".parse::<SocketAddr>().unwrap(),
+        ];
+        let kept = filter_public("split.example", addrs.into_iter()).expect("public addr survives");
+        assert_eq!(kept, vec!["1.1.1.1:443".parse::<SocketAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn filter_public_errors_when_every_answer_is_internal() {
+        let addrs = vec![
+            "127.0.0.1:80".parse::<SocketAddr>().unwrap(),
+            "10.1.2.3:80".parse::<SocketAddr>().unwrap(),
+        ];
+        let err = filter_public("rebind.example", addrs.into_iter())
+            .expect_err("all-internal answer must be refused");
+        assert!(err.contains("rebind.example"), "error text: {err}");
+    }
+
+    #[test]
+    fn nat64_prefix_unwraps_to_its_ipv4() {
+        let ip: Ipv6Addr = "64:ff9b::7f00:1".parse().unwrap();
+        assert_eq!(nat64_embedded_v4(ip), Some(Ipv4Addr::new(127, 0, 0, 1)));
+        let ip: Ipv6Addr = "64:ff9b::808:808".parse().unwrap();
+        assert_eq!(nat64_embedded_v4(ip), Some(Ipv4Addr::new(8, 8, 8, 8)));
+        // A public address that merely starts with 0064 is not the NAT64 prefix.
+        let ip: Ipv6Addr = "64:ff9c::1".parse().unwrap();
+        assert_eq!(nat64_embedded_v4(ip), None);
+    }
+
+    /// The NAT64 unwrap must not turn a public embedded address into a block.
+    #[test]
+    fn nat64_wrapping_a_public_address_stays_allowed() {
+        assert!(check_host("[64:ff9b::808:808]").is_ok());
+    }
+}

--- a/src/tool/impl/builtins/net_guard.rs
+++ b/src/tool/impl/builtins/net_guard.rs
@@ -208,6 +208,15 @@ fn is_public_v6(ip: Ipv6Addr) -> bool {
     // NAT64 prefixes of any length up to /96, so the embedded address does not
     // sit at a fixed offset the way it does under the well-known prefix, and
     // there is no address in the range worth reaching anyway.
+    //
+    // Then three ranges that carry no embedded address and reach no service:
+    // 100::/64 discards whatever is sent to it, and 3fff::/20 and 5f00::/16 are
+    // reserved for documentation and for SRv6 segment identifiers. None is
+    // routable, so none belongs on the allowed side of a predicate that answers
+    // "is this on the public internet".
+    //
+    // 2001:20::/28 (ORCHIDv2) and 2001:30::/28 (DRIP) need no entry of their
+    // own — both sit inside 2001::/23 above.
     let s = ip.segments();
     !((s[0] == 0 && s[1] == 0 && s[2] == 0 && s[3] == 0)
         || (s[0] & 0xfe00) == 0xfc00
@@ -216,7 +225,10 @@ fn is_public_v6(ip: Ipv6Addr) -> bool {
         || (s[0] == 0x2001 && s[1] == 0x0db8)
         || (s[0] == 0x2001 && s[1] < 0x0200)
         || s[0] == 0x2002
-        || (s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0x0001))
+        || (s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0x0001)
+        || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+        || (s[0] == 0x3fff && (s[1] & 0xf000) == 0)
+        || s[0] == 0x5f00)
 }
 
 /// The IPv4 address embedded in a NAT64 well-known-prefix address
@@ -267,6 +279,11 @@ mod tests {
             // rather than unwrapped, which these two spellings pin.
             "[64:ff9b:1::7f00:1]",
             "[64:ff9b:1:ffff::a9fe:a9fe]",
+            "[100::1]",           // RFC 6666 discard-only
+            "[3fff::1]",          // RFC 9637 documentation
+            "[3fff:fff:ffff::1]", // top of that /20
+            "[5f00::1]",          // RFC 9602 SRv6 SIDs
+            "[2001:20::1]",       // ORCHIDv2, covered by 2001::/23
         ] {
             assert!(
                 check_host(host).is_err(),
@@ -275,9 +292,19 @@ mod tests {
         }
     }
 
+    /// The addresses just outside the narrower reserved ranges are included so
+    /// a mask that is one bit too wide fails here rather than silently refusing
+    /// traffic that should have gone out.
     #[test]
     fn check_host_allows_public_literals() {
-        for host in ["1.1.1.1", "8.8.8.8", "[2606:4700:4700::1111]"] {
+        for host in [
+            "1.1.1.1",
+            "8.8.8.8",
+            "[2606:4700:4700::1111]",
+            "[100:0:0:1::1]", // outside 100::/64
+            "[3fff:1000::1]", // outside 3fff::/20
+            "[5f01::1]",      // outside 5f00::/16
+        ] {
             assert!(check_host(host).is_ok(), "{host} must be allowed");
         }
     }

--- a/src/tool/impl/builtins/net_guard.rs
+++ b/src/tool/impl/builtins/net_guard.rs
@@ -21,8 +21,9 @@ use wreq::dns::{Addrs, GaiResolver, Name, Resolve, Resolving};
 /// gated later by [`PublicOnlyResolver`], which is the only place its actual
 /// addresses are known.
 ///
-/// Accepts both spellings of an IPv6 literal: `http::Uri::host` keeps the
-/// brackets (`[::1]`), `url::Url::host_str` strips them.
+/// Strips the brackets an IPv6 literal is written with. Both callers hand them
+/// over — `url::Url::host_str` and `http::Uri::host` each return `[::1]` rather
+/// than `::1` — and `IpAddr` parses neither spelling with them attached.
 pub fn check_host(host: &str) -> Result<(), String> {
     let bare = host
         .strip_prefix('[')
@@ -162,6 +163,12 @@ fn is_public_v6(ip: Ipv6Addr) -> bool {
     // documentation; 2001::/23 IETF protocol assignments; and 2002::/16 6to4.
     // The last two are worth blocking because Teredo and 6to4 each embed an
     // IPv4 address, so an internal target can ride inside one.
+    //
+    // 64:ff9b:1::/48 is here for the same embedding reason but is refused
+    // outright rather than unwrapped. RFC 8215 reserves it for network-specific
+    // NAT64 prefixes of any length up to /96, so the embedded address does not
+    // sit at a fixed offset the way it does under the well-known prefix, and
+    // there is no address in the range worth reaching anyway.
     let s = ip.segments();
     !((s[0] == 0 && s[1] == 0 && s[2] == 0 && s[3] == 0)
         || (s[0] & 0xfe00) == 0xfc00
@@ -169,7 +176,8 @@ fn is_public_v6(ip: Ipv6Addr) -> bool {
         || (s[0] & 0xffc0) == 0xfec0
         || (s[0] == 0x2001 && s[1] == 0x0db8)
         || (s[0] == 0x2001 && s[1] < 0x0200)
-        || s[0] == 0x2002)
+        || s[0] == 0x2002
+        || (s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0x0001))
 }
 
 /// The IPv4 address embedded in a NAT64 well-known-prefix address
@@ -215,6 +223,11 @@ mod tests {
             "[2001::1]",        // Teredo
             "[2002:7f00:1::1]", // 6to4-wrapped 127.0.0.1
             "[::7f00:1]",       // IPv4-compatible loopback
+            // RFC 8215 network-specific NAT64. The prefix may be anywhere up to
+            // /96, so the embedded address moves; the whole /48 is refused
+            // rather than unwrapped, which these two spellings pin.
+            "[64:ff9b:1::7f00:1]",
+            "[64:ff9b:1:ffff::a9fe:a9fe]",
         ] {
             assert!(
                 check_host(host).is_err(),
@@ -318,8 +331,12 @@ mod tests {
     }
 
     /// The NAT64 unwrap must not turn a public embedded address into a block.
+    /// Only the well-known prefix unwraps, so this stays scoped to it: the
+    /// neighbouring `64:ff9b:1::/48` is refused wholesale, and `64:ff9c::/32`
+    /// is an ordinary public range that must not be caught by either rule.
     #[test]
     fn nat64_wrapping_a_public_address_stays_allowed() {
         assert!(check_host("[64:ff9b::808:808]").is_ok());
+        assert!(check_host("[64:ff9c::1]").is_ok());
     }
 }

--- a/src/tool/impl/builtins/python_repl/mod.rs
+++ b/src/tool/impl/builtins/python_repl/mod.rs
@@ -278,8 +278,19 @@ mod tests {
     /// reach, or this would pass just as well against an accidentally-open
     /// policy. `test_host_only_blocks_public_egress` covers the other baseline:
     /// that `HostOnly` on its own reaches nothing outward.
+    ///
+    /// Ignored for the same reason the web_search tests are: it leans on three
+    /// services this repo does not control, and one of them is a moving target
+    /// — the setup script asks GitHub for the *latest* uv release, so a change
+    /// to that release breaks this test without anything here changing. Run it
+    /// when the posture or the setup script moves:
+    ///
+    /// ```text
+    /// cargo test --features sandbox --lib -- --ignored sandbox_setup_under_domain_allowlist
+    /// ```
     #[cfg(feature = "sandbox")]
     #[tokio::test]
+    #[ignore = "slow: boots a VM and installs from apt, GitHub, and PyPI"]
     async fn sandbox_setup_under_domain_allowlist() {
         use crate::runenv::{SandboxBuilder, SandboxNetwork};
 

--- a/src/tool/impl/builtins/python_repl/mod.rs
+++ b/src/tool/impl/builtins/python_repl/mod.rs
@@ -267,4 +267,92 @@ mod tests {
         );
         let _ = std::fs::remove_file(&plot_path);
     }
+
+    /// The domain allowlist documented on `SETUP_CMD` is the narrow posture that
+    /// actually gets `python_repl` running inside a sandbox. Proving it needs a
+    /// real VM: the setup script fetches over both plain HTTP (apt, matched from
+    /// the gateway resolver's cache) and TLS (the uv release and PyPI, matched by
+    /// SNI), and only the runtime exercises those two paths.
+    ///
+    /// The control is the second half — a domain nobody listed has to stay out of
+    /// reach, or this would pass just as well against an accidentally-open
+    /// policy. `test_host_only_blocks_public_egress` covers the other baseline:
+    /// that `HostOnly` on its own reaches nothing outward.
+    #[cfg(feature = "sandbox")]
+    #[tokio::test]
+    async fn sandbox_setup_under_domain_allowlist() {
+        use crate::runenv::{SandboxBuilder, SandboxNetwork};
+
+        let mut sandbox = SandboxBuilder::new()
+            .network(SandboxNetwork::HostOnly.with_domain_suffixes([
+                "ubuntu.com",
+                "github.com",
+                "githubusercontent.com",
+                "pypi.org",
+                "pythonhosted.org",
+            ]))
+            .build()
+            .await
+            .expect("build sandbox");
+        let console = sandbox.start().await.expect("start sandbox");
+
+        let provider = provider();
+        let funcs = provider.provide(&[get_python_repl_tool_desc()]).unwrap();
+        let f = funcs.get("python_repl").unwrap();
+
+        // Bootstrap (apt -> uv release -> venv) plus a real wheel download.
+        let msg = f
+            .call(
+                crate::to_value!({
+                    "code": "import idna; print('idna', idna.__name__)",
+                    "pip_install": ["idna"]
+                }),
+                "1",
+                console,
+            )
+            .next()
+            .await
+            .unwrap()
+            .message;
+        let result = msg.contents[0].as_value().unwrap();
+        assert_eq!(
+            result.pointer("/exit_code").and_then(|v| v.as_integer()),
+            Some(0),
+            "setup and pip install must succeed under the documented posture: {result:?}"
+        );
+
+        // Control: a destination outside the allowlist stays unreachable, over
+        // the same TLS path the allowed ones just used.
+        let blocked = f
+            .call(
+                crate::to_value!({
+                    "code": "import urllib.request; \
+                             urllib.request.urlopen('https://example.com', timeout=15)"
+                }),
+                "2",
+                console,
+            )
+            .next()
+            .await
+            .unwrap()
+            .message;
+        let blocked = blocked.contents[0].as_value().unwrap();
+        assert_ne!(
+            blocked.pointer("/exit_code").and_then(|v| v.as_integer()),
+            Some(0),
+            "an unlisted domain must not be reachable: {blocked:?}"
+        );
+        // Checked by kind, not just by exit code: a syntax error in the probe
+        // would also exit non-zero and would look like a block. `urlopen` wraps
+        // every connection-level OSError -- refusal, reset, timeout -- in
+        // URLError, so this holds regardless of how the runtime drops it.
+        let stderr = blocked
+            .pointer("/stderr")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            stderr.contains("URLError"),
+            "the probe must fail on the connection, not on the script: {stderr}"
+        );
+    }
 }

--- a/src/tool/impl/builtins/python_repl/runner.rs
+++ b/src/tool/impl/builtins/python_repl/runner.rs
@@ -13,6 +13,34 @@ use crate::runenv::{Console, ExecResult};
 ///   1. Ensure python3 + ca-certificates (apt-get fallback for bare ubuntu images).
 ///   2. Resolve uv: symlink from PATH, or download the platform binary via Python urllib.
 ///   3. Create the venv via uv.
+///
+/// # Network reach this needs
+///
+/// Every step above fetches something, so on a [`Console`] backed by a sandbox
+/// this setup runs under the guest network policy. The default posture
+/// (`SandboxNetwork::HostOnly` with no host ports) permits only gateway DNS, and
+/// setup fails there on its first step — `apt-get` cannot reach a mirror, so
+/// `python3` never installs.
+///
+/// A caller that binds `python_repl` to a sandbox has to widen the posture. The
+/// narrow way is to name the destinations rather than take the whole internet:
+///
+/// ```ignore
+/// SandboxNetwork::HostOnly.with_domain_suffixes([
+///     "ubuntu.com",             // apt mirrors, for images without python3
+///     "github.com",             // the uv release
+///     "githubusercontent.com",  // where that release redirects to
+///     "pypi.org",               // uv pip install
+///     "pythonhosted.org",       // where the wheels themselves live
+/// ])
+/// ```
+///
+/// The redirect host and the wheel host are separate entries because a suffix
+/// matches the name actually connected to, not the one first requested. An image
+/// that already ships `python3` and `uv` needs only the last two.
+/// `SandboxNetwork::Public` also works and is the blunt version of the same
+/// grant. `sandbox_setup_under_domain_allowlist`, in the parent module's tests,
+/// runs this script against a real VM under exactly the posture above.
 const SETUP_CMD: &str = r#"set -e
 AILOY_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/ailoy"
 mkdir -p "$AILOY_CACHE/bin"

--- a/src/tool/impl/builtins/python_repl/runner.rs
+++ b/src/tool/impl/builtins/python_repl/runner.rs
@@ -40,7 +40,14 @@ use crate::runenv::{Console, ExecResult};
 /// that already ships `python3` and `uv` needs only the last two.
 /// `SandboxNetwork::Public` also works and is the blunt version of the same
 /// grant. `sandbox_setup_under_domain_allowlist`, in the parent module's tests,
-/// runs this script against a real VM under exactly the posture above.
+/// runs this script against a real VM under exactly the posture above. It is
+/// `#[ignore]`d because it installs from three services this repo does not
+/// control, so changing either the posture above or the script below means
+/// running it by hand:
+///
+/// ```text
+/// cargo test --features sandbox --lib -- --ignored sandbox_setup_under_domain_allowlist
+/// ```
 const SETUP_CMD: &str = r#"set -e
 AILOY_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/ailoy"
 mkdir -p "$AILOY_CACHE/bin"

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -101,7 +101,13 @@ async fn download(
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        // A refusal from the resolver arrives wrapped in a connect error whose
+        // `Display` drops it, so it has to be recovered rather than formatted.
+        // Without this a blocked name reports a plain connection failure and is
+        // indistinguishable from a target that is merely down.
+        .map_err(|e| {
+            net_guard::blocked_reason(&e).unwrap_or_else(|| format!("request failed: {e}"))
+        })?;
     let status = resp.status().as_u16();
     let final_url = resp.uri().to_string();
     let content_type = resp
@@ -352,7 +358,7 @@ async fn fetch_one(
     // parsing, so `http://2130706433/` arrives here as `127.0.0.1`.
     if let Err(e) = net_guard::check_host(&host) {
         log::warn!("web_fetch: refused {url_str}: {e}");
-        return crate::to_value!({"url": url_str, "error": e});
+        return crate::to_value!({"url": url_str, "error": e.to_string()});
     }
     log::debug!("web_fetch: fetching {url_str}");
 
@@ -615,6 +621,61 @@ mod tests {
         );
     }
 
+    /// The same refusal reached by name instead of by literal. It travels a
+    /// different path — the resolver rather than the up-front check — and the
+    /// connector wraps it in an error whose `Display` drops it, so without the
+    /// recovery in `download` this reports a bare connect failure. The two must
+    /// read alike: a model retries a connection that failed and gives up on one
+    /// that policy refused, and this refusal will never succeed.
+    #[tokio::test]
+    async fn fetch_one_refuses_a_name_resolving_inward_with_the_same_error() {
+        use std::sync::{Arc, Mutex};
+
+        use axum::{Router, routing::get};
+
+        let hits = Arc::new(Mutex::new(0u32));
+        let count = hits.clone();
+        let app = Router::new().route(
+            "/admin",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    *count.lock().unwrap() += 1;
+                    "INTERNAL-ONLY db_password=hunter2"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        // `localhost` clears the literal check and is refused by the resolver,
+        // which is the whole point of routing it by name.
+        let result = fetch_one(
+            WebFetchState::new(),
+            format!("http://localhost:{port}/admin"),
+            0,
+            DEFAULT_BODY_CHARS,
+            BodyFormat::Text,
+        )
+        .await;
+
+        let error = result
+            .pointer("/error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            error.starts_with("blocked: "),
+            "a name refused by the resolver must report like a refused literal, \
+             got {result:?}"
+        );
+        assert_eq!(
+            *hits.lock().unwrap(),
+            0,
+            "the request must never reach the service"
+        );
+    }
+
     /// A public-looking start URL that redirects inward must fail at the hop.
     /// The start host is a name so it clears the literal check, and the resolve
     /// override aims it at the local server — the only way to exercise the
@@ -678,9 +739,14 @@ mod tests {
             1,
             "the first hop must be served, otherwise this test proves nothing"
         );
+        let error = result
+            .pointer("/error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
         assert!(
-            result.pointer("/error").is_some(),
-            "following the hop must fail, got {result:?}"
+            error.starts_with("blocked: "),
+            "following the hop must fail as a refusal, not as a bare transport \
+             error, got {result:?}"
         );
         assert_eq!(
             *meta_hits.lock().unwrap(),

--- a/src/tool/impl/builtins/web_fetch.rs
+++ b/src/tool/impl/builtins/web_fetch.rs
@@ -7,9 +7,10 @@ use std::{
 use html_to_markdown_rs::{ConversionOptions, OutputFormat};
 use parking_lot::Mutex;
 use url::Url;
-use wreq::Client;
+use wreq::{Client, ClientBuilder};
 use wreq_util::Emulation;
 
+use super::net_guard;
 use crate::{
     datatype::Value,
     tool::{ToolDesc, ToolDescBuilder, ToolFunc},
@@ -22,6 +23,7 @@ const MAX_DOWNLOAD_BYTES: usize = 2 * 1024 * 1024;
 const MAX_URL_CHARS: usize = 2048;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 const PER_HOST_MIN_INTERVAL: Duration = Duration::from_millis(1000);
+const MAX_REDIRECTS: usize = 10;
 
 #[derive(Clone)]
 struct WebFetchState {
@@ -31,10 +33,36 @@ struct WebFetchState {
 
 impl WebFetchState {
     fn new() -> Self {
-        let client = Client::builder()
+        Self::from_builder(Self::client_builder())
+    }
+
+    /// Client configuration shared by production and tests. `web_fetch` runs in
+    /// the host process, so the two settings that keep it inside the same
+    /// network boundary the sandbox enforces live here:
+    ///
+    /// - the DNS resolver drops every non-public answer, which covers both a
+    ///   name that points inward and one that re-resolves inward mid-request;
+    /// - the redirect policy re-checks each hop, because a public start URL can
+    ///   `302` to an internal address and a `Location` holding an IP literal
+    ///   never reaches the resolver at all.
+    fn client_builder() -> ClientBuilder {
+        Client::builder()
             .emulation(Emulation::Firefox135)
-            .redirect(wreq::redirect::Policy::limited(10))
+            .dns_resolver(net_guard::PublicOnlyResolver::default())
+            .redirect(wreq::redirect::Policy::custom(|attempt| {
+                let target = attempt.uri.clone();
+                if let Err(e) = net_guard::check_redirect_target(target.scheme_str(), target.host())
+                {
+                    log::warn!("web_fetch: refused redirect to {target}: {e}");
+                    return attempt.error(e);
+                }
+                wreq::redirect::Policy::limited(MAX_REDIRECTS).redirect(attempt)
+            }))
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+    }
+
+    fn from_builder(builder: ClientBuilder) -> Self {
+        let client = builder
             .build()
             .expect("wreq::Client builder cannot fail with these settings");
         Self {
@@ -319,6 +347,14 @@ async fn fetch_one(
         Some(h) => h.to_string(),
         None => return crate::to_value!({"url": url_str, "error": "url has no host"}),
     };
+    // Checked on the parsed host, not the raw input: `url` normalizes the
+    // decimal, octal, and hex spellings of an address into a dotted quad while
+    // parsing, so `http://2130706433/` arrives here as `127.0.0.1`.
+    if let Err(e) = net_guard::check_host(&host) {
+        log::warn!("web_fetch: refused {url_str}: {e}");
+        return crate::to_value!({"url": url_str, "error": e});
+    }
+    log::debug!("web_fetch: fetching {url_str}");
 
     rate_limit_for(&state, &host).await;
 
@@ -524,6 +560,133 @@ mod tests {
         let desc = get_web_fetch_tool_desc();
         assert_eq!(desc.name, "web_fetch");
         assert!(desc.description.is_some());
+    }
+
+    /// A loopback target must be refused before a connection happens, not just
+    /// have its body withheld. The server here stands in for an internal
+    /// service: if it records a hit, the guard ran too late to matter.
+    #[tokio::test]
+    async fn fetch_one_refuses_loopback_before_connecting() {
+        use std::sync::{Arc, Mutex};
+
+        use axum::{Router, routing::get};
+
+        let hits = Arc::new(Mutex::new(0u32));
+        let count = hits.clone();
+        let app = Router::new().route(
+            "/admin",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    *count.lock().unwrap() += 1;
+                    "INTERNAL-ONLY db_password=hunter2"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        let result = fetch_one(
+            WebFetchState::new(),
+            format!("http://{addr}/admin"),
+            0,
+            DEFAULT_BODY_CHARS,
+            BodyFormat::Text,
+        )
+        .await;
+
+        let error = result
+            .pointer("/error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            error.contains("blocked"),
+            "expected a blocked error, got {result:?}"
+        );
+        assert!(
+            result.pointer("/body").is_none(),
+            "no body may reach the model: {result:?}"
+        );
+        assert_eq!(
+            *hits.lock().unwrap(),
+            0,
+            "the request must never reach the service"
+        );
+    }
+
+    /// A public-looking start URL that redirects inward must fail at the hop.
+    /// The start host is a name so it clears the literal check, and the resolve
+    /// override aims it at the local server — the only way to exercise the
+    /// redirect path without leaving the machine.
+    #[tokio::test]
+    async fn fetch_one_refuses_redirect_into_loopback() {
+        use std::sync::{Arc, Mutex};
+
+        use axum::{Router, response::Redirect, routing::get};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let go_hits = Arc::new(Mutex::new(0u32));
+        let meta_hits = Arc::new(Mutex::new(0u32));
+
+        let count = meta_hits.clone();
+        let started = go_hits.clone();
+        let app = Router::new()
+            .route(
+                "/go",
+                get(move || {
+                    let started = started.clone();
+                    async move {
+                        *started.lock().unwrap() += 1;
+                        Redirect::temporary(&format!("http://127.0.0.1:{}/meta", addr.port()))
+                    }
+                }),
+            )
+            .route(
+                "/meta",
+                get(move || {
+                    let count = count.clone();
+                    async move {
+                        *count.lock().unwrap() += 1;
+                        "METADATA iam-role-cred=AKIA_EXAMPLE"
+                    }
+                }),
+            );
+        tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+
+        // A DNS override ignores the port in the address it is given, so the
+        // port has to be in the URL as well.
+        let state = WebFetchState::from_builder(
+            WebFetchState::client_builder()
+                .no_proxy()
+                .resolve_to_addrs("first-hop.test", [addr]),
+        );
+        let result = fetch_one(
+            state,
+            format!("http://first-hop.test:{}/go", addr.port()),
+            0,
+            DEFAULT_BODY_CHARS,
+            BodyFormat::Text,
+        )
+        .await;
+
+        // Without this the test could pass for the wrong reason: a failure to
+        // reach the first hop at all looks identical to a refused second hop.
+        assert_eq!(
+            *go_hits.lock().unwrap(),
+            1,
+            "the first hop must be served, otherwise this test proves nothing"
+        );
+        assert!(
+            result.pointer("/error").is_some(),
+            "following the hop must fail, got {result:?}"
+        );
+        assert_eq!(
+            *meta_hits.lock().unwrap(),
+            0,
+            "the redirect target must never be fetched"
+        );
     }
 
     /// Single-URL fetch against a stable public endpoint.


### PR DESCRIPTION
Hardening for the boundary between the host process and the sandbox guest, from an internal review of the network posture. Two independent parts, one commit each.

## `web_fetch` egress is gated to public addresses

`web_fetch` is registered as a pure tool, so it receives no console and the request runs in the host process rather than inside the sandbox VM. The guest network policy therefore never applies to it, and the only validation was URL length, scheme, and the presence of a host string. That left the tool able to reach addresses the sandbox exists to keep an agent away from, and the tool is callable both by a model and, indirectly, by a document a model reads.

A new `net_guard` module decides whether a destination is on the public internet, and the `web_fetch` client is wired through it in three places:

- **IP-literal hosts** are checked against the IANA special-purpose ranges before a connection is opened. The check runs on the parsed host rather than the raw input, so `url`'s normalization of the decimal, octal, hex, and shorthand spellings of an address is what makes those cases safe. There is a test asserting exactly that, since `std`'s `IpAddr` parser rejects all of those forms on its own.
- **Named hosts** go through a custom DNS resolver that drops every non-public answer. Filtering inside the resolver rather than checking the addresses up front is the point: the connector reaches only addresses the filter returned, so there is no gap between a check and the connect for a second answer to land in. A split answer keeps its public addresses and loses the rest.
- **Redirects** re-check scheme and host on every hop. A public start URL can redirect inward, and a `Location` holding an IP literal never reaches the resolver at all, so the per-hop check is what covers it. The hop limit behavior is unchanged.

Addresses that carry an IPv4 address inside an IPv6 one are judged by the address they carry, because that is where the connection lands: `::ffff:127.0.0.1` and the NAT64 form both reach loopback. Teredo and 6to4 prefixes are refused for the same reason. RFC 8215's local-use NAT64 range, `64:ff9b:1::/48`, is refused wholesale rather than unwrapped, because the prefix may be any length up to `/96` there, so the embedded address does not sit at a fixed offset.

Blocked targets are logged at `warn`, which also gives a signal when something is probing for a way around the gate.

All three paths report a refusal the same way, which took a fix of its own after @selloriwoo caught the resolver path not doing so. An IP literal refused before the connection returned `blocked: 127.0.0.1 is not a public address`, but a name refused inside the resolver returned `request failed: ... client error (Connect)` — the block held, the local server in the test recorded no hit, but the refusal sat three levels down a source chain whose outer `Display` stops one level in, so `download`'s `format!("request failed: {e}")` never reached it. That is worth fixing rather than documenting, because the two messages carry opposite instructions: a connect failure reads as a target that happens to be down and invites a retry, a refusal reads as terminal, and the path that will never succeed no matter how many times it is tried was the one reporting as retryable. The guard now raises a `Blocked` error type and `blocked_reason` walks the chain for it — a type rather than a message prefix, since the refusal has to be recognized after the connector has wrapped it twice and matching on text would break the moment someone rewords it. The redirect path was not opaque, `wreq`'s `Display` does carry the hop error's message, but it arrived behind a `request failed: error following redirect for uri (...)` wrapper and now reads like the other two.

One case stays uncovered by design and is documented on the resolver: with an HTTP proxy configured, the connector resolves the proxy's host and the proxy resolves the target, so the target's addresses never pass through the filter. That configuration comes from the host environment rather than from anything a model can set, and the IP-literal check still applies. Worth being precise about how reachable that is rather than leaving it as a footnote: wreq enables system proxies by default (`auto_sys_proxy` is `true`), and the client here does not call `.no_proxy()`, so an `HTTP_PROXY` or `ALL_PROXY` in the environment is enough to put every named host on that path. Surfacing it — a warning when a proxy is configured, or making one opt-in — is a follow-up rather than part of this change.

## Guest host reach is scoped per port, and the default posture is the narrow one

Every `SandboxNetwork` variant built its host rule with `Rule::allow_egress(Destination::Group(DestinationGroup::Host))`. That constructor leaves the rule's port set empty, and an empty port set matches every port. The engine behaves exactly as documented here; the call site expressed more than was intended. The practical effect was that `HostOnly`, the posture meant to be least-privilege, granted the guest every TCP port on the host, so any host service listening on `0.0.0.0` was reachable from inside the VM. Two related defaults compounded it: the default posture was `Public`, so a caller that never mentioned the network got arbitrary outbound reach, and `HostOnly` and `Public` both set `default_ingress: Allow`, flipping microsandbox's own fail-closed default open.

This adds `NetworkPosture`, which pairs the outside-reach variant with the host TCP ports the guest may actually open:

- Host reach is gateway DNS plus the listed ports, nothing else. `Rule::allow_dns()` is what keeps name resolution working, including the lookup for `host.microsandbox.internal`; without it a deny-by-default policy refuses every query.
- The default is `HostOnly` with no host ports. Wider reach is opt-in.
- `default_ingress` is `Deny` again. It only governs connections inbound to a published guest port, and nothing here publishes one, so this is fail-closed for a capability that does not exist yet rather than a restriction on anything in use.
- `domain_suffixes` lets a session that has to install packages name its registries instead of taking `Public` and the whole internet with it. An unparseable suffix is dropped and logged, so a typo costs a failed install rather than an unintended grant. One limit is worth recording, since it belongs to microsandbox's evaluator rather than to this change: over TLS the match is a conjunction, the SNI has to match the suffix *and* the address has to have been resolved from a name that matches, so a shared address on its own admits nothing. Without SNI — plain HTTP, which is how `apt` fetches — the match is on the address alone against any name cached for it, so an allowlisted domain and an unrelated one behind the same CDN address are not told apart there.
- `Full` keeps `allow_all()` as the deliberate escape hatch.

The split between reach and host ports is deliberate: a posture on its own now says nothing about which host services are exposed, so widening outside reach cannot quietly widen host reach too.

### Call sites

`network()` and `try_from_archive_with_network()` take `impl Into<NetworkPosture>`, so a call site passing a bare `SandboxNetwork` keeps compiling and gets the narrower policy. A caller that needs a host service reachable from the guest (a forward server, for instance) asks for it by port:

```rust
SandboxBuilder::new()
    .network(SandboxNetwork::HostOnly.with_host_ports([forward_port]))
```

`try_from_archive_with_network` gains the same coverage, which matters because an archive is only a filesystem snapshot and carries no policy; the host ports would otherwise be lost across a save and restore.

The same `impl Into<NetworkPosture>` that keeps call sites compiling is what makes this a quiet change for anyone using the crate from outside: code that never mentioned the network, or that restores through `try_from_archive`, still builds and now gets `HostOnly` where it used to get `Public`. Nothing warns, because there is nothing to warn about at the type level. There is no CHANGELOG in this repo, so this is the note to carry into the release: a caller that did want outbound reach has to say so now, either `SandboxNetwork::Public` or a `with_domain_suffixes` list. `python_repl` is the first case of that and is documented in its own right.

The one caller inside this repo that the narrowing reaches is the skill benchmark test, which registers `python_repl` against a sandbox it never named a network for, so it now asks for the same suffixes `SETUP_CMD` documents. It passes either way today — twice over against a real VM and the real API — because the skill steers the model to `python -m timeit` in the shell and the model follows, but that is the model's choice rather than a property of the test, and the failure the other choice would hit is a quiet one: the run is `#[ignore]`d, needs a key, and a model that tried `python_repl` and lost it would likely fall back to the shell and still produce the expected table. Measuring the guest is what settled it: `python:3.12-slim` ships python3 but no uv, and under the new default the uv release and pypi.org both come back `URLError: [Errno 111] Connection refused`. The `runenv` module doc gains the same point for anyone starting from the sandbox example there, which showed a bare `build()` and did not mention the network at all.

`fork` builds from a snapshot the same way and had the same hole, so the policy is carried on `Sandbox` and re-applied there too. Without it a fork fell through to microsandbox's default, which is `Public` egress and `default_ingress: Allow` — both halves of this narrowing, undone for anyone who forks. It was quiet before now only because the old default was `Public` too, so a fork reproduced its parent by coincidence.

## Verification

```
cargo clippy --all-targets                      # clean
cargo clippy --all-targets --features sandbox   # clean
cargo test --features sandbox --lib
    test result: ok. 353 passed; 0 failed; 18 ignored
```

The 353 includes the sandbox tests that boot real VMs, so `HostOnly` narrowed to DNS plus explicit ports is confirmed to still produce a working guest network rather than a dead one, and `Public` still reaches the internet. One of the 18 ignored is new and is described below; it needs `--ignored` to run.

New coverage:

- `net_guard`: the range predicates for both families, the NAT64 unwrap in both directions and the local-use range that is refused instead, the resolver's filter on a split answer and on an all-internal one, and the redirect-target rule. Three ranges the predicate described as covered but let through are refused now — 100::/64, which discards what is sent to it, and 3fff::/20 and 5f00::/16, reserved for documentation and for SRv6 segment identifiers — each with the address just outside it in the allowed list, so a mask one bit too wide fails here rather than quietly refusing traffic that should have gone out. 2001:20::/28 and 2001:30::/28 needed no rule of their own, since both sit inside the 2001::/23 entry, and a case pinning that is in the refused list. `blocked_reason` gets two of its own: it finds a refusal under two wrappers that drop their source when formatted, which holds the contract even if `wreq` restructures its errors, and it returns `None` for an ordinary io error, since reporting a target that is genuinely down as a policy refusal would be the same confusion in reverse.
- `web_fetch`: a loopback target is refused with a real local server recording no hit, and a redirect into loopback fails with the first hop served and the second never requested. The redirect test asserts the first hop was served, because otherwise a failure to reach the server at all would look identical to a refused second hop. A third fetches a name that resolves to loopback, covering the resolver path end to end and asserting it reads like the literal case; the redirect test asserted only that some error occurred, which the old generic message satisfied, and now asserts the refusal too. Both of those fail without the recovery in `download`.
- `runenv::sandbox`: a posture that omits a field deserializes to the narrow default rather than failing, checked to fail without the `#[serde(default)]` that makes it so. The postures are also put through microsandbox's own evaluator for host ports, gateway DNS, unmatched ingress, and domain suffixes, so a rule wider than intended shows up as a failing assertion rather than as an open port nobody looked at. One further test boots a VM with two host listeners, one port granted and one not, and confirms the guest reaches exactly one — the port set has to be enforced by the runtime, not merely recorded in the spec. That one was checked against a control run granting both ports, which fails as it should.
- `runenv::sandbox`, forks: a fork of a `HostOnly` parent must not reach `1.1.1.1:443`, and a fork of a `Public` parent still must. The second is there because the first would also pass on a fork whose network was simply broken. Checked that the first fails without the re-apply, where the child does reach the internet.
- `python_repl`: the domain allowlist its setup needs is documented on `SETUP_CMD` and backed by a test that drives the real tool against a real VM under exactly that posture, installs a wheel end to end, and confirms a domain outside the list still fails to connect. Checked both ways: on bare `HostOnly` it fails at `apt`, so the allowlist is what carries it rather than an accidentally open policy, and the control asserts `URLError` rather than only a non-zero exit, since a broken probe script would also exit non-zero. `#[ignore]`d like the `web_search` tests because it installs from three services this repo does not control.

## Notes

`web_search` is also a pure tool, but its engine URL is fixed, so it is not routed through the guard in this change. The `net_guard` module is available if that changes.

Left for a separate change in `agent-k`, since the code lives there: the host-side forward server's bind address and token comparison, and the document parser's lack of a timeout or resource cap. This branch is the piece those depend on, because the forward server now has to name its port.

The consuming side is written against this API and is up for review as brekkylab/agent-k#221, so this is ready rather than draft. Merging it first is the intended order: #221 pins this branch's head and has to be repinned to the merged commit afterwards.
