### PR TITLE
[Example] Company analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -563,3 +563,10 @@ test_*
 
 # git worktrees
 .worktrees/
+
+# company_analysis example run state
+# artifacts/ and workspace/ are produced per run; live/ is the empty directory the
+# registries are mounted over, and what lands under it is API responses.
+examples/company_analysis/artifacts/
+examples/company_analysis/workspace/
+examples/company_analysis/live/

--- a/.gitignore
+++ b/.gitignore
@@ -567,6 +567,5 @@ test_*
 # company_analysis example run state
 # artifacts/ and workspace/ are produced per run; live/ is the empty directory the
 # registries are mounted over, and what lands under it is API responses.
-examples/company_analysis/artifacts/
 examples/company_analysis/workspace/
 examples/company_analysis/live/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "company_analysis"
+version = "0.3.0"
+dependencies = [
+ "ailoy",
+ "anyhow",
+ "cortex",
+ "dotenvy",
+ "futures",
+ "reqwest",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +590,7 @@ dependencies = [
  "bson",
  "cc",
  "futures-core",
+ "libc",
  "pkg-config",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "./",
+    "examples/company_analysis",
 ]
 exclude = [
     ".worktrees",

--- a/examples/company_analysis/Cargo.toml
+++ b/examples/company_analysis/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "company_analysis"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ailoy = { path = "../.." }
+anyhow = "1"
+# `FileSystem` is cortex's trait, so implementing one means depending on cortex by
+# name. `fuse-t` is what turns the trait into a path a subprocess can open; it needs a
+# libfuse provider at build time — see this example's README.
+cortex = { path = "../../../cortex/cortex", features = ["fuse-t"] }
+dotenvy = "0.15"
+futures = "0.3"
+reqwest = { version = "0.13", features = ["json"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/company_analysis/README.md
+++ b/examples/company_analysis/README.md
@@ -25,7 +25,6 @@ by the registries' own APIs rather than by a copy of them.
 [fs]: https://github.com/brekkylab/cortex/blob/main/cortex/src/fs/filesystem/filesystem.rs
 [lei]: https://www.gleif.org/en/organizational-identity/lei-vlei/the-legal-entity-identifier-lei
 [cik]: https://www.sec.gov/search-filings/cik-lookup
-[tickers]: https://www.sec.gov/files/company_tickers.json
 [xbrl]: https://www.sec.gov/data-research/standard-taxonomies
 
 ---
@@ -42,7 +41,7 @@ tool.
 | | GLEIF | SEC EDGAR |
 | --- | --- | --- |
 | Covers | legal entities worldwide, and who owns whom | anyone required to file with the SEC |
-| How many | 3.4M LEI records | 8k registrants trade under a ticker; the rest are the majority |
+| How many | 3.4M LEI records | 982k filers — funds, foreign issuers, subsidiaries, insiders; about 8k of them trade |
 | Identifier | LEI | CIK |
 | A search returns | the whole record | a stub of three fields |
 | Auth | none | a `User-Agent` naming a contact |
@@ -71,9 +70,6 @@ GLEIF search page ends the trip; an EDGAR search only tells you where to look ne
 │           └── page-001.json
 └── edgar/
     ├── CATALOG.md
-    ├── by-ticker/
-    │   ├── _README.md
-    │   └── <TICKER>/             ~8,000 listed, every ticker addressable
     ├── by-cik/
     │   ├── _README.md
     │   └── <CIK>/
@@ -98,8 +94,7 @@ definitions belong to the registries and are linked rather than restated.
 | | | Where one comes from |
 | --- | --- | --- |
 | `<LEI>` | [Legal Entity Identifier][lei] | a `gleif/search` page, or `owns` / `ownedBy` on another record |
-| `<CIK>` | [Central Index Key][cik] | `by-ticker/<TICKER>/`, an `edgar/search` hit, or `submissions.json` naming its own |
-| `<TICKER>` | [the symbol a registrant trades under][tickers] | `ls by-ticker` — one per registrant, about eight thousand |
+| `<CIK>` | [Central Index Key][cik] | an `edgar/search` hit, or `submissions.json` naming its own |
 
 The LEI and the CIK are checked here rather than by the API: an LEI carries ISO 17442
 check digits and a CIK is at most ten digits, so a mistyped one is a directory that does
@@ -157,10 +152,11 @@ zero-padded numbers is a listing nobody can read a company out of, so it does no
 Either way, answering empty would read as "nothing here", so each holds a `_README.md`
 saying how to address one and where an identifier comes from.
 
-They are the exception, not the rule. Where a listing *can* be complete it simply is —
-`ls by-ticker` names every registrant that trades, and under an entity the listing is
-that record's own `relationships`, so a company with no parent shows a reporting
-exception where one with a parent shows a parent.
+They are not the exception here — no directory in this tree can be walked into. Where a
+listing *is* complete it is also small and fixed: the taxonomies under `concept`, the
+fields under `search`, and, under a GLEIF entity, that record's own `relationships`, so
+a company with no parent shows a reporting exception where one with a parent shows a
+parent.
 
 ### 2.5 Why `<name>/<name>.json` instead of `name.json`
 
@@ -170,12 +166,12 @@ followed by a `getattr` per entry, a document's size cannot be known without fet
 it, and so a document listed directly is fetched merely to be listed.
 
 Wrapped, `ls by-cik/<CIK>/` names `submissions/`, `facts/` and `concept/` for nothing,
-and the request waits until someone descends. Listed flat, anything that walks the tree
-spends one fetch per registrant — a single run was measured at 742, and `facts.json` is
-four megabytes each time.
+and the request waits until someone descends. Listed flat, that same `ls` costs both
+documents — `facts.json` is four megabytes of it — whether or not the caller wanted
+either.
 
 Nothing is hidden by this. The flat `submissions.json` beside the wrapper opens too, in
-the same way `page-002` and an unlisted share class do. Not listed is not unreachable.
+the same way `page-002` does. Not listed is not unreachable.
 
 ---
 
@@ -241,7 +237,7 @@ One directory per run, and the four files answer four different readers:
 of `{severity, statement, evidence, confidence}`.
 
 Because the source is live, a claim is only as good as the path behind it.
-`evidence.md` cites from the mount root down — `edgar/by-ticker/NVDA/…` — never the
+`evidence.md` cites from the mount root down — `edgar/by-cik/0001045810/…` — never the
 machine-local prefix, which would leave the citation unresolvable anywhere else.
 `findings.json` is what `--since` reads back in, so a later run can report what changed
 rather than restate what did not.
@@ -254,11 +250,11 @@ rather than restate what did not.
 turns 61 / tool calls 32
 tokens (29 calls): in 675,505 / out 20,540
   largest context 43,746 (the conversation at its last call)
-requests  gleif 5 / edgar 3
+requests  gleif 5 / edgar 2
   gleif   linked resource ×2, search page ×2, lei record ×1
           5 distinct paths; heaviest:
                1 × /by-lei/549300S4KLFTLO7GSQ80/record.json
-  edgar   facts ×1, submissions ×1, ticker index ×1
+  edgar   facts ×1, submissions ×1
 finish    Stop
 artifacts 5:
   ...

--- a/examples/company_analysis/README.md
+++ b/examples/company_analysis/README.md
@@ -66,7 +66,7 @@ GLEIF search page ends the trip; an EDGAR search only tells you where to look ne
 │   │       └── direct-parent/    or direct-parent-reporting-exception/
 │   └── search/<field>/<value>/…/
 │       └── pages/
-│           ├── _README.md
+│           ├── _README.md       how many pages this query has
 │           └── page-001.json
 └── edgar/
     ├── CATALOG.md
@@ -127,9 +127,11 @@ write those.
 
 None of this has asked the API anything. The first request happens when `pages` is
 opened, because only the API knows how many results there are. That listing then names
-one page: a directory read costs a `getattr` per entry and a page's size is unknowable
-without fetching it, so naming all thirteen would spend thirteen requests before
-anything was read. `page-002` onwards still open, unlisted.
+one page and a note: a directory read costs a `getattr` per entry and a page's size is
+unknowable without fetching it, so naming every page would spend a request each before
+anything was read. `page-002` onwards still open, unlisted — and the note says how many
+there are, taken from the page the listing has already fetched, so learning the count
+costs neither a request nor a screenful of records.
 
 ### 2.3 Concept coordinates
 

--- a/examples/company_analysis/README.md
+++ b/examples/company_analysis/README.md
@@ -1,327 +1,322 @@
 # Company Analysis Example
 
-기업정보 데이터 레이크를 파일시스템으로 들고, 유저의 쿼리를 조사·분석해 리포트로 답하는 에이전트 예제.
+Ask a question about a company — whatever the [GLEIF][gleif] and [SEC EDGAR][edgar] APIs
+can reach — and get an answer with its sources attached.
+
+The agent researches the question against those two registries and writes back a report
+in which every claim names the path it came from. It is the reading half of due
+diligence: who an entity is, whether two records are the same company, who owns whom,
+and — as often as not — which of those the registries decline to say.
 
 ```
-질문 (자연어)
-    │
-    ▼
-[ company analysis agent ] ──shell / grep / glob / read──▶ data/   (읽기 전용)
-    │                       └─python_repl (duckdb, pandas)─┘
-    │
-    └──write──▶ artifacts/<slug>/report.md
-                artifacts/<slug>/evidence.md
-                artifacts/<slug>/queries/*.sql|*.py
+   gleif/ ─┐                            artifacts/<run>/
+           ├──▶ [ agent ] ──────────▶   ├─ report.md      the answer, for a person
+   edgar/ ─┘         ▲                  ├─ evidence.md    every claim ↔ its path
+                     │                  ├─ findings.json  the same, for a machine
+                  question              └─ queries/*.py   what was actually run
 ```
+
+The agent gets the built-in file tools and nothing else — no bespoke search tool, no
+client library — and still every answer is current, because the tree it opens is served
+by the registries' own APIs rather than by a copy of them.
+
+[gleif]: https://www.gleif.org/en/lei-data/gleif-api
+[edgar]: https://www.sec.gov/edgar/sec-api-documentation
+[fs]: https://github.com/brekkylab/cortex/blob/main/cortex/src/fs/filesystem/filesystem.rs
+[lei]: https://www.gleif.org/en/organizational-identity/lei-vlei/the-legal-entity-identifier-lei
+[cik]: https://www.sec.gov/search-filings/cik-lookup
+[tickers]: https://www.sec.gov/files/company_tickers.json
+[xbrl]: https://www.sec.gov/data-research/standard-taxonomies
 
 ---
 
-## 1. 시나리오
+## 1. What is mounted
 
-국내·해외 기업정보를 모아둔 데이터 레이크가 로컬 디스크에 있다. 사용자는 자연어로 질문을 던지고, 에이전트는 데이터를 탐색해 근거와 함께 답한다.
+**Nothing here is stored.** Each registry is a cortex [`FileSystem`][fs]: every
+filesystem operation — listing a directory, checking whether a path exists, reading a
+file's bytes — is answered by the GLEIF or SEC EDGAR API. A path that looks like a file
+is a call going out, and a listing is what the registry says at that moment. Two runs a
+day apart can differ, and that is the registry disagreeing with itself rather than the
+tool.
 
-대표 질문 4종 (§7의 프리셋에 대응):
-
-1. **기업 분석** — "Acme Materials의 최근 3년 실적과 사업 구조를 분석해줘."
-2. **공급망 리스크** — "우리 배터리 라인의 2차 협력사 중 제재·지정학 리스크가 있는 곳은?"
-3. **기업 조사** — "Nova Chem Ltd.와 거래하기 전에 알아야 할 것 (실소유주, 제재, 소송, 관계사)."
-4. **자동화** — "watchlist 30개사에 대해 지난주 변경사항을 요약해줘."
-
-에이전트는 `data/`에 대해 **읽기 전용**이다. 쓰기는 `artifacts/`(산출물)와 `workspace/`(중간 계산)에만 허용한다.
-
----
-
-## 2. 범위
-
-**포함**
-
-- 국내·해외 기업정보를 흉내 낸 합성 데이터 레이크 (`data/`)
-- 자유 형식 쿼리 실행 환경: `shell` + `read`/`grep`/`glob` + `python_repl`(duckdb/pandas)
-- 데이터 지도(`data/CATALOG.md`) 기반의 탐색 → 쿼리 → 검증 → 리포트 루프
-- 근거 추적: 리포트의 모든 수치가 파일·쿼리로 역추적 가능
-
-**미포함 (후속)**
-
-- 실제 DART / SEC EDGAR / GLEIF / OFAC API 연동 및 수집 파이프라인
-- 실시간 갱신, 증분 적재, 데이터 품질 모니터링
-- 임베딩 기반 문서 검색 (현재 `ailoy` 크레이트에 임베딩 API 없음 — 공시 원문은 grep/키워드로 접근)
-- 웹 UI, 리포트 배포, 알림 전송
-
----
-
-## 3. 데이터: 파일시스템 데이터 레이크
-
-### 3.1 설계 원칙
-
-- **텍스트 우선** — jsonl / csv / md 만 사용한다. grep과 duckdb 양쪽에서 바로 읽히고, diff와 리뷰가 가능하다. parquet은 쓰지 않는다.
-- **한 파일 = 한 테이블** (또는 한 문서). 파일명만 보고 내용이 짐작되어야 한다.
-- **모든 레코드에 `source`와 `as_of`** — 어디서 온 값이고 언제 기준인지 없는 행은 만들지 않는다.
-- **조인 키는 명시적으로** — 회사 식별자는 §3.3의 `company_id` 하나로 통일하고, 원천 식별자(사업자번호, CIK, LEI 등)는 별도 매핑 테이블에 둔다.
-
-### 3.2 디렉터리 구조
-
-```
-data/
-  CATALOG.md              # 데이터 지도. 에이전트가 가장 먼저 읽는 파일
-  registry/
-    companies.jsonl       # 기업 마스터
-    identifiers.csv       # company_id ↔ 원천 식별자 매핑
-    aliases.csv           # 상호 표기 변형 (한글/영문/약칭/구 상호)
-    ownership.csv         # 지분 관계 (모회사-자회사, 지분율)
-  financials/
-    kr/<company_id>/fs_<year>.csv     # 요약 재무제표 (K-IFRS)
-    us/<company_id>/fs_<year>.csv     # 요약 재무제표 (US GAAP)
-  filings/
-    kr/<company_id>/<date>-<type>.md  # 공시 원문 (요약본)
-    us/<company_id>/<date>-<form>.md  # 10-K / 8-K 등 발췌
-  supplychain/
-    edges.csv             # 거래 관계 (buyer ← supplier)
-    sites.csv             # 생산·물류 거점
-  trade/
-    customs_kr.csv        # 수출입 신고 요약 (HS 코드 기준)
-    bol_us.csv            # 선하증권 기반 수입 기록
-  risk/
-    sanctions.csv         # 제재 대상 목록 (OFAC SDN / EU 통합 리스트 형식)
-    litigation.jsonl      # 소송·분쟁 이력
-    incidents.jsonl       # 사고·리콜·환경/노동 이슈
-    credit.csv            # 신용등급 / 부실 징후 지표
-  news/
-    <YYYY>/<MM>/<date>-<slug>.md      # 기사 (제목/매체/일자/본문 요약)
-  reference/
-    hs_codes.csv, ksic.csv, naics.csv, countries.csv, fx_rates.csv
-  watchlist.csv           # 자동화 시나리오용 모니터링 대상
-```
-
-규모 기준: 기업 200~300개(국내 60%, 해외 40%), 공급망 엣지 800~1,200개, 뉴스 150건, 공시 80건. **3~4단계 공급망 추적이 가능해야 하고**, 제재 대상이 2차·3차 협력사에 숨어 있는 케이스를 최소 두 건 심는다.
-
-### 3.3 핵심 스키마
-
-`registry/companies.jsonl`
-
-```jsonc
-{
-  "company_id": "kr-acme-materials",     // 전 데이터셋 공통 조인 키
-  "legal_name": "주식회사 에이크메머티리얼즈",
-  "legal_name_en": "Acme Materials Co., Ltd.",
-  "country": "KR",
-  "status": "ACTIVE",                    // ACTIVE | DISSOLVED | MERGED
-  "incorporated_on": "2004-06-11",
-  "industry": { "ksic": "20119", "naics": "325180" },
-  "listed": { "market": "KOSDAQ", "ticker": "123456" },  // 비상장이면 null
-  "employees": 412,
-  "hq": { "country": "KR", "region": "충청북도", "city": "청주시" },
-  "website": "https://example.com",
-  "source": "dart-mock",
-  "as_of": "2026-06-30"
-}
-```
-
-`registry/identifiers.csv` — `company_id, scheme, value, source, as_of`
-`scheme` ∈ `brn`(사업자등록번호) | `corp_no`(법인등록번호) | `cik`(SEC) | `lei`(GLEIF) | `duns` | `ticker`
-
-`supplychain/edges.csv`
-
-```
-buyer_id,supplier_id,tier,hs_code,item,share_pct,since,source,as_of,confidence
-kr-acme-materials,cn-hanjiang-chem,1,290369,전해액 첨가제,34.0,2021-03,customs+bol,2026-06-30,0.82
-```
-
-- `tier`는 **기준 기업으로부터의 거리**가 아니라 **이 엣지의 관측 근거 수준**을 뜻하지 않도록 주의한다. 여기서는 "buyer 기준 직접 거래 = 1"로 고정하고, n차 추적은 엣지를 재귀 조인해서 계산한다.
-- `confidence`는 0~1. 관세 신고와 선하증권 양쪽에서 관측되면 높고, 뉴스 언급 1건뿐이면 낮다. **리포트는 이 값을 반드시 함께 표기한다.**
-
-`risk/sanctions.csv` — `list_name, entity_name, aliases, country, program, listed_on, source` (OFAC SDN 형식 차용). **`company_id`가 미리 매핑되어 있지 않다.** 이름 매칭은 에이전트의 일이다(§5.4).
-
-### 3.4 `data/CATALOG.md`
-
-에이전트가 데이터를 헤매지 않도록 하는 진입점. 사람이 손으로 관리한다.
-
-- 각 파일의 경로, 한 줄 설명, 행 수, 컬럼 목록과 타입
-- 조인 키와 조인 예시 (SQL 3~4개)
-- 알려진 한계: 커버리지 구멍, 통화 단위, 회계기준 차이, 갱신 시점
-- **자주 하는 실수** 항목 (예: `edges.csv`의 `share_pct`는 buyer 기준 조달 비중이지 supplier 기준 매출 비중이 아님)
-
----
-
-## 4. 입력: 자유 형식 질문
-
-CLI 인자 또는 파일로 받는다.
-
-```sh
---task "Acme Materials의 중국 의존도를 2차 협력사까지 따져줘"
---task-file ./tasks/supply-chain.md
---preset supply-chain-risk --company "Acme Materials"
-```
-
-프리셋은 §7의 4종에 대응하며, 내부적으로는 잘 쓰인 task 문장 + 산출물 템플릿 지정일 뿐이다. 프리셋 없이 임의의 질문을 던져도 동작해야 한다.
-
----
-
-## 5. 에이전트
-
-### 5.1 환경 = 파일시스템 + 쿼리 런타임
-
-전용 툴을 만들지 않고 **built-in 툴**을 쓴다. 질문의 형태를 미리 정할 수 없기 때문에, 스키마를 고정한 툴은 오히려 표현력을 깎는다.
-
-| 툴 | 용도 |
-| --- | --- |
-| `read` | `CATALOG.md`, 공시·뉴스 원문, csv 헤더 확인 |
-| `glob` | 파일 존재 여부와 커버리지 확인 (`filings/us/*/2026-*-8-K.md`) |
-| `grep` | 원문 문서 검색, 상호·키워드 스캔 |
-| `shell` | 빠른 집계 (`wc -l`, `cut`, `sort | uniq -c`), 파일 크기 확인 |
-| `python_repl` | 본 계산. duckdb로 csv/jsonl에 SQL을 직접 실행, pandas로 후처리 |
-
-`python_repl`은 `pip_install`을 지원하므로 첫 호출에서 `duckdb`를 설치한다. duckdb는 `read_csv_auto` / `read_json_auto`로 파일을 그대로 테이블처럼 다루므로, 별도 적재 단계가 필요 없다.
-
-```python
-import duckdb
-con = duckdb.connect()
-con.sql("""
-  SELECT s.legal_name, e.item, e.share_pct, e.confidence
-  FROM read_csv_auto('data/supplychain/edges.csv') e
-  JOIN read_json_auto('data/registry/companies.jsonl') s ON s.company_id = e.supplier_id
-  WHERE e.buyer_id = 'kr-acme-materials'
-  ORDER BY e.share_pct DESC
-""").show()
-```
-
-### 5.2 쓰기 경계
-
-- `data/` — 읽기 전용. 수정·삭제 금지를 인스트럭션에 명시하고, 실행 전후로 데이터 디렉터리 해시를 비교해 위반을 검출한다.
-- `workspace/<run-slug>/` — 중간 산출물(추출한 csv, 그래프 계산 결과). 실행마다 비운다.
-- `artifacts/<run-slug>/` — 최종 산출물.
-
-### 5.3 루프
-
-1. `data/CATALOG.md`를 읽어 무엇이 있는지 파악한다.
-2. 질문을 답변 가능한 하위 질문으로 분해하고, 각각에 필요한 파일을 지목한다.
-3. 대상 기업을 식별한다 (§5.4).
-4. 하위 질문별로 쿼리를 작성·실행한다. 실패하면 스키마를 다시 확인하고 고친다.
-5. 핵심 수치는 **다른 경로로 한 번 더 검증한다** (예: 공급망 비중을 `edges.csv`와 `trade/customs_kr.csv` 양쪽에서).
-6. 리포트, 근거 목록, 실행한 쿼리를 `artifacts/`에 기록한다.
-
-### 5.4 기업 식별(entity resolution)
-
-이 데이터셋의 가장 큰 함정. 별도 요구사항으로 둔다.
-
-- 입력은 사람이 부르는 이름("에이크메", "Acme Materials", "ACME MATERIALS CO LTD")이고, 데이터의 키는 `company_id`다. `registry/aliases.csv`로 먼저 해소한다.
-- 법인격 접미사(`(주)`, `주식회사`, `Co., Ltd.`, `Inc.`, `GmbH`)와 대소문자·공백은 정규화 후 비교한다.
-- **동명이인 케이스를 반드시 사람에게 되묻는다.** 후보가 둘 이상이면 임의로 고르지 않고, 국가·업종·설립연도를 제시해 확인을 요청하거나 리포트 상단에 모호성을 명시한다.
-- 제재 리스트 매칭은 이름 유사도 기반이므로 **후보 제시**까지만 한다. "제재 대상이다"라고 단정하지 않고, `가능성 있는 일치 — 확인 필요`로 표기하고 근거 행을 인용한다. 오탐의 비용이 큰 영역이다.
-
-### 5.5 분석 품질 요구사항
-
-- **모든 수치에 출처.** 파일 경로 + 필터 조건, 또는 실행한 쿼리 파일명을 함께 적는다.
-- **데이터에 없으면 "없다"고 쓴다.** 추정할 경우 추정임을 명시하고 계산 과정을 남긴다. 일반 상식으로 기업 정보를 채워 넣지 않는다.
-- **기준일을 항상 표기.** 서로 다른 `as_of`의 값을 한 표에 섞을 때는 열을 나눈다.
-- **통화·회계기준을 섞지 않는다.** KRW/USD 환산은 `reference/fx_rates.csv`의 명시된 기준일 환율로만 하고, K-IFRS와 US GAAP 수치를 직접 비교하지 않는다.
-- **`confidence`가 낮은 엣지에 기반한 결론은 그 사실을 함께 쓴다.**
-- 리스크 점수를 낼 경우 **가중치와 계산식을 리포트에 노출한다.** 블랙박스 점수는 금지.
-
----
-
-## 6. 출력: `artifacts/`
-
-```
-artifacts/
-  2026-08-16-acme-supply-chain-risk/
-    report.md          # 사람이 읽는 최종 리포트
-    evidence.md        # 주장 ↔ 근거(파일/쿼리) 대응표
-    findings.json      # 기계가 읽는 구조화 결과 (자동화 시나리오용)
-    queries/
-      01-direct-suppliers.sql
-      02-tier2-expansion.py
-      03-sanctions-match.py
-```
-
-`report.md` 공통 골격:
-
-- **요약** — 질문에 대한 3~5줄 답변. 여기서 결론이 끝나야 한다.
-- **핵심 발견** — 항목별로 사실 + 근거 + 신뢰도
-- **분석 본문** — 프리셋별 구성 (§7)
-- **데이터 한계** — 커버리지 구멍, 오래된 기준일, 낮은 confidence, 미해소 동명이인
-- **다음 단계** — 사람이 확인해야 할 것, 추가로 필요한 데이터
-
-`findings.json`은 자동화 시나리오에서 실행 간 비교(diff)를 하기 위한 것이므로 스키마를 고정한다: `run_id`, `task`, `entities[]`, `findings[] {severity, statement, evidence[], confidence}`, `data_gaps[]`.
-
----
-
-## 7. 프리셋 시나리오
-
-| 프리셋 | 질문 | 리포트 본문 구성 |
+| | GLEIF | SEC EDGAR |
 | --- | --- | --- |
-| `company-profile` | 기업 분석 | 개요·지배구조 / 재무 추이 3년 / 사업·제품 / 주요 거래처 / 최근 공시·뉴스 / 강점·약점 |
-| `supply-chain-risk` | 공급망 리스크 | n차 협력사 전개 / 집중도(단일 공급처·국가 편중) / 제재·지정학 노출 / 대체 공급처 후보 / 시나리오별 영향 |
-| `due-diligence` | 기업 조사 | 실체 확인 / 지분·실소유 구조 / 제재·소송·사고 이력 / 재무 건전성 / 관계사 네트워크 / 레드 플래그 |
-| `watchlist-monitor` | 자동화 | watchlist 대상별 지난 실행 이후 변화 / 신규 리스크 / 변화 없음 항목은 한 줄로 |
+| Covers | legal entities worldwide, and who owns whom | anyone required to file with the SEC |
+| How many | 3.4M LEI records | 8k registrants trade under a ticker; the rest are the majority |
+| Identifier | LEI | CIK |
+| A search returns | the whole record | a stub of three fields |
+| Auth | none | a `User-Agent` naming a contact |
 
-`watchlist-monitor`는 이전 실행의 `findings.json`을 입력으로 받아 **변화만** 보고한다. 매번 전체를 다시 쓰지 않는 것이 요구사항이다.
+The two are shaped oppositely, which is most of what makes having both worthwhile. A
+GLEIF search page ends the trip; an EDGAR search only tells you where to look next.
 
 ---
 
-## 8. 실행
+## 2. Mounted directory structure
 
-```sh
-export ANTHROPIC_API_KEY=...   # 또는 OPENAI_API_KEY 등
-
-# 자유 질문
-cargo run -p company_analysis -- \
-  --task "Acme Materials의 중국 의존도를 2차 협력사까지 분석해줘" \
-  --data ./data --out ./artifacts
-
-# 프리셋
-cargo run -p company_analysis -- \
-  --preset supply-chain-risk --company "Acme Materials"
-
-# 자동화 (이전 결과와 비교)
-cargo run -p company_analysis -- \
-  --preset watchlist-monitor --since ./artifacts/2026-08-09-watchlist/findings.json
+```
+<mountpoint>/
+├── CATALOG.md                    written here — the one path no store answers for
+├── gleif/
+│   ├── CATALOG.md
+│   ├── by-lei/
+│   │   ├── _README.md
+│   │   └── <LEI>/                ls → the resources this record links to
+│   │       ├── record/
+│   │       │   └── record.json
+│   │       └── direct-parent/    or direct-parent-reporting-exception/
+│   └── search/<field>/<value>/…/
+│       └── pages/
+│           ├── _README.md
+│           └── page-001.json
+└── edgar/
+    ├── CATALOG.md
+    ├── by-ticker/
+    │   ├── _README.md
+    │   └── <TICKER>/             ~8,000 listed, every ticker addressable
+    ├── by-cik/
+    │   ├── _README.md
+    │   └── <CIK>/
+    │       ├── submissions/
+    │       │   └── submissions.json
+    │       ├── facts/
+    │       │   └── facts.json
+    │       └── concept/<taxonomy>/<tag>.json
+    └── search/<parameter>/<value>/…/pages/
 ```
 
-- 모델은 `--model`로 지정, 기본값 `anthropic/claude-sonnet-4-6`.
-- 진행 상황은 `cortex` 콘솔로 스트리밍한다.
-- 종료 시 생성 파일 목록과 실행한 쿼리 수를 출력한다.
+None of it exists until it is asked for. The shape is fixed and known here; the contents
+arrive from the API on the read that names them.
+
+Everything in angle brackets is a name you supply, and they come in three kinds.
+
+### 2.1 Identifiers
+
+Each names one company, and which one you hold decides which door you come in by. The
+definitions belong to the registries and are linked rather than restated.
+
+| | | Where one comes from |
+| --- | --- | --- |
+| `<LEI>` | [Legal Entity Identifier][lei] | a `gleif/search` page, or `owns` / `ownedBy` on another record |
+| `<CIK>` | [Central Index Key][cik] | `by-ticker/<TICKER>/`, an `edgar/search` hit, or `submissions.json` naming its own |
+| `<TICKER>` | [the symbol a registrant trades under][tickers] | `ls by-ticker` — one per registrant, about eight thousand |
+
+The LEI and the CIK are checked here rather than by the API: an LEI carries ISO 17442
+check digits and a CIK is at most ten digits, so a mistyped one is a directory that does
+not exist — a `No such file` before anything goes out. The CIK has three spellings,
+`1045810`, `0001045810` and `CIK0001045810`, all naming the same registrant.
+
+What that check cannot catch is an identifier that is well formed and wrong: that one
+answers with somebody else's company rather than with an error. Identifiers are worth
+confirming rather than recalling.
+
+### 2.2 Query segments
+
+A filter is a pair — a `<field>` and its `<value>` on GLEIF, a `<parameter>` and its
+`<value>` on EDGAR — and pairs stack by descending:
+
+```
+gleif/search/entity.legalAddress.country/KR/entity.status/ACTIVE/pages/
+edgar/search/forms/10-K/entityName/Samsung/pages/
+```
+
+Upstream those are `filter[entity.legalAddress.country]=KR&filter[entity.status]=ACTIVE`
+and `forms=10-K&entityName=Samsung`. Order does not matter: either way round is one
+query and one cached result.
+
+`ls search` names the fields on offer — twelve on GLEIF, six on EDGAR — so **a wrong
+field is a missing directory rather than a failed request.** GLEIF accepts more than
+twelve; the rest are vendor cross-references and registry bookkeeping, left out because
+no question about a company needs them. Values are not listable and could not be; you
+write those.
+
+None of this has asked the API anything. The first request happens when `pages` is
+opened, because only the API knows how many results there are. That listing then names
+one page: a directory read costs a `getattr` per entry and a page's size is unknowable
+without fetching it, so naming all thirteen would spend thirteen requests before
+anything was read. `page-002` onwards still open, unlisted.
+
+### 2.3 Concept coordinates
+
+A `<taxonomy>` and a `<tag>` address one XBRL number over the whole filing history:
+
+```
+edgar/by-cik/0001045810/concept/us-gaap/Revenues.json
+edgar/by-cik/0001045810/concept/dei/EntityCommonStockSharesOutstanding.json
+```
+
+The five taxonomies are [the ones the SEC publishes][xbrl] — `us-gaap`, `dei`,
+`ifrs-full`, `srt`, `invest` — and `ls concept` names them. The tags are that company's
+own: whichever it reports, which is the keys of its `facts.json`.
+
+### 2.4 `_README.md`
+
+Some directories do not list what they hold. `by-lei` cannot: the API has no index to
+build one from. `by-cik` could — the SEC publishes all 982,172 of them — but a million
+zero-padded numbers is a listing nobody can read a company out of, so it does not.
+Either way, answering empty would read as "nothing here", so each holds a `_README.md`
+saying how to address one and where an identifier comes from.
+
+They are the exception, not the rule. Where a listing *can* be complete it simply is —
+`ls by-ticker` names every registrant that trades, and under an entity the listing is
+that record's own `relationships`, so a company with no parent shows a reporting
+exception where one with a parent shows a parent.
+
+### 2.5 Why `<name>/<name>.json` instead of `name.json`
+
+Every fetchable document sits inside a directory of its own, holding one file named
+after it. The reason is that **files cost and directories do not.** A directory read is
+followed by a `getattr` per entry, a document's size cannot be known without fetching
+it, and so a document listed directly is fetched merely to be listed.
+
+Wrapped, `ls by-cik/<CIK>/` names `submissions/`, `facts/` and `concept/` for nothing,
+and the request waits until someone descends. Listed flat, anything that walks the tree
+spends one fetch per registrant — a single run was measured at 742, and `facts.json` is
+four megabytes each time.
+
+Nothing is hidden by this. The flat `submissions.json` beside the wrapper opens too, in
+the same way `page-002` and an unlisted share class do. Not listed is not unreachable.
 
 ---
 
-## 9. 디렉터리 구조
+## 3. Usage
+
+```sh
+# 1. Credentials — the repository's .env is read at startup
+ANTHROPIC_API_KEY=...
+SEC_USER_AGENT='company-analysis you@example.com'
+
+# 2. A libfuse provider, and the console server
+brew install --cask fuse-t
+export PKG_CONFIG_PATH="$PWD/../cortex/cortex/contrib/pkgconfig:/usr/local/lib/pkgconfig"
+cd ../cortex && cargo build -p cortex-local-console
+export AILOY_CORTEX_CONSOLE=$PWD/target/debug/cortex-local-console
+
+# 3. Ask
+cd examples/company_analysis
+cargo run -p company_analysis -- --preset entity-profile --company "Samsung Electronics"
+cargo run -p company_analysis -- --task "Who owns Alphabet's subsidiaries?"
+```
+
+`SEC_USER_AGENT` is required rather than defaulted: SEC answers 403 with an HTML page to
+a `User-Agent` that names no contact, and a default would only move the failure to the
+first read, where it arrives as a JSON syntax error.
+
+`PKG_CONFIG_PATH` points at a shim cortex ships, because FUSE-T installs `fuse-t.pc`
+while the mount bindings probe for `fuse.pc`.
+
+### Presets
+
+Three questions come ready-made. Each takes `--company <name>`, and each fixes the body
+of the report — the **Summary**, **Data limits** and **Next steps** are common to all
+three.
+
+| | Asks | The report body |
+| --- | --- | --- |
+| `entity-profile` | who is this? | the entity · identifiers and where each comes from · registration and status · what the filings say |
+| `cross-registry` | is this the same company in both? | the two records · how they were matched and how sure that is · where they agree · where they disagree |
+| `ownership-tree` | who owns whom? | the group as disclosed · direction of each relationship · where the tree stops · what the shape does not tell you |
+
+The answer to any of them may be that the registries do not carry it, and saying so is
+treated as an answer rather than a failure.
+
+`--task` takes a question in your own words instead, and the body is then organised to
+fit it. `--since <findings.json>` makes the report cover what changed against a previous
+run.
+
+---
+
+## 4. Deliverables
+
+One directory per run, and the four files answer four different readers:
+
+| | Answers | Shape |
+| --- | --- | --- |
+| `report.md` | what was found | a **Summary** that stands alone, then **Data limits** and **Next steps** |
+| `evidence.md` | how it is known | one bullet per claim, naming the path and the field |
+| `findings.json` | the same, for a machine | fixed schema, so two runs diff |
+| `queries/*.py` | what was actually run | numbered, so the route to a finding can be walked again |
+
+`findings.json` carries `run_id`, `task`, `entities`, `data_gaps`, and a `findings` list
+of `{severity, statement, evidence, confidence}`.
+
+Because the source is live, a claim is only as good as the path behind it.
+`evidence.md` cites from the mount root down — `edgar/by-ticker/NVDA/…` — never the
+machine-local prefix, which would leave the citation unresolvable anywhere else.
+`findings.json` is what `--since` reads back in, so a later run can report what changed
+rather than restate what did not.
+
+---
+
+## 5. The run summary
+
+```
+turns 61 / tool calls 32
+tokens (29 calls): in 675,505 / out 20,540
+  largest context 43,746 (the conversation at its last call)
+requests  gleif 5 / edgar 3
+  gleif   linked resource ×2, search page ×2, lei record ×1
+          5 distinct paths; heaviest:
+               1 × /by-lei/549300S4KLFTLO7GSQ80/record.json
+  edgar   facts ×1, submissions ×1, ticker index ×1
+finish    Stop
+artifacts 5:
+  ...
+```
+
+`requests` is the number that matters for the design: narrowing should not move it, and
+a large number means the agent paged through a broad query instead of asking a narrow
+one. The breakdown beneath it is what makes that readable — a total says a run was
+expensive without saying what it bought, and the distinct-path count separates one
+document fetched many times from many fetched once. Each tool call is printed with the
+requests it cost, so the answer is attributed rather than inferred.
+
+---
+
+## 6. Limits
+
+Three things this example does not have.
+
+**A reliable key between the registries.** `submissions.json` has an `lei` field and it
+was empty for all fifteen registrants sampled; EIN does not bridge either. Crossing
+between them means matching on a name, and a name match is a candidate — a search for
+NVIDIA returns a fund before it returns the manufacturer. The instruction requires such
+a match to be reported as unconfirmed.
+
+**Sanctions, litigation, news, or financial statements outside the US.** Questions
+needing those have no answer here, and the instruction treats saying so as the answer.
+
+**Enforcement of the write boundary.** The stores refuse writes, but commands run on the
+host and the mountpoint's parent is an ordinary directory. `guard.rs` detects a write
+that left the allowed directories; it does not prevent one.
+
+---
+
+## 7. Layout
 
 ```
 examples/company_analysis/
   README.md
   Cargo.toml
   src/
-    main.rs        # CLI, 에이전트 조립, 실행
-    preset.rs      # 프리셋 → task 문장 + 리포트 템플릿
-    prompt.rs      # 시스템 인스트럭션 (데이터 규칙, 근거 규칙, 쓰기 경계)
-    guard.rs       # data/ 무결성 검사, 산출물 경로 제한
-  data/            # 합성 데이터 레이크 (커밋)
-  tasks/           # 예시 질문 모음
-  workspace/       # gitignore
-  artifacts/       # gitignore (샘플 1건만 커밋)
+    main.rs      CLI, the two mounts, the run summary
+    prompt.rs    system instruction and presets — policy, not the map
+    apifs.rs     the client, cache and request count both stores share
+    gleif.rs     GLEIF as a FileSystem
+    edgar.rs     EDGAR as a FileSystem
+    guard.rs     which directories a run may write into
+  artifacts/     one directory per run
+  workspace/     scratch
 ```
 
-루트 `Cargo.toml`의 `[workspace] members`에 `examples/company_analysis`를 추가한다.
+Each store's tests cover its path grammar offline; the ones that mount and talk to a
+registry are `#[ignore]`d.
 
----
+```sh
+cargo test -p company_analysis
+SEC_USER_AGENT='...' cargo test -p company_analysis -- --ignored --test-threads=1
+```
 
-## 10. 완료 기준
-
-- [ ] API 키만 있으면 `cargo run -p company_analysis`가 동작한다
-- [ ] 프리셋 4종이 각각 `report.md` + `evidence.md` + `findings.json`을 생성한다
-- [ ] 리포트의 모든 수치가 `evidence.md`를 통해 파일·쿼리로 역추적된다 (수동 검증)
-- [ ] 데이터에 없는 기업·거래·제재를 지어내지 않는다
-- [ ] 2차·3차 협력사에 심어둔 제재 리스크 케이스를 실제로 찾아낸다
-- [ ] 동명이인 케이스에서 임의로 하나를 고르지 않는다
-- [ ] 실행 후 `data/`가 변경되지 않았음이 검증된다
-- [ ] `watchlist-monitor`가 변화 없는 항목을 반복 서술하지 않는다
-
----
-
-## 11. 열린 질문
-
-1. **duckdb 의존을 전제할 것인가.** `python_repl`의 `pip_install`에 의존하면 오프라인 환경에서 깨진다. 순수 python(csv+dict)만으로도 돌아가게 할지, duckdb를 필수로 둘지.
-2. **공시·뉴스 원문 검색을 grep으로 버틸 수 있는가.** 문서 수가 늘면 키워드 검색의 재현율이 떨어진다. 임베딩이 없는 지금, 문서에 프론트매터 태그(기업/주제/일자)를 붙여 구조화 검색으로 대신할지.
-3. **서브에이전트 분리 여부.** 공급망 n차 전개처럼 컨텍스트를 많이 먹는 작업을 서브에이전트로 뺄지. 기업당 조사 서브에이전트가 자연스럽지만 예제의 가독성은 떨어진다.
-4. **리스크 점수 산식을 코드로 고정할지, 에이전트가 매번 설계할지.** 고정하면 재현 가능하지만 자유 형식 질문의 취지와 어긋난다. 프리셋에서만 고정하는 절충안이 유력하다.
-5. **합성 데이터의 현실성 수준.** 실제 DART/EDGAR 스키마를 얼마나 충실히 흉내 낼지. 너무 충실하면 예제가 무거워지고, 너무 단순하면 free-form 쿼리의 어려움이 사라진다.
-6. **실존 기업명 사용 금지 범위.** 제재 리스트는 형식만 차용하고 대상은 전부 가공해야 한다. 국가명·HS 코드는 실제 값을 써도 되는지.
+`--test-threads=1` is not optional for the mounting ones. Each holds a mount for the
+length of the test and unmounts by dropping it, and two of those overlapping deadlock —
+the tests report their results and then hang on the way out.

--- a/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/evidence.md
+++ b/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/evidence.md
@@ -1,0 +1,145 @@
+# Evidence log
+
+All paths below are relative to the mount root (the
+`ailoy-company-analysis` prefix is omitted, per instructions). Each path was
+read live during this session.
+
+## GLEIF
+
+1. **Path:** `gleif/search/entity.legalName/Samsung Electronics Co., Ltd/entity.legalAddress.country/KR/pages/page-001.json`
+   **Claim:** An exact legal-name search for "Samsung Electronics Co., Ltd"
+   filtered to Korean addresses returns 50 records, none of which is Samsung
+   Electronics itself — because GLEIF stores its legal name in Korean script.
+   **Detail:** `meta.pagination.total = 50`; scanned all 50 `entity.legalName.name`
+   values, none contain "samsung electronics" (case-insensitive).
+
+2. **Path:** `gleif/search/fulltext/Samsung Electronics/pages/page-001.json`
+   **Claim:** Full-text search for "Samsung Electronics" returns 81 records
+   (one page, under the 200/page cap). Record `id`/`lei` =
+   `9884007ER46L6N7EI764` is Samsung Electronics Co., Ltd.
+   **Detail:** record's `entity.legalName.name` = "삼성전자(주)" (language `ko`);
+   `entity.otherNames[0]` = `{"name":"SAMSUNG ELECTRONICS CO., LTD","language":"en","type":"ALTERNATIVE_LANGUAGE_LEGAL_NAME"}`;
+   `entity.legalAddress` = Suwon, Gyeonggi-do (KR-41), KR 16677;
+   `entity.registeredAs` = "124-81-00998"; `entity.jurisdiction` = "KR";
+   `entity.legalForm.id` = "5RCH"; `entity.status` = "ACTIVE";
+   `entity.creationDate` = "1969-01-13T00:00:00Z";
+   `registration.status` = "ISSUED"; `registration.initialRegistrationDate` =
+   "2017-09-27T00:00:00Z"; `registration.lastUpdateDate` = "2025-10-31T09:40:29Z";
+   `registration.managingLou` = "9884008RRMX1X5HV6625";
+   `registration.validatedAt.id` = "RA000657"; `registration.validatedAs` =
+   "124-81-00998"; `bic` = ["SECTKRSEXXX"]; `spglobal` = ["91868"];
+   `conformityFlag` = "CONFORMING".
+
+3. **Path:** `gleif/search/ownedBy/9884007ER46L6N7EI764/pages/page-001.json`
+   **Claim:** GLEIF records 22 entities directly/ultimately owned by this LEI.
+   **Detail:** `meta.pagination.total = 22`. Names include: Samsung Display
+   Noida Private Limited (IN), Samsung OAK Holdings, Inc. (US), Samsung
+   Malaysia Electronics (SME) Sdn. Bhd. (MY), Samsung R&D Institute India –
+   Bangalore Private Limited (IN), 삼성디스플레이(주) (KR), Samsung Eletronica
+   da Amazonia Ltda (BR), and 12 Harman-branded subsidiaries across HU, NL, DE,
+   GB, DK, MU, US, AT, RU, CN (×3), MX, RO.
+
+4. **Path:** `gleif/search/owns/9884007ER46L6N7EI764/pages/page-001.json`
+   **Claim:** GLEIF records 0 entities that own this LEI (empty parent
+   relationship set at the `owns` search endpoint).
+   **Detail:** `meta.pagination.total = 0`, `data = []`.
+
+5. **Path:** `gleif/by-lei/9884007ER46L6N7EI764/direct-parent-reporting-exception/direct-parent-reporting-exception.json`
+   **Claim:** No direct parent is reported; reason given is `NO_KNOWN_PERSON`.
+   **Detail:** `data.attributes.category` = "DIRECT_ACCOUNTING_CONSOLIDATION_PARENT",
+   `data.attributes.reason` = "NO_KNOWN_PERSON".
+
+6. **Path:** `gleif/by-lei/9884007ER46L6N7EI764/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json`
+   **Claim:** No ultimate parent is reported; same reason.
+   **Detail:** `data.attributes.category` = "ULTIMATE_ACCOUNTING_CONSOLIDATION_PARENT",
+   `data.attributes.reason` = "NO_KNOWN_PERSON".
+
+7. **Path:** `gleif/by-lei/9884007ER46L6N7EI764/isins/isins.json`
+   **Claim:** 15 ISINs are linked to this LEI.
+   **Detail:** `meta.pagination.total = 15`; ISINs: US7960503008, US7960504097,
+   US7960506076, US796050AA00, US7960508056, US7960507066, US7960508882,
+   US7960502018, US796050AE22, US796050AB82, US0019071044, US7960508700,
+   US7960505086, USY74718AQ37, US7960508627.
+
+8. **Path (checked, negative result):** `gleif/search/entity.legalName/Samsung Electronics/entity.legalAddress.country/KR/pages/page-001.json`
+   **Claim:** An exact legal-name search for the bare string "Samsung
+   Electronics" (no "Co., Ltd") filtered to KR returns 0 records — GLEIF's
+   `entity.legalName` filter requires an exact match, and the Korean legal
+   name doesn't literally read "Samsung Electronics" in Latin script.
+   **Detail:** `meta.pagination.total = 0`, `data = []`.
+
+## SEC EDGAR
+
+9. **Path:** `edgar/search/entityName/Samsung Electronics/pages/page-001.json`
+   **Claim:** Full-text filing search for "Samsung Electronics" returns 213
+   filing hits, spanning only 4 distinct CIKs: 0000879316 (Samsung
+   Electronics itself), 0000917273 (Rambus Inc.), 0001137789 (Seagate
+   Technology plc), 0001585854 (SunEdison Semiconductor Ltd).
+   **Detail:** `hits.total.value = 213`; ciks collected from all
+   `hits.hits[]._source.ciks`.
+
+10. **Path:** `edgar/search/entityName/Samsung Electronics Co Ltd/pages/page-001.json`
+    **Claim:** A near-identical query without punctuation returns the same
+    213-hit total, confirming this is a full-text search over filing
+    documents rather than an exact company-name index.
+    **Detail:** `hits.total.value = 213`.
+
+11. **Path:** `edgar/by-cik/0000879316/submissions/submissions.json`
+    **Claim:** CIK 0000879316 is registered under the name "SAMSUNG
+    ELECTRONICS CO LTD /FI"; `entityType` = "other"; EIN = "953170778"; `lei`
+    field = null; `stateOfIncorporation` = "M5" (Korea, Republic of);
+    `fiscalYearEnd` = "1231"; mailing/business address = "250 2 KA TAEPYUNG
+    RO CHUNG KU, SEOUL, KOREA, 100742"; `tickers` = []; `exchanges` = [];
+    `description`/`website`/`investorWebsite` = "" (empty).
+    **Detail:** direct field values as listed, read from the JSON object's
+    top level (excluding `filings`).
+
+12. **Path:** `edgar/by-cik/0000879316/submissions/submissions.json`
+    (`filings.recent`, zipped by index)
+    **Claim:** 251 filings on record for this CIK, dated 1995-03-06 to
+    2015-01-20. Form-type counts: SUPPL 196, SC 14D1/A 18, ARS 9, SC 13E3/A
+    9, SC 13D/A 6, SC 13G/A 2, SC 13G 2, SC 14D1 2, SC 14D9/A 2, Form 4 1,
+    Form 3 1, SC 13D 1, SC 13E3 1, SC 14D9 1.
+    **Detail:** computed via `collections.Counter` over
+    `filings.recent.form` (251 entries), min/max over
+    `filings.recent.filingDate`.
+
+13. **Path:** `edgar/by-cik/0000879316/submissions/submissions.json`
+    (`filings.recent`, individual rows)
+    **Claim:** 1995 filings (SC 14D1, SC 14D1/A ×8, SC 14D9, SC 14D9/A ×2)
+    and 1997 filings (SC 14D1, SC 13E3, and 9 rounds of amendments to each)
+    relate to a tender offer / going-private transaction; several 1997
+    `primaryDocDescription` values explicitly read "AST/SAMSUNG MERGER" or
+    "SAMSUNG / AST MERGER".
+    **Detail:** e.g. accession `0001017062-97-000688`,
+    `primaryDocDescription` = "SCHEDULE 13E3-3 RE SAMSUNG / AST MERGER";
+    accession `0001017062-97-000832`, `primaryDocDescription` = "AMEND. #2
+    TO SCH13E-3 - AST/SAMSUNG MERGER".
+
+14. **Path:** `edgar/by-cik/0000879316/submissions/submissions.json`
+    (`filings.recent`, individual rows)
+    **Claim:** Samsung Electronics is named as a co-filer/subject on SC 13D
+    and SC 13D/A filings for Seagate Technology plc (2011–2013), an SC 13G/A
+    for Rambus Inc. (2012), SC 13G/SC 13G-A for SunEdison Semiconductor Ltd
+    (2014–2015), and Forms 3/4 tied to the Seagate position (2012–2013).
+    **Detail:** e.g. accession `0001193125-13-406331`,
+    `display_names` = ["Seagate Technology plc (STX) (CIK 0001137789)",
+    "SAMSUNG ELECTRONICS CO LTD /FI (CIK 0000879316)"]; accession
+    `0001193125-15-014566`, `display_names` = ["SunEdison Semiconductor Ltd
+    (CIK 0001585854)", "SAMSUNG ELECTRONICS CO LTD /FI (CIK 0000879316)"].
+
+15. **Path:** `edgar/by-cik/0000879316/facts/facts.json`
+    **Claim:** No XBRL company-facts document exists for this CIK; the
+    endpoint returns an S3 "NoSuchKey" error instead.
+    **Detail:** raw response body: `<?xml version="1.0" encoding="UTF-8"?>
+    <Error><Code>NoSuchKey</Code><Message>The specified key does not
+    exist.</Message><Key>api/xbrl/companyfacts/CIK0000879316.json</Key>...`.
+
+## Cross-registry note
+
+No path in either registry cites the other's identifier: GLEIF's record for
+LEI `9884007ER46L6N7EI764` has no CIK/EIN field, and EDGAR's `lei` field for
+CIK `0000879316` is `null` (evidence #11). The association between the two
+records made in this report rests on matching the company name ("Samsung
+Electronics") and Korea as the home jurisdiction in both records — a name
+match, per the catalog's guidance, not a confirmed shared-entity fact.

--- a/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/findings.json
+++ b/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/findings.json
@@ -1,0 +1,97 @@
+{
+  "run_id": "1787632223-samsung-electronics-entity-profile",
+  "task": "Profile Samsung Electronics from the registries: what the entity is, where it is registered, what identifiers name it, and what it discloses about itself.",
+  "entities": [
+    {
+      "name": "삼성전자(주) / SAMSUNG ELECTRONICS CO., LTD",
+      "registry": "GLEIF",
+      "identifier_type": "LEI",
+      "identifier": "9884007ER46L6N7EI764",
+      "jurisdiction": "KR",
+      "status": "ACTIVE (entity) / ISSUED (LEI registration)"
+    },
+    {
+      "name": "SAMSUNG ELECTRONICS CO LTD /FI",
+      "registry": "SEC EDGAR",
+      "identifier_type": "CIK",
+      "identifier": "0000879316",
+      "jurisdiction": "M5 (Korea, Republic of)",
+      "status": "entityType: other; last filing 2015-01-20"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "info",
+      "statement": "Samsung Electronics Co., Ltd. (GLEIF legal name 삼성전자(주)) holds LEI 9884007ER46L6N7EI764, status ACTIVE, registered/validated against Korean business registration number 124-81-00998 at registration authority RA000657, headquartered in Suwon, Gyeonggi-do, KR.",
+      "evidence": ["gleif/search/fulltext/Samsung Electronics/pages/page-001.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "GLEIF reports no direct or ultimate parent for this LEI; both relationships are recorded as reporting exceptions with reason NO_KNOWN_PERSON.",
+      "evidence": [
+        "gleif/by-lei/9884007ER46L6N7EI764/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/9884007ER46L6N7EI764/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "GLEIF records 22 entities owned by this LEI, including Samsung Display Noida, Samsung OAK Holdings, Samsung Malaysia Electronics, Samsung R&D Institute India-Bangalore, Samsung Display Co. Ltd (Korea), Samsung Eletronica da Amazonia, and 12 Harman International subsidiaries.",
+      "evidence": ["gleif/search/ownedBy/9884007ER46L6N7EI764/pages/page-001.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "GLEIF links 15 ISINs to this LEI, mostly with prefix US7960..., plus US0019071044 and USY74718AQ37.",
+      "evidence": ["gleif/by-lei/9884007ER46L6N7EI764/isins/isins.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "In SEC EDGAR, Samsung Electronics is filer CIK 0000879316, name on file 'SAMSUNG ELECTRONICS CO LTD /FI', entityType 'other', EIN 953170778, state of incorporation M5 (Korea), fiscal year end 12/31, no tickers/exchanges listed, lei field null.",
+      "evidence": ["edgar/by-cik/0000879316/submissions/submissions.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "CIK 0000879316 has 251 filings on record spanning 1995-03-06 to 2015-01-20, dominated by paper SUPPL filings (196), tender-offer/going-private schedules (SC 14D1/A x18, SC 13E3/A x9, SC 14D9 family), and paper ARS annual reports (9); nothing filed after January 2015.",
+      "evidence": ["edgar/by-cik/0000879316/submissions/submissions.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "1997 filings under this CIK (SC 14D1, SC 13E3 and amendments) are explicitly described in filing metadata as relating to the 'AST/SAMSUNG MERGER', i.e. Samsung's acquisition/going-private of AST Research.",
+      "evidence": ["edgar/by-cik/0000879316/submissions/submissions.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "Samsung Electronics appears as a co-filer/beneficial owner in SC 13D/13D-A filings on Seagate Technology plc (2011-2013), SC 13G/A on Rambus Inc. (2012), and SC 13G/13G-A on SunEdison Semiconductor Ltd (2014-2015).",
+      "evidence": ["edgar/search/entityName/Samsung Electronics/pages/page-001.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "warning",
+      "statement": "No XBRL company-facts document exists for CIK 0000879316; the facts endpoint returns an S3 NoSuchKey error, so no structured financial data is available from EDGAR for this filer.",
+      "evidence": ["edgar/by-cik/0000879316/facts/facts.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "warning",
+      "statement": "The GLEIF LEI record and the EDGAR CIK record for Samsung Electronics are a possible match, not a confirmed link: neither record carries the other's identifier (EDGAR's lei field is null; GLEIF's record has no CIK/EIN field). The join rests on matching company name and Korean jurisdiction across both records.",
+      "evidence": [
+        "gleif/search/fulltext/Samsung Electronics/pages/page-001.json",
+        "edgar/by-cik/0000879316/submissions/submissions.json"
+      ],
+      "confidence": "medium"
+    }
+  ],
+  "data_gaps": [
+    "No financial statements, revenue, or headcount data available in either registry for this non-US entity.",
+    "GLEIF legal-form code '5RCH' and registration authority code 'RA000657' are not decoded to plain text within this mount (no legal-form/RA reference table available).",
+    "EDGAR filing history for CIK 0000879316 stops at 2015-01-20; any more recent SEC-related activity is not visible in this record.",
+    "GLEIF full-text search for 'Samsung Electronics' was capped at one page of 81 results (under the 200/page limit, so not truncated), but a broader name search could surface additional related entities not reviewed here.",
+    "Cross-registry identity between the GLEIF LEI and the EDGAR CIK is a name-based match only; no shared identifier confirms it."
+  ]
+}

--- a/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/queries/01-gleif-search.py
+++ b/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/queries/01-gleif-search.py
@@ -1,0 +1,57 @@
+"""
+GLEIF lookups for Samsung Electronics Co., Ltd.
+
+Run against the read-only mount at
+<mount>/gleif/  (mount root omitted per task instructions; see evidence.md
+for the paths as read).
+
+Each `read`/`ls` against a `pages/page-NNN.json` path is a live request to the
+GLEIF API. This script documents the paths opened, in order, and what they
+returned, re-reading the same JSON files from the mount.
+"""
+import json
+
+ROOT = "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis"
+
+# 1. Exact legal name "Samsung Electronics Co., Ltd" narrowed by country=KR
+#    -- returned 50 Korean entities named similarly, none of them Samsung
+#    Electronics itself (GLEIF stores its legal name in Korean script).
+p1 = f"{ROOT}/gleif/search/entity.legalName/Samsung Electronics Co., Ltd/entity.legalAddress.country/KR/pages/page-001.json"
+d1 = json.load(open(p1))
+print("Step 1 total hits (legalName exact, KR):", d1["meta"]["pagination"]["total"])
+print("Samsung Electronics itself present?",
+      any("samsung electronics" in r["attributes"]["entity"]["legalName"]["name"].lower()
+          for r in d1["data"]))
+
+# 2. Full-text search "Samsung Electronics" -- 81 hits, one page. Confirms
+#    the Korean-script legal name record: LEI 9884007ER46L6N7EI764.
+p2 = f"{ROOT}/gleif/search/fulltext/Samsung Electronics/pages/page-001.json"
+d2 = json.load(open(p2))
+print("\nStep 2 total hits (fulltext):", d2["meta"]["pagination"]["total"])
+for rec in d2["data"]:
+    if rec["attributes"]["lei"] == "9884007ER46L6N7EI764":
+        print("Matched GLEIF record for the parent company:")
+        print(json.dumps(rec, ensure_ascii=False, indent=2))
+
+# 3. Ownership relationships as reported to GLEIF.
+p3 = f"{ROOT}/gleif/search/ownedBy/9884007ER46L6N7EI764/pages/page-001.json"
+d3 = json.load(open(p3))
+print("\nDirect/ultimate children reported (ownedBy):", d3["meta"]["pagination"]["total"])
+for rec in d3["data"]:
+    print(" -", rec["attributes"]["lei"], rec["attributes"]["entity"]["legalName"]["name"],
+          rec["attributes"]["entity"]["legalAddress"]["country"])
+
+p4 = f"{ROOT}/gleif/search/owns/9884007ER46L6N7EI764/pages/page-001.json"
+d4 = json.load(open(p4))
+print("\nParent reported (owns):", d4["meta"]["pagination"]["total"])
+
+# 4. Reporting exceptions -- why no parent is listed.
+for rel in ["direct-parent-reporting-exception", "ultimate-parent-reporting-exception"]:
+    p = f"{ROOT}/gleif/by-lei/9884007ER46L6N7EI764/{rel}/{rel}.json"
+    d = json.load(open(p))
+    print(f"\n{rel}:", d["data"]["attributes"]["reason"])
+
+# 5. ISINs linked to the LEI.
+p5 = f"{ROOT}/gleif/by-lei/9884007ER46L6N7EI764/isins/isins.json"
+d5 = json.load(open(p5))
+print("\nISINs:", [x["attributes"]["isin"] for x in d5["data"]])

--- a/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/queries/02-edgar-search.py
+++ b/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/queries/02-edgar-search.py
@@ -1,0 +1,53 @@
+"""
+EDGAR lookups for Samsung Electronics.
+
+Run against the read-only mount at <mount>/edgar/.
+"""
+import json
+from collections import Counter
+
+ROOT = "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis"
+
+# 1. entityName search "Samsung Electronics" -- full text search over filings,
+#    213 hits total, but only 4 distinct CIKs appear as filer/subject.
+p1 = f"{ROOT}/edgar/search/entityName/Samsung Electronics/pages/page-001.json"
+d1 = json.load(open(p1))
+print("Step 1 total hits:", d1["hits"]["total"])
+ciks = set()
+names = {}
+for h in d1["hits"]["hits"]:
+    for c, n in zip(h["_source"]["ciks"], h["_source"]["display_names"]):
+        ciks.add(c)
+        names[c] = n
+for c in ciks:
+    print(" -", c, names[c])
+
+# 2. entityName search "Samsung Electronics Co Ltd" -- same result set (213
+#    hits), confirming these are full-text hits on filing documents that
+#    mention the name, not a company-name index lookup.
+p2 = f"{ROOT}/edgar/search/entityName/Samsung Electronics Co Ltd/pages/page-001.json"
+d2 = json.load(open(p2))
+print("\nStep 2 total hits:", d2["hits"]["total"])
+
+# 3. The one CIK registered under Samsung Electronics' own name:
+#    0000879316, "SAMSUNG ELECTRONICS CO LTD /FI"
+p3 = f"{ROOT}/edgar/by-cik/0000879316/submissions/submissions.json"
+d3 = json.load(open(p3))
+core = {k: v for k, v in d3.items() if k != "filings"}
+print("\nCIK 0000879316 core submission fields:")
+print(json.dumps(core, indent=2, ensure_ascii=False))
+
+recent = d3["filings"]["recent"]
+forms = Counter(recent["form"])
+print("\nForm-type counts across all filings on record:")
+for k, v in forms.most_common():
+    print(f"  {k}: {v}")
+print("Earliest filing date:", min(recent["filingDate"]))
+print("Latest filing date:", max(recent["filingDate"]))
+
+# 4. company facts (XBRL) -- not available for this filer; the response is
+#    an S3 NoSuchKey XML error rather than a JSON facts document.
+p4 = f"{ROOT}/edgar/by-cik/0000879316/facts/facts.json"
+raw4 = open(p4).read()
+print("\nfacts.json raw response (not JSON facts, an error body):")
+print(raw4)

--- a/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/report.md
+++ b/examples/company_analysis/artifacts/1787632223-samsung-electronics-entity-profile/report.md
@@ -1,0 +1,180 @@
+# Samsung Electronics — Entity Profile
+
+## Summary
+
+- **Samsung Electronics Co., Ltd.** (Korean legal name 삼성전자(주)) is a South Korean
+  company headquartered in Suwon, Gyeonggi-do, holding an **active** Legal Entity
+  Identifier (LEI) `9884007ER46L6N7EI764` issued under GLEIF, validated against the
+  Korean business registration number `124-81-00998` (registration authority
+  `RA000657`).
+- GLEIF reports **no parent** for Samsung Electronics — both the direct- and
+  ultimate-parent relationships carry the exception reason `NO_KNOWN_PERSON`, meaning
+  no controlling entity was reported to the LEI system. GLEIF does list 22 entities
+  Samsung Electronics itself owns (e.g. Samsung Display, Samsung Malaysia Electronics,
+  and the Harman International group).
+- In SEC EDGAR, Samsung Electronics is registered as filer **CIK 0000879316**,
+  "SAMSUNG ELECTRONICS CO LTD /FI", a foreign private issuer incorporated in the
+  Republic of Korea (state code `M5`), EIN `953170778`. Its EDGAR filing history is
+  narrow and dated: 251 filings from 1995 to 2015, dominated by beneficial-ownership
+  and tender-offer schedules (SC 13D/G, SC 14D1/9, SC 13E3) and paper annual-report
+  supplements — no 10-K/20-F-style disclosures and nothing filed after January 2015.
+- No XBRL company-facts are on file for this CIK (the API returns a "NoSuchKey"
+  error), and no ticker/exchange listing is recorded — consistent with Samsung
+  Electronics not being an SEC reporting company in the ordinary sense, but a foreign
+  entity that has occasionally been a subject or filer in US ownership/tender-offer
+  filings.
+- The two registries share no common identifier: GLEIF's LEI and EDGAR's CIK were
+  joined here only by matching the company name and its Korean HQ address/description
+  across records — see "Identifiers" below.
+
+## 1. The entity
+
+Samsung Electronics is a Korean electronics manufacturer. The GLEIF record's legal
+name is stored in Korean script — **삼성전자(주)** — with the English form
+"SAMSUNG ELECTRONICS CO., LTD" recorded as an `ALTERNATIVE_LANGUAGE_LEGAL_NAME`.
+`gleif/search/fulltext/Samsung Electronics/pages/page-001.json`, record with
+`lei = 9884007ER46L6N7EI764`.
+
+Its legal and headquarters address, per GLEIF, is:
+
+> 경기도 수원시 영통구 삼성로 129 (매탄동), 삼성전자 — Suwon, Gyeonggi-do (KR-41), KR 16677
+> (English form: 129, Samsung-ro, Yeongtong-gu, Suwon-si, Gyeonggi-do)
+
+`gleif/search/fulltext/Samsung Electronics/pages/page-001.json` (same record,
+`entity.legalAddress` / `entity.otherAddresses`).
+
+GLEIF's `entity.creationDate` for this LEI record is `1969-01-13`, i.e. the entity's
+founding date as reported to GLEIF. Same source.
+
+In SEC EDGAR, the filer of record under this name is CIK `0000879316`, name on file
+"SAMSUNG ELECTRONICS CO LTD /FI" (the "/FI" suffix is EDGAR's own disambiguation
+suffix, not part of the legal name), `entityType: "other"`, incorporated/organized in
+`M5` = "Korea, Republic of." `edgar/by-cik/0000879316/submissions/submissions.json`.
+
+A full-text search of EDGAR filings for "Samsung Electronics" returns 213 filing hits
+across only four distinct CIKs — Samsung Electronics itself (0000879316), and three
+unrelated US filers (Rambus Inc., Seagate Technology plc, SunEdison Semiconductor
+Ltd) whose filings merely *mention* Samsung Electronics (e.g. as a 5%+ beneficial
+owner in SC 13D/G schedules). `edgar/search/entityName/Samsung Electronics/pages/page-001.json`.
+
+## 2. Identifiers and where each comes from
+
+| Identifier | Value | Source | Notes |
+|---|---|---|---|
+| LEI (GLEIF) | `9884007ER46L6N7EI764` | `gleif/search/fulltext/Samsung Electronics/pages/page-001.json` | Status `ISSUED`, `conformityFlag: CONFORMING`. Managing LOU: `9884008RRMX1X5HV6625`. |
+| Local registration number (validated by GLEIF) | `124-81-00998` | same record, `entity.registeredAs` / `registration.validatedAs` | Validated at registration authority `RA000657` (Korea), i.e. a Korean business registration number, not the EDGAR CIK or EIN. |
+| BIC | `SECTKRSEXXX` | same record, `attributes.bic` | Bank identifier code associated with the entity in GLEIF's data. |
+| ISINs (15 listed) | e.g. `US7960503008`, `US7960504097`, `US0019071044`, `USY74718AQ37`, … | `gleif/by-lei/9884007ER46L6N7EI764/isins/isins.json` | Securities linked to this LEI; several `US7960...` and `US796050...` ISINs plus one non-matching prefix (`US0019071044`, `USY74718AQ37`) that GLEIF nonetheless associates with this LEI. |
+| SEC CIK | `0000879316` | `edgar/by-cik/0000879316/submissions/submissions.json` | Filer name on record: "SAMSUNG ELECTRONICS CO LTD /FI". |
+| EIN (US tax ID, as recorded by EDGAR) | `953170778` | same submissions.json | EDGAR's `ein` field; per the registry-crossing rule this is *not* a bridge to GLEIF, which records a local registration number instead. |
+| GLEIF `lei` field inside EDGAR | `null` | same submissions.json | Confirms the catalog's warning that EDGAR's `lei` field is essentially never populated for this filer. |
+
+**No shared key exists between the two records.** They were matched here on **name +
+jurisdiction** (Korean electronics company named "Samsung Electronics," headquartered
+in / incorporated under Korea in both records) — this is a **name match, treated as a
+candidate joined and cross-checked on jurisdiction, not a guaranteed same-legal-entity
+link** the way the catalogs describe. Nothing in either record cites the other's
+identifier directly.
+
+## 3. Registration and status
+
+**GLEIF (LEI record):**
+- Status: `ACTIVE` (entity status) / `ISSUED` (LEI registration status)
+- Initial LEI registration: 2017-09-27; last update 2025-10-31; next renewal
+  2026-10-31
+- Jurisdiction: `KR`; legal form code `5RCH` (a GLEIF-internal legal-form code; the
+  record does not spell out its label, and no local legal-form lookup table is
+  available in this mount)
+- Direct-parent / ultimate-parent: both report `NO_KNOWN_PERSON` — GLEIF was told
+  there is no reportable controlling entity above Samsung Electronics.
+- Direct/ultimate subsidiaries reported to GLEIF (`ownedBy` relationship, 22 total):
+  includes Samsung Display Noida (India), Samsung OAK Holdings Inc. (US), Samsung
+  Malaysia Electronics, Samsung R&D Institute India–Bangalore, 삼성디스플레이(주)
+  (Samsung Display Co., Ltd, Korea), Samsung Eletrônica da Amazônia (Brazil), and the
+  Harman International group of subsidiaries (US, DE, NL, HU, DK, AT, MU, RU, CN, MX,
+  RO). `gleif/search/ownedBy/9884007ER46L6N7EI764/pages/page-001.json`.
+
+**SEC EDGAR (filer record):**
+- `entityType: "other"`; no ticker, no exchange listed
+  (`tickers: []`, `exchanges: []`)
+- State/country of incorporation: `M5` = Korea, Republic of
+- Fiscal year end: 12/31
+- Filing history spans **1995-03-06 to 2015-01-20** (251 filings on record); nothing
+  filed since January 2015 under this CIK.
+- Form mix (251 filings): 196 `SUPPL` (auto-generated paper-document placeholders),
+  18 `SC 14D1/A`, 9 `ARS` (annual report to shareholders, paper), 9 `SC 13E3/A`, 6
+  `SC 13D/A`, 2 each of `SC 13G/A`, `SC 13G`, `SC 14D1`, `SC 14D9/A`, and 1 each of
+  `SC 13D`, `SC 13E3`, `SC 14D9`, Form `3`, Form `4`.
+  `edgar/by-cik/0000879316/submissions/submissions.json`.
+- Company-facts (XBRL) endpoint returns an S3 "NoSuchKey" error rather than a facts
+  document — no structured financial facts are on file for this CIK.
+  `edgar/by-cik/0000879316/facts/facts.json`.
+
+## 4. What the filings say
+
+The EDGAR filing history under CIK 0000879316 is not a normal US-issuer disclosure
+record (no 10-K/10-Q, no XBRL facts). It consists almost entirely of:
+
+- **Tender-offer / going-private paperwork from 1995 and 1997**: Schedule 14D-1 and
+  14D-9 filings (and their amendments) plus Schedule 13E-3 filings, associated with a
+  1995 tender offer and a 1997 going-private transaction involving **AST Research**
+  (the 1997 filings are explicitly described as "AST/SAMSUNG MERGER" /
+  "SAMSUNG/AST MERGER" in `primaryDocDescription`). `edgar/by-cik/0000879316/submissions/submissions.json`, filings dated 1995-03-06 through 1997-08-15.
+- **Beneficial-ownership schedules where Samsung Electronics is the reporting
+  person or subject** on other companies' securities: Schedule 13D/13D-A on Seagate
+  Technology plc (2011–2013) and Rambus Inc. (2012), Schedule 13G/13G-A on SunEdison
+  Semiconductor Ltd (2014–2015), and individual Forms 3/4 tied to the Seagate
+  position (2012–2013). `edgar/search/entityName/Samsung Electronics/pages/page-001.json`.
+- **Paper annual reports (ARS) and paper "SUPPL" filings from 2002–2010**, i.e.
+  Samsung Electronics periodically submitted its annual report to shareholders (as a
+  foreign private issuer furnishing information under Rule 12g3-2(b)) as
+  auto-generated paper documents rather than electronic disclosures.
+  `edgar/by-cik/0000879316/submissions/submissions.json`.
+
+No 20-F, 10-K, or other periodic US disclosure form appears in the filing history, and
+no filings are on record after **2015-01-20**. EDGAR's `description` and `website`
+fields for this CIK are both empty strings — the registry does not carry a
+self-description or website for this filer.
+
+## Data limits
+
+- **No structured financial disclosures**: EDGAR carries no XBRL company facts for
+  this CIK (`facts.json` — S3 "NoSuchKey" error) and no 10-K/20-F on record — this
+  registry cannot answer questions about Samsung Electronics' revenue, headcount, or
+  financial statements, and the task instructions note this is out of scope for both
+  registries generally (non-US financial statements aren't covered).
+- **No shared identifier confirms the two records are the same legal entity beyond
+  name + Korean jurisdiction.** The join between GLEIF's LEI `9884007ER46L6N7EI764`
+  and EDGAR's CIK `0000879316` is a **possible match — needs confirmation**, checked
+  here only against: (a) both naming "Samsung Electronics," and (b) both citing Korea
+  as the home jurisdiction. Neither record cites the other's identifier.
+- **GLEIF's `entity.legalForm.id` (`5RCH`) and `registeredAt.id` (`RA000657`) are
+  opaque codes** in the record; no legal-form or registration-authority lookup table
+  was available in this mount to translate them into plain text, so they are reported
+  as-is.
+- **EDGAR's `lei` field for this filer is `null`**, matching the catalog's warning
+  that this field is almost never populated — it could not be used to confirm the
+  cross-registry match.
+- **EDGAR's filing history stops in January 2015.** Whether Samsung Electronics has
+  had any EDGAR-reportable events since then (e.g. further Schedule 13D/G activity)
+  is not something this record can speak to; only what is on file for CIK 0000879316
+  was read.
+- The GLEIF full-text search for "Samsung Electronics" returned 81 records on a
+  single page (under the API's 200-per-page cap) and was not paginated further, but a
+  broader legal-name search (without "Electronics") could return additional
+  Samsung-affiliated entities not surfaced here; the search here was scoped to
+  entities whose name contains "Samsung Electronics" specifically.
+
+## Next steps
+
+- If a full ownership/subsidiary map is needed, walk GLEIF's
+  `direct-children`/`ultimate-children` relationship endpoints beyond the 22 entities
+  already surfaced under `ownedBy`, and decode legal-form code `5RCH` against GLEIF's
+  full ISO 20275 legal-form-code reference (not available in this mount).
+  Ownership structure and control cannot be confirmed further within this registry.
+- If current (post-2015) SEC activity is in scope, re-run the EDGAR full-text search
+  narrowed by a recent `startdt` to check whether Samsung Electronics has appeared as
+  a subject of any new Schedule 13D/G filings by other CIKs.
+- For financial statements, corporate registry filings, or news about Samsung
+  Electronics, a different data source is required — neither GLEIF nor EDGAR carries
+  this, per the catalog's own statement of scope.

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/evidence.md
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/evidence.md
@@ -1,0 +1,103 @@
+# Evidence
+
+All paths below are relative to the mount root (the `.../ailoy-company-analysis`
+prefix is omitted per instructions).
+
+## GLEIF
+
+**Path:** `gleif/search/entity.legalName/NVIDIA/pages/page-001.json`
+Retrieved by descending `gleif/search/entity.legalName/NVIDIA/pages` and reading
+`page-001.json` (the only paid request in this branch). `meta.pagination.total`
+= 19.
+
+Claims sourced from `data[0]` (the `NVIDIA CORPORATION` record, LEI
+`549300S4KLFTLO7GSQ80`):
+- LEI `549300S4KLFTLO7GSQ80`
+- Legal name "NVIDIA CORPORATION"
+- Category `GENERAL`, status `ACTIVE`, legal form id `XTIQ`
+- Jurisdiction `US-DE`; `registeredAs` "2862596"; `registeredAt.id` "RA000602"
+- Legal address: C/O Corporation Service Company, 251 Little Falls Drive,
+  Wilmington, US-DE, 19808
+- Headquarters address: 2788 San Tomas Expressway, Santa Clara, US-CA, 95051
+- `creationDate` 1998-02-24T00:00:00Z
+- Event: `CHANGE_HQ_ADDRESS`, effective 2024-02-05
+- Registration: `initialRegistrationDate` 2013-04-09T17:39:00Z, `lastUpdateDate`
+  2026-01-07T01:29:18Z, `nextRenewalDate` 2027-02-06T17:45:00Z,
+  `corroborationLevel` "FULLY_CORROBORATED"
+- `bic`: `NVDAUS6SXXX`; `spglobal`: `["32307"]`
+
+Claims sourced from `data[1]` (`NVIDIA INTERNATIONAL, INC.`, LEI
+`549300EK80J3WR5TSA69`) — used only to show what was ruled out, not as the
+matched record:
+- Legal name "NVIDIA INTERNATIONAL, INC."
+- Same headquarters address as `data[0]` (2788 San Tomas Expressway, Santa
+  Clara, US-CA, 95051) and same jurisdiction `US-DE`
+- Different `registeredAs`: "6004882"; `creationDate` 2021-06-28
+
+Claims sourced from `data[2..18]` (funds/ETFs/subsidiaries) — used to show
+what the "NVIDIA" name match returns besides the parent company:
+- "Defiance Nvidia Ventures ETF", LEI `529900YQV0X0R0T0AZ11`, category `FUND`
+- "NINEPOINT NVIDIA HIGHSHARES ETF", LEI `894500UB1PEXN75HFT11`, category
+  `FUND`, jurisdiction `CA` (Canada)
+- "NVIDIA GRAPHICS PRIVATE LIMITED", LEI `335800TGZ6N1BWAN7Q35`, jurisdiction
+  `IN`, category `GENERAL`
+- "NVIDIA SINGAPORE PTE LTD", LEI `549300PVTLDCMDI67P44`, jurisdiction `SG`,
+  category `GENERAL`
+- "Nvidia Land Development, LLC", LEI `54930030GWBYMACGJH60`, jurisdiction
+  `US-DE`, category `GENERAL`
+- Remaining hits are further fund/ETF products (Kurv, Tuttle, CHINAAMC,
+  Harvest, Purpose, PurePlay, CSOP, T-Rex, ASA), all category `FUND`.
+
+## EDGAR
+
+**Path:** `edgar/search/entityName/NVIDIA/pages/page-001.json`
+Retrieved by descending `edgar/search/entityName/NVIDIA/pages` and reading
+`page-001.json`. `hits.total.value` = 2415 (capped display: the search backend
+caps at 10,000; this number is below the cap, so it is exact per the catalog's
+rule).
+
+Claim sourced: top hit's `_source.display_names` includes
+`"NVIDIA CORP  (NVDA)  (CIK 0001045810)"`, and `_source.ciks` includes
+`"0001045810"` — this is the CIK used for the by-CIK lookup below. Other CIKs
+appearing in this result page (insiders, Vanguard entities, CoreWeave, Nebius
+Group) are filers who filed *about* NVIDIA (e.g. Form 4 insider filings,
+13F holdings, Schedule 13G), not NVIDIA itself.
+
+**Path:** `edgar/by-cik/0001045810/submissions/submissions.json`
+Retrieved directly since the CIK was confirmed via the search above.
+
+Claims sourced:
+- `cik`: `"0001045810"`
+- `name`: `"NVIDIA CORP"`
+- `tickers`: `["NVDA"]`; `exchanges`: `["Nasdaq"]`
+- `ein`: `"943177549"`
+- `lei`: `null` — confirms the catalog's statement that this field is
+  "almost always null"
+- `stateOfIncorporation`: `"DE"`
+- `sic`: `"3674"`, `sicDescription`: `"Semiconductors & Related Devices"`
+- `category`: `"Large accelerated filer"`; `fiscalYearEnd`: `"0131"`
+- `formerNames`: `[{"name": "NVIDIA CORP/CA", "from": "1998-05-07T00:00:00.000Z",
+  "to": "2002-06-04T00:00:00.000Z"}]`
+- `addresses.mailing` and `addresses.business`: both
+  `2788 SAN TOMAS EXPRESSWAY, SANTA CLARA, CA, 95051`
+
+## Cross-registry comparison basis
+
+- Address match (GLEIF `entity.headquartersAddress` vs. EDGAR
+  `addresses.business`/`addresses.mailing`): both "2788 San Tomas Expressway,
+  Santa Clara, CA 95051" — used as the primary corroborating fact for the
+  match, per `gleif/search/.../page-001.json` and
+  `edgar/by-cik/0001045810/submissions/submissions.json`.
+- Jurisdiction match: GLEIF `entity.jurisdiction` = `US-DE`; EDGAR
+  `stateOfIncorporation` = `DE` — same fact, different field names.
+
+## Catalog statements relied on directly
+
+- `CATALOG.md` (root): "GLEIF's identifier is the LEI and EDGAR's is the CIK,
+  and neither registry carries the other's... EIN does not bridge either" —
+  basis for treating this as a name match rather than a key join.
+- `edgar/CATALOG.md`: "`ciks` is a list of zero-padded strings —
+  `["0001045810"]` — and that is the one to use" — followed when extracting
+  the CIK from the search hit.
+- `gleif/CATALOG.md`: "Descending is free; opening `pages` is not" — followed
+  by naming the filter (`entity.legalName/NVIDIA`) before opening `pages`.

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/findings.json
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/findings.json
@@ -1,0 +1,96 @@
+{
+  "run_id": "1787632744-nvidia-cross-registry",
+  "task": "Find NVIDIA in both registries (GLEIF, EDGAR) and compare what each says: agreements, differences, match confidence.",
+  "entities": [
+    {
+      "registry": "gleif",
+      "id_type": "LEI",
+      "id": "549300S4KLFTLO7GSQ80",
+      "legal_name": "NVIDIA CORPORATION",
+      "source": "gleif/search/entity.legalName/NVIDIA/pages/page-001.json"
+    },
+    {
+      "registry": "edgar",
+      "id_type": "CIK",
+      "id": "0001045810",
+      "legal_name": "NVIDIA CORP",
+      "ticker": "NVDA",
+      "source": "edgar/by-cik/0001045810/submissions/submissions.json"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "info",
+      "statement": "GLEIF LEI 549300S4KLFTLO7GSQ80 (NVIDIA CORPORATION) and EDGAR CIK 0001045810 (NVIDIA CORP / NVDA) are the same operating company, matched by name and corroborated by identical headquarters address and identical state of incorporation.",
+      "evidence": [
+        "gleif/search/entity.legalName/NVIDIA/pages/page-001.json",
+        "edgar/search/entityName/NVIDIA/pages/page-001.json",
+        "edgar/by-cik/0001045810/submissions/submissions.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "Both records agree on headquarters street address: 2788 San Tomas Expressway, Santa Clara, CA 95051.",
+      "evidence": [
+        "gleif/search/entity.legalName/NVIDIA/pages/page-001.json",
+        "edgar/by-cik/0001045810/submissions/submissions.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "Both records agree on jurisdiction/state of incorporation: Delaware (GLEIF entity.jurisdiction = US-DE; EDGAR stateOfIncorporation = DE).",
+      "evidence": [
+        "gleif/search/entity.legalName/NVIDIA/pages/page-001.json",
+        "edgar/by-cik/0001045810/submissions/submissions.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "EDGAR's own lei field for NVIDIA CORP (CIK 0001045810) is null, confirming there is no reliable cross-registry key and this match rests on name + attribute corroboration only.",
+      "evidence": ["edgar/by-cik/0001045810/submissions/submissions.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "GLEIF's legal address (registered-agent address, 251 Little Falls Drive, Wilmington DE) differs from its own headquarters address and has no counterpart field in the EDGAR record, which carries only mailing/business addresses.",
+      "evidence": ["gleif/search/entity.legalName/NVIDIA/pages/page-001.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "Each registry carries fields absent from the other: GLEIF has no EIN, SIC code, ticker, or exchange; EDGAR has no LEI, Delaware file number, or LEI-registration dates. This is a coverage difference, not a factual disagreement.",
+      "evidence": [
+        "gleif/search/entity.legalName/NVIDIA/pages/page-001.json",
+        "edgar/by-cik/0001045810/submissions/submissions.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "caution",
+      "statement": "A GLEIF legal-name search for \"NVIDIA\" returns 19 records; most are ETFs/funds tracking NVIDIA stock (e.g. Defiance Nvidia Ventures ETF, T-Rex 2X Long NVIDIA Daily Target ETF) or foreign subsidiaries (NVIDIA SINGAPORE PTE LTD, NVIDIA GRAPHICS PRIVATE LIMITED), not the parent company itself.",
+      "evidence": ["gleif/search/entity.legalName/NVIDIA/pages/page-001.json"],
+      "confidence": "high"
+    },
+    {
+      "severity": "caution",
+      "statement": "NVIDIA INTERNATIONAL, INC. (LEI 549300EK80J3WR5TSA69) shares the same headquarters address and Delaware jurisdiction as NVIDIA CORPORATION but is a distinct LEI record (different Delaware file number, different creation date, 2021 vs 1998) — presumed subsidiary, not confirmed via a parent/child relationship query in this run.",
+      "evidence": ["gleif/search/entity.legalName/NVIDIA/pages/page-001.json"],
+      "confidence": "medium"
+    },
+    {
+      "severity": "caution",
+      "statement": "EDGAR full-text search for 'NVIDIA' returns 2,415 hits; most surfaced on the first page are filings by other filers (insiders, Vanguard entities, CoreWeave, Nebius Group) that merely mention NVIDIA, not NVIDIA's own filings.",
+      "evidence": ["edgar/search/entityName/NVIDIA/pages/page-001.json"],
+      "confidence": "high"
+    }
+  ],
+  "data_gaps": [
+    "No shared identifier exists between GLEIF (LEI) and EDGAR (CIK); the join used here is name plus address/jurisdiction corroboration, reported as a possible-match confirmed by two independent attributes rather than a guaranteed identity.",
+    "Neither registry covers financial statements (beyond XBRL facts not queried here), sanctions, litigation, or news for NVIDIA.",
+    "GLEIF's direct-parent/direct-children relationship links for NVIDIA CORPORATION were not queried, so the relationship between NVIDIA CORPORATION and NVIDIA INTERNATIONAL, INC. (and the Singapore/India subsidiaries) is inferred from shared address only, not confirmed structurally.",
+    "EDGAR's XBRL facts/concept endpoints (financial data) under by-cik/0001045810 were not queried in this run; only submissions.json (registrant metadata) was used."
+  ]
+}

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/01-gleif-search-nvidia.py
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/01-gleif-search-nvidia.py
@@ -1,0 +1,30 @@
+"""
+Query 1: search GLEIF by legal name "NVIDIA" and read the results page.
+
+Path walked (mounted filesystem, read-only, live):
+  gleif/search/entity.legalName/NVIDIA/pages/page-001.json
+
+This is a free descent (naming the filter costs nothing) followed by one
+paid read (opening `pages`).
+"""
+import json
+
+PATH = "gleif/search/entity.legalName/NVIDIA/pages/page-001.json"
+
+with open(
+    "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/" + PATH
+) as f:
+    data = json.load(f)
+
+print("total hits:", data["meta"]["pagination"]["total"])
+for rec in data["data"]:
+    a = rec["attributes"]
+    print("-" * 60)
+    print("LEI:", a["lei"])
+    print("legalName:", a["entity"]["legalName"]["name"])
+    print("category:", a["entity"]["category"])
+    print("jurisdiction:", a["entity"]["jurisdiction"])
+    print("status:", a["entity"]["status"])
+    print("hqAddress:", a["entity"]["headquartersAddress"]["addressLines"],
+          a["entity"]["headquartersAddress"]["city"],
+          a["entity"]["headquartersAddress"]["region"])

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/02-edgar-search-nvidia.py
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/02-edgar-search-nvidia.py
@@ -1,0 +1,25 @@
+"""
+Query 2: search EDGAR full text index by entity name "NVIDIA" and read the
+first results page to recover the CIK behind the hits.
+
+Path walked:
+  edgar/search/entityName/NVIDIA/pages/page-001.json
+"""
+import json
+
+PATH = "edgar/search/entityName/NVIDIA/pages/page-001.json"
+
+with open(
+    "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/" + PATH
+) as f:
+    data = json.load(f)
+
+print("total hits (capped at 10000):", data["hits"]["total"]["value"])
+ciks_seen = {}
+for hit in data["hits"]["hits"]:
+    src = hit["_source"]
+    for cik, name in zip(src["ciks"], src["display_names"]):
+        ciks_seen.setdefault(cik, name)
+
+for cik, name in ciks_seen.items():
+    print(cik, "->", name)

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/03-edgar-submissions-nvda.py
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/queries/03-edgar-submissions-nvda.py
@@ -1,0 +1,24 @@
+"""
+Query 3: read the full submissions record for CIK 0001045810 (NVIDIA CORP,
+found via query 2) to get registrant-level facts: EIN, addresses, former
+names, state of incorporation, tickers, and confirm the `lei` field is null.
+
+Path walked:
+  edgar/by-cik/0001045810/submissions/submissions.json
+"""
+import json
+
+PATH = "edgar/by-cik/0001045810/submissions/submissions.json"
+
+with open(
+    "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/" + PATH
+) as f:
+    data = json.load(f)
+
+fields = [
+    "cik", "name", "tickers", "exchanges", "ein", "lei",
+    "stateOfIncorporation", "sic", "sicDescription", "category",
+    "fiscalYearEnd", "formerNames", "addresses",
+]
+for k in fields:
+    print(k, ":", data.get(k))

--- a/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/report.md
+++ b/examples/company_analysis/artifacts/1787632744-nvidia-cross-registry/report.md
@@ -1,0 +1,148 @@
+# NVIDIA — GLEIF vs. EDGAR
+
+## Summary
+
+NVIDIA's operating company is identified in GLEIF as **NVIDIA CORPORATION**, LEI
+`549300S4KLFTLO7GSQ80`, and in EDGAR as **NVIDIA CORP**, CIK `0001045810` / ticker
+`NVDA`. The two records agree on headquarters address (2788 San Tomas Expressway,
+Santa Clara, CA), state of incorporation (Delaware), and active/operating status.
+They diverge in what they cover — GLEIF carries a Delaware file number and LEI
+registration history, EDGAR carries EIN, SIC code, tickers, exchange and filing
+history — because the two registries record different things about the same
+company. The match is **high confidence**: no shared key exists (see Data limits),
+but name, jurisdiction and exact street address all line up on one candidate out
+of 19 GLEIF hits for "NVIDIA".
+
+## 1. The two records
+
+**GLEIF** (`gleif/search/entity.legalName/NVIDIA/pages/page-001.json`, `data[0]`):
+- LEI: `549300S4KLFTLO7GSQ80`
+- Legal name: `NVIDIA CORPORATION`
+- Legal form: `XTIQ`, category `GENERAL`, status `ACTIVE`
+- Jurisdiction: `US-DE`; registered as `2862596` with Delaware registrar `RA000602`
+- Legal address: c/o Corporation Service Company, 251 Little Falls Drive,
+  Wilmington, US-DE 19808
+- Headquarters address: 2788 San Tomas Expressway, Santa Clara, US-CA 95051
+- Entity creation date: 1998-02-24; last HQ-address change event: 2024-02-05
+- LEI registration: initial 2013-04-09, last update 2026-01-07, next renewal
+  2027-02-06, fully corroborated
+- BIC: `NVDAUS6SXXX`; associated S&P Global ID `32307`
+
+**EDGAR** (`edgar/by-cik/0001045810/submissions/submissions.json`):
+- CIK: `0001045810`
+- Name: `NVIDIA CORP` (former name `NVIDIA CORP/CA`, 1998-05-07 to 2002-06-04)
+- Ticker: `NVDA` on Nasdaq
+- EIN: `943177549`
+- State of incorporation: `DE`
+- SIC: `3674` — Semiconductors & Related Devices
+- Filer category: Large accelerated filer; fiscal year end 01/31
+- Mailing and business address (identical): 2788 San Tomas Expressway,
+  Santa Clara, CA 95051
+- `lei` field in this record: `null`
+
+## 2. How they were matched, and how sure
+
+There is no shared identifier — GLEIF exposes LEIs, EDGAR exposes CIKs, and
+EDGAR's own `lei` field for NVIDIA is empty (confirmed above), matching the
+catalog's warning that this bridge does not work in practice.
+
+The match was made by:
+1. Searching GLEIF for legal name "NVIDIA" — 19 records returned, most of them
+   funds/ETFs tracking NVIDIA (e.g. "Defiance Nvidia Ventures ETF",
+   "T-Rex 2X Long NVIDIA Daily Target ETF") or foreign subsidiaries
+   ("NVIDIA SINGAPORE PTE LTD", "NVIDIA GRAPHICS PRIVATE LIMITED").
+2. Selecting the one record categorized `GENERAL` (not `FUND`), jurisdiction
+   `US-DE`, legal name exactly "NVIDIA CORPORATION" — the parent entity, not a
+   subsidiary or a tracking fund.
+3. Searching EDGAR full text index for "NVIDIA" — top hit is CIK `0001045810`,
+   `NVIDIA CORP (NVDA)`.
+4. Cross-checking the two candidates on data outside the name: **both give the
+   identical headquarters street address** (2788 San Tomas Expressway, Santa
+   Clara, CA 95051) and **both give Delaware as the jurisdiction of
+   incorporation**.
+
+Given an exact address match plus an exact jurisdiction match, on top of the
+name match, this is a **high-confidence match** — as high as this task
+structure permits, since it is still ultimately a name-plus-attributes
+correlation rather than a shared key. It is reported as such, not as fact.
+
+Two entities were explicitly *not* picked despite matching on name:
+- `NVIDIA INTERNATIONAL, INC.` (LEI `549300EK80J3WR5TSA69`) — same Santa Clara
+  HQ address and same Delaware jurisdiction, but a distinct legal entity
+  (different LEI, different Delaware file number `6004882` vs `2862596`,
+  created 2021 vs 1998). This looks like a subsidiary of NVIDIA CORPORATION,
+  not the SEC registrant.
+- Several fund/ETF names containing "NVIDIA" (Defiance, Kurv, Tuttle, Ninepoint,
+  Harvest, CSOP, T-Rex, ASA, PurePlay) — these are investment products that
+  hold or track NVIDIA stock, evidenced by category `FUND` and fund-manager
+  addresses unrelated to Santa Clara. They are not NVIDIA itself.
+
+## 3. Where they agree
+
+| Fact | GLEIF | EDGAR |
+|---|---|---|
+| Headquarters street address | 2788 San Tomas Expressway, Santa Clara, CA 95051 | 2788 San Tomas Expressway, Santa Clara, CA 95051 |
+| State/jurisdiction of incorporation | US-DE (Delaware) | DE |
+| Entity is active/operating | status `ACTIVE` | filer status implies operating (Large accelerated filer, current filings) |
+| Legal name (core) | "NVIDIA CORPORATION" | "NVIDIA CORP" |
+
+Sources: `gleif/search/entity.legalName/NVIDIA/pages/page-001.json` (record with
+LEI `549300S4KLFTLO7GSQ80`); `edgar/by-cik/0001045810/submissions/submissions.json`.
+
+## 4. Where they disagree / do not overlap
+
+These are not contradictions — each registry carries fields the other does not:
+
+- **Legal-form spelling**: GLEIF's legal name is "NVIDIA CORPORATION"; EDGAR's
+  is "NVIDIA CORP" — a suffix difference typical of EDGAR's abbreviated
+  registrant names, not a discrepancy about the underlying entity.
+- **Registered address vs. mailing address**: GLEIF's *legal* address (used for
+  service of process) is c/o Corporation Service Company, 251 Little Falls
+  Drive, Wilmington, DE 19808 — a registered-agent address, different from its
+  own *headquarters* address field, which matches EDGAR's business/mailing
+  address. EDGAR does not distinguish a separate "legal" address at all.
+- **Identifiers each side carries that the other lacks**: GLEIF has no EIN, SIC
+  code, ticker, or exchange; EDGAR has no LEI (field is `null` for this CIK,
+  confirmed directly), no Delaware file number, no LEI-registration dates.
+- **Former name**: EDGAR records a former name, "NVIDIA CORP/CA" (1998–2002).
+  GLEIF's record shows no `otherNames` entries for the current record — this
+  is not evidence the name change didn't happen, only that GLEIF's snapshot
+  does not carry legal-name history the way EDGAR does.
+- **Creation/registration dates differ in what they measure**: GLEIF's
+  `creationDate` (1998-02-24) is entity formation; EDGAR carries no formation
+  date at all, only a former-name window starting 1998-05-07 — close but not
+  the same event, and not comparable without more care.
+
+## Data limits
+
+- No shared identifier bridges the two registries; the match above is a name
+  match corroborated by address and jurisdiction, per the catalog's warning
+  that "a search for NVIDIA returns a fund before it returns the manufacturer."
+  Confirmed directly: EDGAR's own `lei` field for CIK 0001045810 is `null`.
+- GLEIF's "NVIDIA" search returned 19 records; most were fund/ETF products
+  tracking NVIDIA stock or NVIDIA subsidiaries, not NVIDIA CORPORATION itself.
+  Only the one flagged `GENERAL`/`US-DE` with the matching HQ address was used.
+- `NVIDIA INTERNATIONAL, INC.` (LEI `549300EK80J3WR5TSA69`) shares the same HQ
+  address and Delaware jurisdiction as NVIDIA CORPORATION but is a separate LEI
+  record — presumed subsidiary, not confirmed against a parent/child
+  relationship record (GLEIF exposes `direct-parent`/`ultimate-parent`
+  relationship links for this LEI that were not queried in this run).
+- Neither registry contains financial statements, sanctions, litigation, or
+  news — as the top-level catalog states outright, that class of question has
+  no answer in this data.
+- EDGAR's full-text search (2,415 hits for "NVIDIA", capped display at one
+  page of ~24 shown here) surfaces filings that *mention* NVIDIA — insiders,
+  index funds, and counterparties like CoreWeave and Nebius filing about
+  NVIDIA — not just NVIDIA's own filings; only rows with CIK `0001045810` are
+  NVIDIA the registrant.
+
+## Next steps
+
+- Query `gleif/by-lei/549300S4KLFTLO7GSQ80/direct-parent` and
+  `.../ultimate-children` (or the `direct-children` relationship link already
+  present in the GLEIF record) to confirm `NVIDIA INTERNATIONAL, INC.` and the
+  Singapore/India subsidiaries as children of NVIDIA CORPORATION, rather than
+  inferring it from address overlap alone.
+- If a financial or ownership comparison is wanted, EDGAR's `facts`/`concept`
+  endpoints under `by-cik/0001045810/` carry XBRL financials that GLEIF does
+  not — a natural follow-up query, not run here since it wasn't asked for.

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/evidence.md
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/evidence.md
@@ -1,0 +1,148 @@
+# Evidence
+
+All paths below are relative to the mount root and omit the
+`/var/folders/.../ailoy-company-analysis` prefix, per instructions.
+
+## Identifying Alphabet Inc. in GLEIF
+
+- **Claim:** Alphabet Inc.'s LEI is `5493006MHB84DD0ZWV18`, jurisdiction US-DE,
+  registered as 5786925, HQ 1600 Amphitheatre Parkway, Mountain View, CA, status ACTIVE.
+  - `gleif/search/entity.legalName/Alphabet Inc/pages/page-001.json` — record with
+    `id: "5493006MHB84DD0ZWV18"`, `legalName.name: "ALPHABET INC."`,
+    `legalAddress.country: "US"`, `jurisdiction: "US-DE"`,
+    `headquartersAddress: {city: "Mountain View", region: "US-CA"}`.
+- **Claim:** the same search also returns four unrelated "Alphabet …" entities that do
+  not belong to this group: Alphabet Energy Inc (India, Bilaspur), Alphabet Minerals
+  Inc (India, Bilaspur), Alphabet Holding Company, Inc. (Delaware, registered as
+  4846758, status LAPSED — a different registration number from Alphabet Inc.'s
+  5786925), and Alphabet Millcreek Self Storage Inc. (Ontario, Canada).
+  - Same file, records with ids `984500443D78642F8280`, `335800TESL8Z1SFPDI66`,
+    `5493000J3OND4HN47659`, `549300HKFWRE70KP4M82`.
+
+## Alphabet Inc.'s own parent (or lack of one)
+
+- **Claim:** GLEIF records no direct parent for Alphabet Inc.; the reason given is
+  "no known person."
+  - `gleif/by-lei/5493006MHB84DD0ZWV18/direct-parent-reporting-exception/direct-parent-reporting-exception.json`
+    — `category: "DIRECT_ACCOUNTING_CONSOLIDATION_PARENT"`, `reason: "NO_KNOWN_PERSON"`.
+- **Claim:** same for the ultimate parent.
+  - `gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json`
+    — `category: "ULTIMATE_ACCOUNTING_CONSOLIDATION_PARENT"`, `reason: "NO_KNOWN_PERSON"`.
+- **Claim:** no entity in GLEIF's index is recorded as owning Alphabet Inc.
+  - `gleif/search/owns/5493006MHB84DD0ZWV18/pages/page-001.json` — `meta.pagination.total: 0`.
+
+## Alphabet Inc.'s disclosed subsidiaries (50 total)
+
+- **Claim:** Alphabet Inc. is recorded as the ultimate owner of 50 entities.
+  - `gleif/search/ownedBy/5493006MHB84DD0ZWV18/pages/page-001.json` — `meta.pagination.total: 50`,
+    all 50 records returned on a single page (perPage 200).
+  - Cross-checked against `gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-children/ultimate-children.json`
+    — `meta.pagination.total: 50` (page 1 shows 15 of them; all 15 are a subset of the
+    ownedBy list of 50, confirmed programmatically).
+- **Claim:** Alphabet Inc. has 33 *direct* children (a strict subset of the 50 above);
+  the rest sit one or two tiers further down, under Google LLC, Google International
+  LLC, Wiz Inc., or Google Cloud EMEA Limited.
+  - `gleif/by-lei/5493006MHB84DD0ZWV18/direct-children/direct-children.json` —
+    `meta.pagination.total: 33`.
+  - `gleif/by-lei/5493006MHB84DD0ZWV18/direct-child-relationships/direct-child-relationships.json`
+    — same total (33), giving the relationship type `IS_DIRECTLY_CONSOLIDATED_BY` for
+    each, e.g. Firebase, Inc. (`9845003D44CCA145CC76`) → Alphabet Inc., relationship
+    period starting 2014-10-17.
+
+### Entity-by-entity parent (all 50), read from each subsidiary's own record
+
+Format: subsidiary — direct parent as disclosed on the subsidiary's own GLEIF record
+(`gleif/by-lei/<LEI>/direct-parent/direct-parent.json`), or, where that file does not
+exist, the reporting exception plus the ultimate parent that is still on file.
+
+| Subsidiary (LEI) | Direct parent (source) |
+|---|---|
+| GOOGLE ARGENTINA S.R.L. (`98450066EDFC0Y6C2A54`) | ALPHABET INC. — `by-lei/98450066EDFC0Y6C2A54/direct-parent/direct-parent.json` |
+| Google Austria GmbH (`984500D8D6D8C77L5B32`) | ALPHABET INC. — `by-lei/984500D8D6D8C77L5B32/direct-parent/direct-parent.json` |
+| GOOGLE BELGIUM (`213800WO2QK7HUL8R680`) | ALPHABET INC. — `by-lei/213800WO2QK7HUL8R680/direct-parent/direct-parent.json` |
+| GOOGLE BRASIL INTERNET LTDA. (`984500B5170E75C99056`) | ALPHABET INC. — `by-lei/984500B5170E75C99056/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD CANADA CORPORATION (`984500074CCB812A5D80`) | ALPHABET INC. — `by-lei/984500074CCB812A5D80/direct-parent/direct-parent.json` |
+| Google Switzerland GmbH (`984500B1C1A7S4898E77`) | ALPHABET INC. — `by-lei/984500B1C1A7S4898E77/direct-parent/direct-parent.json` |
+| GOOGLE CHILE LIMITADA (`984500C04A37BB9B5215`) | ALPHABET INC. — `by-lei/984500C04A37BB9B5215/direct-parent/direct-parent.json` |
+| Google Germany GmbH (`529900H4SBHKV7XQXK22`) | ALPHABET INC. — `by-lei/529900H4SBHKV7XQXK22/direct-parent/direct-parent.json` |
+| GLUI Engineering Oy (`74370096HBTUWJRFIT29`) | withheld, reason `NO_LEI`; ultimate parent on file = ALPHABET INC. — `by-lei/74370096HBTUWJRFIT29/direct-parent-reporting-exception/…json`, `.../ultimate-parent/ultimate-parent.json` |
+| Tuike Finland Oy (`743700HGB1CRPBRA1K29`) | ALPHABET INC. — `by-lei/743700HGB1CRPBRA1K29/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD FRANCE (`9845003T366A4EB2EE58`) | ALPHABET INC. — `by-lei/9845003T366A4EB2EE58/direct-parent/direct-parent.json` |
+| GOOGLE FRANCE (`9845004B3AADDD5FB669`) | ALPHABET INC. — `by-lei/9845004B3AADDD5FB669/direct-parent/direct-parent.json` |
+| GOOGLE PAYMENT LIMITED (`6488U5HN5HSK59195V82`) | ALPHABET INC. — `by-lei/6488U5HN5HSK59195V82/direct-parent/direct-parent.json` |
+| GOOGLE UK LIMITED (`64886BIOSLNV78184624`) | ALPHABET INC. — `by-lei/64886BIOSLNV78184624/direct-parent/direct-parent.json` |
+| WIZ CLOUD LIMITED (`6488R1WLKN077T974P96`) | WIZ, INC. — `by-lei/6488R1WLKN077T974P96/direct-parent/direct-parent.json` |
+| GOOGLE PAYMENT IRELAND LIMITED (`9845003AA4F14A013C44`) | ALPHABET INC. — `by-lei/9845003AA4F14A013C44/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD EMEA LIMITED (`98450052CF14CFEB6435`) | ALPHABET INC. — `by-lei/98450052CF14CFEB6435/direct-parent/direct-parent.json` |
+| GOOGLE EUROPE, MIDDLE EAST AND AFRICA UNLIMITED COMPANY (`549300YY0W0QP4SZAG19`) | ALPHABET INC. — `by-lei/549300YY0W0QP4SZAG19/direct-parent/direct-parent.json` |
+| GOOGLE IRELAND HOLDINGS UNLIMITED COMPANY (`1FN51LDHILXJ06W1QN20`) | ALPHABET INC. — `by-lei/1FN51LDHILXJ06W1QN20/direct-parent/direct-parent.json` |
+| GOOGLE IRELAND LIMITED (`YYPPRNO5HB304LHFVG31`) | GOOGLE INTERNATIONAL LLC — `by-lei/YYPPRNO5HB304LHFVG31/direct-parent/direct-parent.json` |
+| WAYMO IT SERVICES INDIA PRIVATE LIMITED (`335800LW63MGNBQTB908`) | withheld, reason `NO_LEI`; ultimate parent = ALPHABET INC. — `by-lei/335800LW63MGNBQTB908/direct-parent-reporting-exception/…json`, `.../ultimate-parent/ultimate-parent.json` |
+| GOOGLE IT SERVICES INDIA PRIVATE LIMITED (`335800VPK652AEFF1O79`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — same file pattern under this LEI |
+| RAIDEN INFOTECH INDIA PRIVATE LIMITED (`335800FMIGZ24EJ2XW80`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — same file pattern |
+| SZS TECH PRIVATE LIMITED (`335800VQ73CQOLRRSK16`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — same file pattern |
+| MANDIANT CYBERSECURITY PRIVATE LIMITED (`335800APEHUAALHEZA12`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — same file pattern |
+| GOOGLE PAYMENT INDIA PRIVATE LIMITED (`335800SCE2XZHDWXCG42`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — same file pattern |
+| GOOGLE CLOUD INDIA PRIVATE LIMITED (`335800WBAET9Q971AT75`) | ALPHABET INC. — `by-lei/335800WBAET9Q971AT75/direct-parent/direct-parent.json` |
+| GOOGLE INDIA DIGITAL SERVICES PRIVATE LIMITED (`3358004GEBDX73EU6859`) | ALPHABET INC. — `by-lei/3358004GEBDX73EU6859/direct-parent/direct-parent.json` |
+| GOOGLE CAPITAL ADVISORS INDIA PRIVATE LIMITED (`335800DFHCGEFFZXRA34`) | ALPHABET INC. — `by-lei/335800DFHCGEFFZXRA34/direct-parent/direct-parent.json` |
+| GOOGLE INFORMATION SERVICES INDIA PRIVATE LIMITED (`335800FCLGQFJQJGHP87`) | ALPHABET INC. — `by-lei/335800FCLGQFJQJGHP87/direct-parent/direct-parent.json` |
+| GOOGLE CONNECT SERVICES INDIA PRIVATE LIMITED (`3358009UB5HS2WQF6Y18`) | ALPHABET INC. — `by-lei/3358009UB5HS2WQF6Y18/direct-parent/direct-parent.json` |
+| GOOGLE INDIA PRIVATE LIMITED (`335800P2W6AY6E8BEP06`) | GOOGLE INTERNATIONAL LLC — `by-lei/335800P2W6AY6E8BEP06/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD ITALY S.R.L. (`529900H6FVQK3TP02Z71`) | ALPHABET INC. — `by-lei/529900H6FVQK3TP02Z71/direct-parent/direct-parent.json` |
+| Google Payment Lithuania, UAB (`6488JJ7LW4MS85G57298`) | ALPHABET INC. — `by-lei/6488JJ7LW4MS85G57298/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD MEXICO S DE RL DE CV (`984500F71C16CDC30C27`) | ALPHABET INC. — `by-lei/984500F71C16CDC30C27/direct-parent/direct-parent.json` |
+| Google Netherlands B.V. (`984500DO4RF63E8D6604`) | ALPHABET INC. — `by-lei/984500DO4RF63E8D6604/direct-parent/direct-parent.json` |
+| GOOGLE POLAND SP. Z O.O. (`984500E14WF63DAD2C91`) | GOOGLE INTERNATIONAL LLC — `by-lei/984500E14WF63DAD2C91/direct-parent/direct-parent.json` |
+| GOOGLE CLOUD POLAND SP. Z O.O. (`984500B8CC95C15F8Q65`) | GOOGLE CLOUD EMEA LIMITED — `by-lei/984500B8CC95C15F8Q65/direct-parent/direct-parent.json`; also confirmed from the parent side: `by-lei/98450052CF14CFEB6435/direct-children/direct-children.json` lists this as its only direct child |
+| GOOGLE HOLDINGS PTE. LTD. (`549300AYV236IWGM7312`) | ALPHABET INC. — `by-lei/549300AYV236IWGM7312/direct-parent/direct-parent.json` |
+| GOOGLE ASIA PACIFIC PTE. LTD. (`RXU43ANVI3MGLXA9UI89`) | ALPHABET INC. — `by-lei/RXU43ANVI3MGLXA9UI89/direct-parent/direct-parent.json` |
+| ALPHABET CAPITAL US LLC (`549300KG6S007HTRLN18`) | withheld, reason `NON_PUBLIC`; ultimate parent = ALPHABET INC. — `by-lei/549300KG6S007HTRLN18/direct-parent-reporting-exception/…json`, `.../ultimate-parent/ultimate-parent.json` |
+| CHARLESTON ROAD REGISTRY INC. (`984500639BT036CND679`) | GOOGLE LLC — `by-lei/984500639BT036CND679/direct-parent/direct-parent.json` |
+| GOC INTERNATIONAL LLC (`984500DI9BZD41OF4781`) | ALPHABET INC. — `by-lei/984500DI9BZD41OF4781/direct-parent/direct-parent.json` (also in Alphabet's own `direct-child-relationships.json`, relationship period starting 2018-10-25) |
+| Design, LLC (`9845000BD467666E3930`) | ALPHABET INC. — `by-lei/9845000BD467666E3930/direct-parent/direct-parent.json` (also in Alphabet's own `direct-child-relationships.json`, relationship period starting 2004-11-30, registration status LAPSED) |
+| FIREBASE, INC. (`9845003D44CCA145CC76`) | ALPHABET INC. — `by-lei/9845003D44CCA145CC76/direct-parent/direct-parent.json` |
+| WIZ, INC. (`6488C2T08TXT755U3P86`) | GOOGLE LLC — `by-lei/6488C2T08TXT755U3P86/direct-parent/direct-parent.json` |
+| GOOGLE ENERGY LLC (`549300XRQBENEKTBS153`) | GOOGLE LLC — `by-lei/549300XRQBENEKTBS153/direct-parent/direct-parent.json` |
+| GOOGLE INTERNATIONAL LLC (`549300Y7W34DK0WBPY51`) | GOOGLE LLC — `by-lei/549300Y7W34DK0WBPY51/direct-parent/direct-parent.json` |
+| ALPHABET CAPITAL US II LLC (`549300SW82SFEORONS31`) | ALPHABET INC. — `by-lei/549300SW82SFEORONS31/direct-parent/direct-parent.json` (also in Alphabet's own `direct-child-relationships.json`, relationship period starting 2005-12-20) |
+| GOOGLE LLC (`7ZW8QJWVPR4P1J1KQY45`) | ALPHABET INC. — `by-lei/7ZW8QJWVPR4P1J1KQY45/direct-parent/direct-parent.json`, relationship period starting 2002-10-22 per `by-lei/7ZW8QJWVPR4P1J1KQY45/direct-parent-relationship/direct-parent-relationship.json` |
+
+## Confirming the tree bottoms out (no fifth tier)
+
+- **Claim:** none of the 50 subsidiaries has any direct-children beyond the four
+  already accounted for (Google LLC, Google International LLC, Google Cloud EMEA
+  Limited, Wiz, Inc.).
+  - Read `direct-children/direct-children.json` for all 50 LEIs (path pattern
+    `gleif/by-lei/<LEI>/direct-children/direct-children.json`); only these four LEIs
+    have that file present with non-empty `data`:
+    - `gleif/by-lei/7ZW8QJWVPR4P1J1KQY45/direct-children/direct-children.json` (GOOGLE
+      LLC) — 4 children: Charleston Road Registry Inc., Wiz Inc., Google Energy LLC,
+      Google International LLC.
+    - `gleif/by-lei/549300Y7W34DK0WBPY51/direct-children/direct-children.json` (GOOGLE
+      INTERNATIONAL LLC) — 3 children: Google Poland, Google India Private Limited,
+      Google Ireland Limited.
+    - `gleif/by-lei/98450052CF14CFEB6435/direct-children/direct-children.json` (GOOGLE
+      CLOUD EMEA LIMITED) — 1 child: Google Cloud Poland Sp. z o.o.
+    - `gleif/by-lei/6488C2T08TXT755U3P86/direct-children/direct-children.json` (WIZ,
+      INC.) — 1 child: Wiz Cloud Limited.
+  - All other 46 LEIs: no `direct-children` file exists at that path (verified with a
+    directory listing under each `gleif/by-lei/<LEI>/`), meaning GLEIF records zero
+    further descendants for them.
+
+## EDGAR side
+
+- **Claim:** Alphabet Inc.'s SEC CIK is `0001652044`; this matches the GLEIF record on
+  name and address (Mountain View, CA; EIN 61-1767919, Delaware incorporation).
+  - `edgar/search/entityName/Alphabet Inc/pages/page-001.json` — hit with
+    `display_names: ["Alphabet Inc.  (GOOG, GOOGL, GOOGM, GOOGN)  (CIK 0001652044)"]`.
+  - `edgar/by-cik/0001652044/submissions/submissions.json` — `name: "Alphabet Inc."`,
+    `stateOfIncorporation: "DE"`, `ein: "611767919"`, mailing/business address
+    "1600 AMPHITHEATRE PARKWAY, MOUNTAIN VIEW, CA", `lei: null` (as the cross-registry
+    catalog states is typical — EDGAR does not carry a usable LEI cross-reference).
+- **Claim:** EDGAR's full-text search on "Alphabet Inc" surfaces routine issuer
+  filings and insider Form 3/4/5s (e.g. Sergey Brin, John L. Hennessy, Frances Arnold)
+  but no structured subsidiary/ownership graph was retrieved from this registry in
+  this run.
+  - `edgar/search/entityName/Alphabet Inc/pages/page-001.json` — `hits.total.value: 2760`;
+    sample rows include forms `4`, `8-K`, `13F-HR`, `424B2`, `424B5`, `FWP`, `144`.

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/findings.json
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/findings.json
@@ -1,0 +1,91 @@
+{
+  "run_id": "1787633069-alphabet-ownership-tree",
+  "task": "Starting from Alphabet, follow the disclosed ownership relationships as far as they go. Report the shape of the group and where the disclosure stops.",
+  "entities": [
+    {"name": "ALPHABET INC.", "lei": "5493006MHB84DD0ZWV18", "cik": "0001652044", "jurisdiction": "US-DE", "role": "ultimate parent (root of the disclosed tree)"},
+    {"name": "GOOGLE LLC", "lei": "7ZW8QJWVPR4P1J1KQY45", "jurisdiction": "US-DE", "role": "direct child of Alphabet Inc."},
+    {"name": "GOOGLE INTERNATIONAL LLC", "lei": "549300Y7W34DK0WBPY51", "jurisdiction": "US-DE", "role": "direct child of Google LLC"},
+    {"name": "WIZ, INC.", "lei": "6488C2T08TXT755U3P86", "jurisdiction": "US-DE", "role": "direct child of Google LLC"},
+    {"name": "GOOGLE CLOUD EMEA LIMITED", "lei": "98450052CF14CFEB6435", "jurisdiction": "IE", "role": "direct child of Alphabet Inc."},
+    {"name": "CHARLESTON ROAD REGISTRY INC.", "lei": "984500639BT036CND679", "jurisdiction": "US-DE", "role": "direct child of Google LLC"},
+    {"name": "GOOGLE ENERGY LLC", "lei": "549300XRQBENEKTBS153", "jurisdiction": "US-DE", "role": "direct child of Google LLC"},
+    {"name": "GOOGLE IRELAND LIMITED", "lei": "YYPPRNO5HB304LHFVG31", "jurisdiction": "IE", "role": "direct child of Google International LLC"},
+    {"name": "GOOGLE INDIA PRIVATE LIMITED", "lei": "335800P2W6AY6E8BEP06", "jurisdiction": "IN", "role": "direct child of Google International LLC"},
+    {"name": "GOOGLE POLAND SP. Z O.O.", "lei": "984500E14WF63DAD2C91", "jurisdiction": "PL", "role": "direct child of Google International LLC"},
+    {"name": "GOOGLE CLOUD POLAND SP. Z O.O.", "lei": "984500B8CC95C15F8Q65", "jurisdiction": "PL", "role": "direct child of Google Cloud EMEA Limited"},
+    {"name": "WIZ CLOUD LIMITED", "lei": "6488R1WLKN077T974P96", "jurisdiction": "GB", "role": "direct child of Wiz, Inc."}
+  ],
+  "findings": [
+    {
+      "severity": "info",
+      "statement": "Alphabet Inc. (LEI 5493006MHB84DD0ZWV18) has no parent disclosed in GLEIF; both direct- and ultimate-parent fields carry a reporting exception with reason 'NO_KNOWN_PERSON', and a search for entities that own it (search/owns) returns zero results.",
+      "evidence": [
+        "gleif/by-lei/5493006MHB84DD0ZWV18/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json",
+        "gleif/search/owns/5493006MHB84DD0ZWV18/pages/page-001.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "GLEIF discloses exactly 50 entities consolidated under Alphabet Inc. (its 'ownedBy'/ultimate-children set), arranged across up to four tiers below Alphabet: Alphabet -> Google LLC -> {Google International LLC, Wiz Inc.} -> their own subsidiaries (e.g. Google Ireland Limited, Google India Private Limited, Google Poland, Wiz Cloud Limited); and Alphabet -> Google Cloud EMEA Limited -> Google Cloud Poland.",
+      "evidence": [
+        "gleif/search/ownedBy/5493006MHB84DD0ZWV18/pages/page-001.json",
+        "gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-children/ultimate-children.json",
+        "gleif/by-lei/5493006MHB84DD0ZWV18/direct-children/direct-children.json",
+        "gleif/by-lei/7ZW8QJWVPR4P1J1KQY45/direct-children/direct-children.json",
+        "gleif/by-lei/549300Y7W34DK0WBPY51/direct-children/direct-children.json",
+        "gleif/by-lei/98450052CF14CFEB6435/direct-children/direct-children.json",
+        "gleif/by-lei/6488C2T08TXT755U3P86/direct-children/direct-children.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "info",
+      "statement": "No entity among the 50 disclosed subsidiaries has any further direct-children of its own beyond Google LLC, Google International LLC, Google Cloud EMEA Limited, and Wiz, Inc. -- the disclosed tree has a maximum depth of four tiers below Alphabet and does not extend further in GLEIF's data.",
+      "evidence": [
+        "gleif/by-lei/<LEI>/direct-children/direct-children.json for each of the 50 LEIs listed in evidence.md (only the four LEIs above return non-empty data)"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "caveat",
+      "statement": "Nine of the 50 subsidiaries (GLUI Engineering Oy; Waymo IT Services India; Google IT Services India; Raiden Infotech India; SZS Tech India; Mandiant Cybersecurity India; Google Payment India; Alphabet Capital US LLC) have their direct-parent relationship withheld under a reporting exception (reason NON_PUBLIC or NO_LEI); only their ultimate-parent link to Alphabet Inc. is disclosed, so one middle link in the chain is not shown for these nine.",
+      "evidence": [
+        "gleif/by-lei/74370096HBTUWJRFIT29/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800LW63MGNBQTB908/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800VPK652AEFF1O79/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800FMIGZ24EJ2XW80/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800VQ73CQOLRRSK16/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800APEHUAALHEZA12/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/335800SCE2XZHDWXCG42/direct-parent-reporting-exception/direct-parent-reporting-exception.json",
+        "gleif/by-lei/549300KG6S007HTRLN18/direct-parent-reporting-exception/direct-parent-reporting-exception.json"
+      ],
+      "confidence": "high"
+    },
+    {
+      "severity": "caveat",
+      "statement": "A GLEIF name search for 'Alphabet Inc' also surfaces four unrelated entities (Alphabet Energy Inc, India; Alphabet Minerals Inc, India; Alphabet Holding Company, Inc., Delaware but a different registration number and LAPSED status; Alphabet Millcreek Self Storage Inc., Ontario) that share the word 'Alphabet' but do not appear in Alphabet Inc.'s ownedBy list and whose addresses/registration numbers do not corroborate a link -- treated as name collisions, not part of the group.",
+      "evidence": [
+        "gleif/search/entity.legalName/Alphabet Inc/pages/page-001.json"
+      ],
+      "confidence": "medium"
+    },
+    {
+      "severity": "caveat",
+      "statement": "Alphabet Inc.'s CIK in EDGAR (0001652044) was confirmed by name and address/EIN match against the GLEIF record (both give Mountain View, CA and Delaware incorporation), but EDGAR's submissions.json carries a null 'lei' field and no structured subsidiary list -- EDGAR did not contribute additional ownership-tree data in this run beyond confirming Alphabet is a top-level public filer.",
+      "evidence": [
+        "edgar/search/entityName/Alphabet Inc/pages/page-001.json",
+        "edgar/by-cik/0001652044/submissions/submissions.json"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "data_gaps": [
+    "GLEIF's ownership data reflects accounting-consolidation relationships (IS_DIRECTLY/ULTIMATELY_CONSOLIDATED_BY), not stated ownership percentages or voting control -- percentage of equity held is not available from the fields read here.",
+    "GLEIF only shows entities that hold an LEI and have filed a relationship record; Alphabet's full corporate family (e.g. as listed in a 10-K Exhibit 21) likely includes additional subsidiaries with no LEI, which would not appear in this 50-entity set.",
+    "Nine of the 50 subsidiaries have their direct-parent link withheld (reason NON_PUBLIC or NO_LEI); only the ultimate-parent (Alphabet Inc.) is confirmed for those nine, not the immediate parent in between.",
+    "EDGAR was checked (submissions.json, full-text search) but does not carry a machine-readable subsidiary/ownership graph for Alphabet in the paths available; a narrower search for Exhibit 21 filings was not performed in this run.",
+    "Neither registry covers ownership percentage, governance/control agreements, or non-US financial-statement detail, per the top-level CATALOG.md scope note."
+  ]
+}

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/01-alphabet-lei-lookup.py
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/01-alphabet-lei-lookup.py
@@ -1,0 +1,26 @@
+"""
+Find Alphabet Inc.'s LEI in GLEIF by legal name, and confirm the record
+against known facts (Delaware incorporation, Mountain View HQ).
+
+Path read (mount root down, prefix omitted):
+  gleif/search/entity.legalName/Alphabet Inc/pages/page-001.json
+"""
+import json
+
+PATH = "gleif/search/entity.legalName/Alphabet Inc/pages/page-001.json"
+FULL = "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/" + PATH
+
+with open(FULL) as f:
+    d = json.load(f)
+
+print("total hits:", d["meta"]["pagination"]["total"])
+for rec in d["data"]:
+    e = rec["attributes"]["entity"]
+    print(rec["id"], "|", e["legalName"]["name"], "|", e["legalAddress"]["country"], "|", e["jurisdiction"])
+
+# ALPHABET INC., LEI 5493006MHB84DD0ZWV18, jurisdiction US-DE, HQ Mountain View, CA
+# -- this is the public holding company (ticker GOOGL/GOOG). Other "Alphabet *"
+# hits (Alphabet Energy Inc, Alphabet Minerals Inc, Alphabet Holding Company Inc,
+# Alphabet Millcreek Self Storage Inc) are unrelated entities that merely share
+# the word "Alphabet" -- confirmed by country/address mismatch (India, Canada,
+# unrelated Delaware entity registered as 4846758 vs Alphabet Inc.'s 5786925).

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/02-alphabet-parent-and-children.py
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/02-alphabet-parent-and-children.py
@@ -1,0 +1,48 @@
+"""
+Alphabet Inc. (LEI 5493006MHB84DD0ZWV18): read its own relationship files to find
+whether GLEIF discloses a parent above it, and its direct/ultimate children.
+
+Paths read:
+  gleif/by-lei/5493006MHB84DD0ZWV18/direct-parent-reporting-exception/direct-parent-reporting-exception.json
+  gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json
+  gleif/by-lei/5493006MHB84DD0ZWV18/direct-children/direct-children.json
+  gleif/by-lei/5493006MHB84DD0ZWV18/ultimate-children/ultimate-children.json
+  gleif/search/ownedBy/5493006MHB84DD0ZWV18/pages/page-001.json
+  gleif/search/owns/5493006MHB84DD0ZWV18/pages/page-001.json
+"""
+import json
+
+ROOT = "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/"
+LEI = "5493006MHB84DD0ZWV18"
+
+def load(rel):
+    with open(ROOT + rel) as f:
+        return json.load(f)
+
+# 1. Does Alphabet report a parent?
+exc = load(f"gleif/by-lei/{LEI}/direct-parent-reporting-exception/direct-parent-reporting-exception.json")
+print("direct-parent exception:", exc["data"]["attributes"]["category"], "-", exc["data"]["attributes"]["reason"])
+
+exc2 = load(f"gleif/by-lei/{LEI}/ultimate-parent-reporting-exception/ultimate-parent-reporting-exception.json")
+print("ultimate-parent exception:", exc2["data"]["attributes"]["category"], "-", exc2["data"]["attributes"]["reason"])
+
+# 2. owns (who owns Alphabet) via the search index -- should be empty
+owns = load(f"gleif/search/owns/{LEI}/pages/page-001.json")
+print("search/owns total (entities that own Alphabet):", owns["meta"]["pagination"]["total"])
+
+# 3. ownedBy (who Alphabet owns) via the search index -- flat list, includes
+# every entity anywhere below Alphabet in the consolidation chain
+owned = load(f"gleif/search/ownedBy/{LEI}/pages/page-001.json")
+print("search/ownedBy total (all entities Alphabet ultimately consolidates):", owned["meta"]["pagination"]["total"])
+
+# 4. direct-children (first tier only)
+dc = load(f"gleif/by-lei/{LEI}/direct-children/direct-children.json")
+print("direct-children total (page 1 of", dc['meta']['pagination']['lastPage'], "pages):", dc["meta"]["pagination"]["total"])
+
+# 5. ultimate-children (GLEIF's own "ultimate-children" relation - should match ownedBy)
+uc = load(f"gleif/by-lei/{LEI}/ultimate-children/ultimate-children.json")
+print("ultimate-children total:", uc["meta"]["pagination"]["total"])
+
+owned_ids = {e["id"] for e in owned["data"]}
+uc_ids_p1 = {e["id"] for e in uc["data"]}
+print("ultimate-children page1 subset of ownedBy list:", uc_ids_p1.issubset(owned_ids))

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/03-walk-full-tree.py
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/queries/03-walk-full-tree.py
@@ -1,0 +1,98 @@
+"""
+For all 50 entities GLEIF lists under Alphabet's ownedBy/ultimate-children set,
+fetch each one's direct-parent (or, where that is withheld, its
+direct-parent-reporting-exception + ultimate-parent) to reconstruct which tier
+of the tree each sits in, and confirm none of them has its own further
+direct-children beyond what is already captured (i.e. the tree bottoms out).
+
+Paths read (one per entity, all under gleif/by-lei/<LEI>/...):
+  direct-parent/direct-parent.json                          (when disclosed)
+  direct-parent-reporting-exception/direct-parent-reporting-exception.json (when withheld)
+  ultimate-parent/ultimate-parent.json                       (to confirm root)
+  direct-children/direct-children.json                       (to check for a further tier)
+"""
+import json, os
+
+ROOT = "/var/folders/b1/n4bd3bq52gx_g1h4tfbr_s6m0000gn/T/ailoy-company-analysis/"
+BASE = ROOT + "gleif/by-lei/"
+
+owned_lei_names = {
+"98450066EDFC0Y6C2A54":"GOOGLE ARGENTINA S.R.L.",
+"984500D8D6D8C77L5B32":"Google Austria GmbH",
+"213800WO2QK7HUL8R680":"GOOGLE BELGIUM",
+"984500B5170E75C99056":"GOOGLE BRASIL INTERNET LTDA.",
+"984500074CCB812A5D80":"GOOGLE CLOUD CANADA CORPORATION",
+"984500B1C1A7S4898E77":"Google Switzerland GmbH",
+"984500C04A37BB9B5215":"GOOGLE CHILE LIMITADA",
+"529900H4SBHKV7XQXK22":"Google Germany GmbH",
+"74370096HBTUWJRFIT29":"GLUI Engineering Oy",
+"743700HGB1CRPBRA1K29":"Tuike Finland Oy",
+"9845003T366A4EB2EE58":"GOOGLE CLOUD FRANCE",
+"9845004B3AADDD5FB669":"GOOGLE FRANCE",
+"6488U5HN5HSK59195V82":"GOOGLE PAYMENT LIMITED",
+"64886BIOSLNV78184624":"GOOGLE UK LIMITED",
+"6488R1WLKN077T974P96":"WIZ CLOUD LIMITED",
+"9845003AA4F14A013C44":"GOOGLE PAYMENT IRELAND LIMITED",
+"98450052CF14CFEB6435":"GOOGLE CLOUD EMEA LIMITED",
+"549300YY0W0QP4SZAG19":"GOOGLE EUROPE, MIDDLE EAST AND AFRICA UNLIMITED COMPANY",
+"1FN51LDHILXJ06W1QN20":"GOOGLE IRELAND HOLDINGS UNLIMITED COMPANY",
+"YYPPRNO5HB304LHFVG31":"GOOGLE IRELAND LIMITED",
+"335800LW63MGNBQTB908":"WAYMO IT SERVICES INDIA PRIVATE LIMITED",
+"335800VPK652AEFF1O79":"GOOGLE IT SERVICES INDIA PRIVATE LIMITED",
+"335800FMIGZ24EJ2XW80":"RAIDEN INFOTECH INDIA PRIVATE LIMITED",
+"335800VQ73CQOLRRSK16":"SZS TECH PRIVATE LIMITED",
+"335800APEHUAALHEZA12":"MANDIANT CYBERSECURITY PRIVATE LIMITED",
+"335800SCE2XZHDWXCG42":"GOOGLE PAYMENT INDIA PRIVATE LIMITED",
+"335800WBAET9Q971AT75":"GOOGLE CLOUD INDIA PRIVATE LIMITED",
+"3358004GEBDX73EU6859":"GOOGLE INDIA DIGITAL SERVICES PRIVATE LIMITED",
+"335800DFHCGEFFZXRA34":"GOOGLE CAPITAL ADVISORS INDIA PRIVATE LIMITED",
+"335800FCLGQFJQJGHP87":"GOOGLE INFORMATION SERVICES INDIA PRIVATE LIMITED",
+"3358009UB5HS2WQF6Y18":"GOOGLE CONNECT SERVICES INDIA PRIVATE LIMITED",
+"335800P2W6AY6E8BEP06":"GOOGLE INDIA PRIVATE LIMITED",
+"529900H6FVQK3TP02Z71":"GOOGLE CLOUD ITALY S.R.L.",
+"6488JJ7LW4MS85G57298":"Google Payment Lithuania, UAB",
+"984500F71C16CDC30C27":"GOOGLE CLOUD MEXICO S DE RL DE CV",
+"984500DO4RF63E8D6604":"Google Netherlands B.V.",
+"984500E14WF63DAD2C91":"GOOGLE POLAND SP Z O O",
+"984500B8CC95C15F8Q65":"GOOGLE CLOUD POLAND SP Z O O",
+"549300AYV236IWGM7312":"GOOGLE HOLDINGS PTE. LTD.",
+"RXU43ANVI3MGLXA9UI89":"GOOGLE ASIA PACIFIC PTE. LTD.",
+"549300KG6S007HTRLN18":"ALPHABET CAPITAL US LLC",
+"984500639BT036CND679":"CHARLESTON ROAD REGISTRY INC.",
+"984500DI9BZD41OF4781":"GOC INTERNATIONAL LLC",
+"9845000BD467666E3930":"Design, LLC",
+"9845003D44CCA145CC76":"FIREBASE, INC.",
+"6488C2T08TXT755U3P86":"WIZ, INC.",
+"549300XRQBENEKTBS153":"GOOGLE ENERGY LLC",
+"549300Y7W34DK0WBPY51":"GOOGLE INTERNATIONAL LLC",
+"549300SW82SFEORONS31":"ALPHABET CAPITAL US II LLC",
+"7ZW8QJWVPR4P1J1KQY45":"GOOGLE LLC",
+}
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+for lei, name in owned_lei_names.items():
+    d = load(f"{BASE}{lei}/direct-parent/direct-parent.json")
+    if d:
+        parent = d["data"]["attributes"]["entity"]["legalName"]["name"]
+        print(f"{name:52s} <- direct parent: {parent}")
+    else:
+        exc = load(f"{BASE}{lei}/direct-parent-reporting-exception/direct-parent-reporting-exception.json")
+        reason = exc["data"]["attributes"]["reason"] if exc else "UNKNOWN"
+        up = load(f"{BASE}{lei}/ultimate-parent/ultimate-parent.json")
+        upname = up["data"]["attributes"]["entity"]["legalName"]["name"] if up else "?"
+        print(f"{name:52s} <- direct parent WITHHELD (reason={reason}); ultimate parent on file: {upname}")
+
+# Check whether any of the 50 has its own direct-children (a further tier)
+print("\n-- checking for a further tier below any of the 50 --")
+for lei, name in owned_lei_names.items():
+    dc = load(f"{BASE}{lei}/direct-children/direct-children.json")
+    if dc:
+        n = dc["meta"]["pagination"]["total"]
+        kids = ", ".join(e["attributes"]["entity"]["legalName"]["name"] for e in dc["data"])
+        print(f"{name:52s} has {n} direct child(ren): {kids}")

--- a/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/report.md
+++ b/examples/company_analysis/artifacts/1787633069-alphabet-ownership-tree/report.md
@@ -1,0 +1,157 @@
+# Alphabet Inc. — Disclosed Ownership Tree
+
+## Summary
+
+Alphabet Inc. (LEI `5493006MHB84DD0ZWV18`, Delaware, HQ Mountain View CA) sits at the
+top of the tree GLEIF discloses: no entity is recorded as owning it, and GLEIF
+explicitly marks both its direct- and ultimate-parent fields as exceptions with reason
+"no known person" — i.e., Alphabet has no controlling parent to disclose, consistent
+with it being a widely-held public holding company. Below it, GLEIF's Level 2
+("who owns whom") data lists exactly **50 entities** consolidated under Alphabet,
+arranged in up to four tiers (Alphabet → Google LLC → Google International LLC/
+Wiz, Inc. → their own subsidiaries), all bottoming out — no fifth tier appears
+anywhere in the disclosed data. Several of the 50 have their *direct* parent withheld
+(reason `NON_PUBLIC` or `NO_LEI`) even though their *ultimate* parent is still recorded
+as Alphabet Inc., so the tree is complete at the ultimate-owner level but has small
+gaps in the middle links. EDGAR, the other registry available, does not carry
+ownership/subsidiary structure for Alphabet in the fields checked here — it confirms
+Alphabet as CIK `0001652044`, a public filer with no parent of its own on that side
+either, but contributes no additional subsidiary graph.
+
+## The group as disclosed (GLEIF Level 2 data)
+
+Alphabet Inc. is the ultimate parent of 50 entities, per
+`gleif/search/ownedBy/5493006MHB84DD0ZWV18/pages/page-001.json` (total: 50) and cross-checked
+against `gleif/by-lei/.../ultimate-children/ultimate-children.json` (total: 50, first
+page's 15 records all appear in the ownedBy list). The chain has up to four tiers:
+
+```
+ALPHABET INC. (US-DE, LEI 5493006MHB84DD0ZWV18)
+│  [parent: none disclosed — reporting exception "NO_KNOWN_PERSON"]
+│
+├── GOOGLE LLC (US-DE)                          — direct child of Alphabet
+│     ├── CHARLESTON ROAD REGISTRY INC. (US)     — direct child of Google LLC
+│     ├── WIZ, INC. (US)                         — direct child of Google LLC
+│     │     └── WIZ CLOUD LIMITED (GB)           — direct child of Wiz, Inc.
+│     ├── GOOGLE ENERGY LLC (US)                  — direct child of Google LLC
+│     └── GOOGLE INTERNATIONAL LLC (US)           — direct child of Google LLC
+│           ├── GOOGLE POLAND SP. Z O.O. (PL)
+│           ├── GOOGLE INDIA PRIVATE LIMITED (IN)
+│           └── GOOGLE IRELAND LIMITED (IE)
+│
+├── GOOGLE CLOUD EMEA LIMITED (IE)               — direct child of Alphabet
+│     └── GOOGLE CLOUD POLAND SP. Z O.O. (PL)     — direct child of Google Cloud EMEA
+│
+└── 40 further entities recorded as direct children of Alphabet Inc. itself,
+    spanning Argentina, Austria, Belgium, Brazil, Canada, Switzerland, Chile,
+    Germany, Finland (2), France (2), UK (2, incl. Google Payment Limited),
+    Ireland (3 more: Google Payment Ireland, Google Europe/Middle East/Africa
+    Unlimited Co., Google Ireland Holdings Unlimited Co.), 10 "…India Private
+    Limited" entities, Italy, Lithuania, Mexico, Netherlands, Singapore (2),
+    and 3 US entities (Alphabet Capital US LLC, Alphabet Capital US II LLC,
+    GOC International LLC, Design LLC, Firebase Inc.)
+```
+
+Full entity-by-entity parent listing is in `evidence.md`.
+
+No entity among the 50 has any further direct-children beyond the four already shown
+(Google LLC, Google International LLC, Google Cloud EMEA Limited, Wiz, Inc.) —
+checked by reading `direct-children/direct-children.json` for all 50 LEIs; every other
+one returns none. The tree, as GLEIF discloses it, therefore has a maximum depth of
+four tiers below Alphabet and does not extend further.
+
+## Direction of each relationship
+
+GLEIF's `direct-parent` / `ultimate-parent` files on a subsidiary's own record point
+**upward** (child → parent: "this entity `IS_DIRECTLY_CONSOLIDATED_BY` Alphabet Inc.").
+The `search/ownedBy/<LEI>` and `search/owns/<LEI>` index, read from Alphabet's side,
+gives the same relationships from the parent's side: `ownedBy` returned Alphabet's 50
+children, and `owns` (which entity owns Alphabet) returned zero results — confirming
+the direction and confirming no parent is disclosed above Alphabet.
+(`gleif/CATALOG.md` warns the naming is counter-intuitive; both directions were
+cross-checked against each other and agree.)
+
+## Where the tree stops
+
+- **Above Alphabet:** nothing. `direct-parent-reporting-exception` and
+  `ultimate-parent-reporting-exception` for Alphabet both give
+  `category: DIRECT/ULTIMATE_ACCOUNTING_CONSOLIDATION_PARENT`,
+  `reason: NO_KNOWN_PERSON` — GLEIF's own statement that no natural or legal person is
+  known to control Alphabet, i.e., its shareholding is dispersed enough (or LEI
+  reporting rules judge it) that no consolidating parent is named.
+- **Below the 50 disclosed subsidiaries:** nothing further appears. Every one of the 50
+  was checked for its own `direct-children`; only four (Google LLC, Google
+  International LLC, Google Cloud EMEA Limited, Wiz, Inc.) have any, and those
+  children are already inside the 50 — i.e., the set is closed and the deepest chain is
+  four links (Alphabet → Google LLC → Google International LLC → Google Poland /
+  Google India / Google Ireland, or Alphabet → Google LLC → Wiz, Inc. → Wiz Cloud
+  Limited).
+- **Middle links sometimes withheld:** nine of the 50 (GLUI Engineering Oy, Waymo IT
+  Services India, Google IT Services India, Raiden Infotech India, SZS Tech India,
+  Mandiant Cybersecurity India, Google Payment India, Alphabet Capital US LLC) have
+  their *direct*-parent relationship withheld under a reporting exception
+  (`NO_LEI` — the immediate parent has no LEI of its own to name — or `NON_PUBLIC` —
+  the immediate parent chose not to disclose). In every one of these cases the
+  *ultimate*-parent field is still populated and still names Alphabet Inc., so the
+  end of the chain is known even where a link in the middle is not shown.
+- **EDGAR side:** Alphabet's own `submissions.json` carries no subsidiary list and an
+  empty `lei` field (as the cross-registry catalog warns is typical). EDGAR's
+  full-text search over Alphabet's filings surfaces insiders (Form 3/4/5 filers such
+  as Sergey Brin, John L. Hennessy) and routine issuer filings (8-K, 424B, 13F-HR) but
+  not a machine-readable ownership graph; EDGAR was not the source of the subsidiary
+  tree above.
+
+## What the shape does not tell you
+
+- **Ownership percentage / voting control.** GLEIF's relationship type here is
+  accounting consolidation (`IS_DIRECTLY_CONSOLIDATED_BY` /
+  `IS_ULTIMATELY_CONSOLIDATED_BY`), not a stated percentage shareholding. A 100%-owned
+  subsidiary and a majority-owned-but-consolidated one look identical in this data.
+- **Completeness of Alphabet's actual corporate family.** GLEIF only shows entities
+  that (a) hold an LEI and (b) have filed a relationship record with GLEIF. Alphabet's
+  SEC 10-K Exhibit 21 (list of subsidiaries) would likely show more entities than the
+  50 with LEIs found here, including ones with no LEI at all (e.g., many small or
+  dormant subsidiaries) — that exhibit was not read in this run (EDGAR full-text
+  search on entity name alone does not surface a specific exhibit without a further,
+  narrower query).
+- **Whether "Alphabet" name-collisions are related.** The GLEIF search for
+  "Alphabet Inc" also returned "ALPHABET ENERGY INC" (India), "ALPHABET MINERALS INC"
+  (India), "ALPHABET HOLDING COMPANY, INC." (Delaware, different registration number
+  4846758 vs. Alphabet Inc.'s 5786925, LAPSED status), and
+  "Alphabet Millcreek Self Storage Inc." (Canada) — none of these appear in Alphabet
+  Inc.'s ownedBy/ultimate-children list, and their addresses/registration numbers do
+  not match, so they are treated here as unrelated name collisions, not part of the
+  tree.
+- **Direction of dependency vs. legal risk/liability.** A consolidation relationship
+  says an entity's financials roll up into Alphabet's; it says nothing about
+  guarantees, intercompany debt, or litigation exposure between the entities.
+
+## Data limits
+
+- GLEIF's registry is name/LEI-indexed only; percentages of ownership and the legal
+  basis for "control" are not part of the fields read here.
+- Nine of the 50 disclosed subsidiaries have their immediate parent withheld
+  (`NON_PUBLIC` or `NO_LEI`); only the ultimate-parent link to Alphabet is visible for
+  those nine.
+- EDGAR was checked but does not carry a machine-readable subsidiary/ownership graph
+  for Alphabet in the paths available (`submissions.json`, full-text search); a
+  narrower EDGAR full-text search restricted to Exhibit 21 filings could surface
+  Alphabet's SEC-disclosed subsidiary list, which was not pulled in this run.
+- The four "Alphabet *" name matches found in GLEIF search (Alphabet Energy Inc,
+  Alphabet Minerals Inc, Alphabet Holding Company Inc., Alphabet Millcreek Self
+  Storage Inc.) are **possible matches — needs confirmation** only in the sense that a
+  bare name search surfaces them; on inspection (country, registration number,
+  address) none of them corroborate as part of Alphabet Inc.'s group, and none appear
+  in its ownedBy list, so they are excluded from the tree above.
+
+## Next steps
+
+- Pull Alphabet's most recent 10-K Exhibit 21 (list of subsidiaries) from EDGAR via a
+  narrower full-text search (`forms=10-K`, `q=Exhibit 21` or similar) to compare
+  against GLEIF's 50-entity list and see whether SEC disclosure names entities GLEIF's
+  LEI graph does not (e.g., subsidiaries without an LEI).
+- For the nine entities with a withheld direct parent, if the immediate parent is
+  later assigned an LEI, re-check `direct-parent` to fill in the missing middle link.
+- If ownership *percentages* are needed rather than consolidation relationships, this
+  question requires a different source (e.g., the 10-K itself or a proxy statement),
+  which neither registry mounted here provides in structured form.

--- a/examples/company_analysis/src/apifs.rs
+++ b/examples/company_analysis/src/apifs.rs
@@ -147,13 +147,31 @@ impl Fetcher {
 }
 
 /// Percent-decoding for a path segment, so a value containing `/` can be named.
+/// The byte two hex digits spell, or nothing if they are not both hex.
+///
+/// Not [`u8::from_str_radix`], which takes a sign: it reads `+1` as 1, so `%+1` would
+/// decode where it should stay as written.
+fn hex_byte(hi: u8, lo: u8) -> Option<u8> {
+    let digit = |b: u8| match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    };
+    Some(digit(hi)? * 16 + digit(lo)?)
+}
+
 pub fn percent_decode(s: &str) -> String {
     let b = s.as_bytes();
     let mut out = Vec::with_capacity(b.len());
     let mut i = 0;
     while i < b.len() {
+        // Read the two digits as bytes. Slicing the `&str` here would panic on
+        // `%` followed by a multi-byte character — `%가` cuts a char boundary — and this
+        // runs inside an `extern "C"` callback with nothing to catch it, so the panic
+        // aborts and the mount outlives the process that made it.
         if b[i] == b'%' && i + 2 < b.len() {
-            if let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+            if let Some(v) = hex_byte(b[i + 1], b[i + 2]) {
                 out.push(v);
                 i += 3;
                 continue;
@@ -204,5 +222,21 @@ mod tests {
         for s in ["A/B", "plain", "a b", "100%"] {
             assert_eq!(percent_decode(&urlencode(s)), s);
         }
+    }
+
+    /// A `%` that is not an escape must survive whatever follows it.
+    ///
+    /// Path segments are values a caller wrote — a legal name, a query — so a stray `%`
+    /// is ordinary input. Reading the two digits as anything but bytes panics when the
+    /// next character is multi-byte, and a panic here runs in an `extern "C"` callback:
+    /// it aborts, and the mount is still there afterwards.
+    #[test]
+    fn a_stray_percent_is_left_alone() {
+        for s in ["%가", "%a한", "%🙂", "50%가치", "%", "%4", "%zz", "100%!", "%+1", "%+f"] {
+            assert_eq!(percent_decode(s), s, "{s}");
+        }
+        // Real escapes still decode, including one before a multi-byte character.
+        assert_eq!(percent_decode("%41가"), "A가");
+        assert_eq!(percent_decode("%ea%b0%80"), "가");
     }
 }

--- a/examples/company_analysis/src/apifs.rs
+++ b/examples/company_analysis/src/apifs.rs
@@ -1,0 +1,208 @@
+//! The part every API-backed [`FileSystem`](cortex::fs::FileSystem) needs and none of
+//! them differ on: one client, one cache, one count of what was spent.
+//!
+//! What differs between sources is the path grammar and which URL a path means. That
+//! stays in each store. Fetching does not, and four copies of a retry loop would be
+//! four places for the backoff to drift.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    io,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+/// Waits before the 1st and 2nd retry of a rate-limited or 5xx request.
+const BACKOFF: [Duration; 2] = [Duration::from_millis(400), Duration::from_millis(1600)];
+
+/// A client, the bodies it has fetched, and the number of requests that took.
+pub struct Fetcher {
+    http: reqwest::Client,
+    /// key → bytes. Also the size source for `stat`.
+    ///
+    /// Kept for the life of the store, which is one run. Two reasons, and neither is
+    /// speed. A `stat` and the reads after it have to agree on a size, and a report
+    /// that cites a path has to still mean the same bytes when someone follows the
+    /// citation — an index that moved under a 40-turn investigation would leave its
+    /// own evidence disagreeing with itself. A run is minutes long, so one snapshot
+    /// per run is the freshness that matters. (A long-lived host would want a bound
+    /// here; these stores are built per run and dropped with it.)
+    bodies: Mutex<HashMap<String, Arc<Vec<u8>>>>,
+    calls: AtomicUsize,
+    /// Requests per kind of resource. The kind comes from the caller, not from parsing
+    /// the key: a key is only a string that looks like a path.
+    kinds: Mutex<BTreeMap<&'static str, usize>>,
+    /// Requests per cache key, which the kind alone cannot separate: one file fetched
+    /// many times counts the same as many files fetched once.
+    keys: Mutex<BTreeMap<String, usize>>,
+}
+
+impl Fetcher {
+    /// `user_agent` is not decoration everywhere: SEC rejects a request without one.
+    pub fn new(user_agent: &str) -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .user_agent(user_agent.to_string())
+                .build()
+                .expect("reqwest client"),
+            bodies: Mutex::new(HashMap::new()),
+            calls: AtomicUsize::new(0),
+            kinds: Mutex::new(BTreeMap::new()),
+            keys: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// How many requests this store has sent. A cache hit is not one.
+    pub fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+
+    /// What the requests were spent on, heaviest first.
+    pub fn breakdown(&self) -> Vec<(&'static str, usize)> {
+        let mut v: Vec<_> = self
+            .kinds
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, n)| (*k, *n))
+            .collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+        v
+    }
+
+    /// The `n` costliest paths, heaviest first.
+    pub fn hot_keys(&self, n: usize) -> Vec<(String, usize)> {
+        let mut v: Vec<_> = self
+            .keys
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, c)| (k.clone(), *c))
+            .collect();
+        v.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+        v.truncate(n);
+        v
+    }
+
+    pub fn distinct_keys(&self) -> usize {
+        self.keys.lock().unwrap().len()
+    }
+
+    pub fn cached(&self, key: &str) -> Option<Arc<Vec<u8>>> {
+        self.bodies.lock().unwrap().get(key).cloned()
+    }
+
+    /// Fetch `url` unless a copy is already held under `key`.
+    ///
+    /// The one place a body enters the cache, so `stat`'s size and the reads after it
+    /// come from the same fetch.
+    pub async fn get(&self, kind: &'static str, key: &str, url: &str) -> io::Result<Arc<Vec<u8>>> {
+        if let Some(hit) = self.cached(key) {
+            return Ok(hit);
+        }
+        *self.kinds.lock().unwrap().entry(kind).or_insert(0) += 1;
+        *self.keys.lock().unwrap().entry(key.to_string()).or_insert(0) += 1;
+        let bytes = Arc::new(self.fetch(url).await?);
+        self.bodies
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), bytes.clone());
+        Ok(bytes)
+    }
+
+    /// GET with retries, returning the body whatever the status.
+    ///
+    /// A non-2xx body is JSON too, and handing it back is how a caller learns *why*
+    /// rather than only that something failed. It is also what these sources do among
+    /// themselves: DART answers `{"status":"013"}` and EDINET a 401, both under HTTP
+    /// 200. Only a transport failure or a 5xx that outlived its retries is an error.
+    async fn fetch(&self, url: &str) -> io::Result<Vec<u8>> {
+        let mut last = String::new();
+        for attempt in 0..=BACKOFF.len() {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            match self.http.get(url).send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp
+                        .bytes()
+                        .await
+                        .map_err(|e| io::Error::other(e.to_string()))?
+                        .to_vec();
+                    if status.is_success() || status.is_client_error() {
+                        return Ok(body);
+                    }
+                    last = format!("HTTP {status}");
+                }
+                Err(e) => last = e.to_string(),
+            }
+            if let Some(wait) = BACKOFF.get(attempt) {
+                tokio::time::sleep(*wait).await;
+            }
+        }
+        Err(io::Error::other(format!("{url}: {last}")))
+    }
+}
+
+/// Percent-decoding for a path segment, so a value containing `/` can be named.
+pub fn percent_decode(s: &str) -> String {
+    let b = s.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            if let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(v);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Encoding for a query parameter. Deliberately conservative: a comma is left alone
+/// because these APIs read it as a list separator, and encoding it would change the
+/// question rather than transmit it.
+pub fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b',' => {
+                out.push(b as char)
+            }
+            b' ' => out.push_str("%20"),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+pub fn io_err<E: std::fmt::Display>(e: E) -> io::Error {
+    io::Error::other(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_comma_survives_encoding() {
+        // These APIs read `KR,JP` as OR. Percent-encoding it would ask a different
+        // question, so the one reserved character we leave alone is this one.
+        assert_eq!(urlencode("KR,JP"), "KR,JP");
+        assert_eq!(urlencode("Samsung Electronics"), "Samsung%20Electronics");
+        assert_eq!(urlencode("a/b"), "a%2Fb");
+    }
+
+    #[test]
+    fn decoding_is_the_inverse_for_a_path_segment() {
+        for s in ["A/B", "plain", "a b", "100%"] {
+            assert_eq!(percent_decode(&urlencode(s)), s);
+        }
+    }
+}

--- a/examples/company_analysis/src/edgar.rs
+++ b/examples/company_analysis/src/edgar.rs
@@ -67,6 +67,32 @@ const TAXONOMIES: &[&str] = &["us-gaap", "dei", "ifrs-full", "srt", "invest"];
 /// worse than a rejection because the count looks like an answer.
 const FILTERS: &[&str] = &["q", "forms", "ciks", "entityName", "startdt", "enddt"];
 
+/// What a query's `pages` says about itself.
+const PAGES_README: &str = r#"# pages — page 1 is listed, the rest are named
+
+    page-001.json   the first page of hits
+    page-002.json   the second, and so on — 1-based, three digits
+
+Only `page-001.json` appears in the listing. The others exist and are read the same way;
+they are left out because a directory read makes the kernel ask for every entry's size,
+and a page's size is not known until that page has been fetched. Listing them all would
+spend one request per page before anything had been read. A page past the last one is
+`No such file`, not an empty result.
+
+## A hit is a filing, not a company
+
+Each hit names the document and the filers behind it. `ciks` is the list to follow —
+zero-padded, so it drops straight into `/by-cik/<CIK>/`. `display_names` reads
+`NVIDIA CORP  (NVDA)  (CIK 0001045810)`, which is for a person; the spacing is not a
+contract.
+
+A search for a company therefore returns filings that *mention* it as well as its own —
+insiders, index funds, counterparties. Only rows carrying its CIK are the registrant.
+
+Paging is the expensive way to read a large result. The directory above this one still
+lists parameters to narrow by, and descending into them costs nothing.
+"#;
+
 /// What `/by-cik` says about itself.
 const BY_CIK_README: &str = r#"# /by-cik — addressed, not listed
 
@@ -170,6 +196,8 @@ enum Node {
     /// `/by-cik`
     ByCikRoot,
     ByCikReadme,
+    /// `/search/…/pages/_README.md` — generated per query, so it can say how large it is.
+    PagesReadme(Vec<(String, String)>),
     /// `/by-cik/<CIK>` — the CIK padded to the ten digits the SEC's URLs use.
     Entity(String),
     /// `/by-cik/<CIK>/submissions` — the wrapper, free to stat.
@@ -272,7 +300,10 @@ impl EdgarFs {
     /// Same grammar as the GLEIF store's, for the same reason: AND by descending, and
     /// a field and its value as separate segments so `/search` can list the fields.
     fn parse_query(rest: &[&str]) -> Option<Node> {
-        let (pairs, tail) = match rest {
+        let (pairs, tail, readme) = match rest {
+            // The note belongs to this query, not to `pages` in general: it reports the
+            // query's own size, which the listing has already paid for.
+            [init @ .., "pages", "_README.md"] => (init, Some(None), true),
             [init @ .., "pages", page] if page.starts_with("page-") && page.ends_with(".json") => {
                 let n: usize = page
                     .trim_start_matches("page-")
@@ -282,10 +313,10 @@ impl EdgarFs {
                 if n == 0 {
                     return None;
                 }
-                (init, Some(Some(n)))
+                (init, Some(Some(n)), false)
             }
-            [init @ .., "pages"] => (init, Some(None)),
-            _ => (rest, None),
+            [init @ .., "pages"] => (init, Some(None), false),
+            _ => (rest, None, false),
         };
 
         if pairs.is_empty() {
@@ -316,6 +347,7 @@ impl EdgarFs {
         }
         Some(match tail {
             Some(Some(n)) => Node::Page(out, n),
+            Some(None) if readme => Node::PagesReadme(out),
             Some(None) => Node::Pages(out),
             None => Node::Query(out),
         })
@@ -391,6 +423,19 @@ impl EdgarFs {
         }
     }
 
+    /// The note for one query's `pages`, with that query's own size in it.
+    ///
+    /// The count comes from page 1, which the listing has already fetched, so reading it
+    /// here is a cache hit. Without it the note can only say where the count is, and the
+    /// caller pulls a hundred hits into view to read one number.
+    async fn pages_note(&self, pairs: &[(String, String)]) -> io::Result<Arc<Vec<u8>>> {
+        let total = self.total_hits(pairs).await?;
+        let last = total.div_ceil(HITS_PER_PAGE).max(1);
+        Ok(Arc::new(
+            format!("This query has {last} page(s), {total} hit(s).\n\n{PAGES_README}").into_bytes(),
+        ))
+    }
+
     /// Whether a query has a page `n`, from the hit count the first page reports.
     ///
     /// Only page 1 is ever listed, so this answers about a page named directly.
@@ -411,6 +456,9 @@ impl FileSystem for EdgarFs {
             Ok(match &node {
                 Node::Catalog => Stat::new(DirentKind::File, CATALOG.len() as u64),
                 Node::ByCikReadme => Stat::new(DirentKind::File, BY_CIK_README.len() as u64),
+                Node::PagesReadme(pairs) => {
+                    Stat::new(DirentKind::File, self.pages_note(pairs).await?.len() as u64)
+                }
                 Node::Submissions(_)
                 | Node::Facts(_)
                 | Node::Concept(..)
@@ -484,10 +532,15 @@ impl FileSystem for EdgarFs {
                 // One request, and it names only the page it already holds.
                 Node::Pages(pairs) => {
                     let first = self.body(&Node::Page(pairs.clone(), 1)).await?;
-                    vec![Dirent::with_stat(
-                        "page-001.json",
-                        Stat::new(DirentKind::File, first.len() as u64),
-                    )]
+                    vec![
+                        Dirent::with_stat(
+                            "page-001.json",
+                            Stat::new(DirentKind::File, first.len() as u64),
+                        ),
+                        note("_README.md", &String::from_utf8_lossy(
+                            &self.pages_note(&pairs).await?,
+                        )),
+                    ]
                 }
                 _ => return Err(io::ErrorKind::NotADirectory.into()),
             })
@@ -510,7 +563,10 @@ impl FileSystem for EdgarFs {
                     return Err(io::ErrorKind::NotFound.into());
                 }
             }
-            let bytes = self.body(&node).await?;
+            let bytes = match &node {
+                Node::PagesReadme(pairs) => self.pages_note(pairs).await?,
+                _ => self.body(&node).await?,
+            };
             let start = (offset as usize).min(bytes.len());
             let n = buf.len().min(bytes.len() - start);
             buf[..n].copy_from_slice(&bytes[start..start + n]);
@@ -623,6 +679,22 @@ mod tests {
     /// size — so one ordinary recursive pass over the ticker listing spent 742
     /// requests. Hiding the file fixed the cost and lost the discovery; wrapping it in
     /// a directory keeps both.
+    /// The note under `pages` belongs to its query, so it can report that query's own
+    /// size. Parsing has to keep the pairs for that; dropping them is how it silently
+    /// becomes the same note everywhere.
+    #[test]
+    fn the_pages_note_keeps_its_query() {
+        let Some(Node::PagesReadme(pairs)) = parse("/search/entityName/NVDA/pages/_README.md") else {
+            panic!("the note did not parse as a query's own")
+        };
+        assert!(!pairs.is_empty(), "the note lost the query it belongs to");
+        // The same query with and without the note names one query, not two.
+        let Some(Node::Pages(same)) = parse("/search/entityName/NVDA/pages") else {
+            panic!("pages")
+        };
+        assert_eq!(pairs, same);
+    }
+
     #[tokio::test]
     async fn listing_a_registrant_names_everything_and_fetches_nothing() {
         let fs = EdgarFs::new("test");

--- a/examples/company_analysis/src/edgar.rs
+++ b/examples/company_analysis/src/edgar.rs
@@ -128,8 +128,9 @@ Every file here is one request to the SEC, answered live. Nothing is stored.
 
 ## Which way in
 
-A registrant is addressed by CIK. If you do not have one, `/search/entityName/` takes a
-company name or a ticker and reports the CIK behind each hit.
+A registrant is addressed, not found by listing: `ls /by-cik` names nothing but its own
+note. If you do not have a CIK, `/search/entityName/` takes a company name or a ticker
+and reports the CIK behind each hit.
 
 Identifiers are worth confirming rather than recalling: a wrong CIK answers with
 somebody else's filings rather than with an error.

--- a/examples/company_analysis/src/edgar.rs
+++ b/examples/company_analysis/src/edgar.rs
@@ -1,0 +1,937 @@
+//! SEC EDGAR projected onto a read-only [`FileSystem`].
+//!
+//! ```text
+//! /by-ticker/<TICKER>/                 the same registrant, reached by what it trades as
+//! /by-cik/<CIK>/submissions.json       one registrant: identifiers, addresses, filings
+//! /by-cik/<CIK>/concept/<tax>/<tag>.json   one XBRL concept's history
+//! /search/<field>/<value>/…/pages/      full-text search over filings
+//! ```
+//!
+//! # The opposite of GLEIF
+//!
+//! GLEIF answers a search with the whole record, so a search page is the end of the
+//! trip. EDGAR's list is a stub — cik, ticker, title — and everything else needs the
+//! registrant fetched by CIK.
+//!
+//! # Two ways in, and why both exist
+//!
+//! `by-ticker` is listable: eight thousand names, one per registrant, so `ls` and
+//! `glob` find a company without anyone knowing its number. `by-cik` is not listable
+//! and cannot be — most of what files with the SEC has no ticker at all. In one
+//! full-text search, eleven of the twenty-three CIKs that came back were absent from
+//! the ticker file. Dropping `by-cik` would leave those results with nowhere to go.
+//!
+//! So `by-ticker/<TICKER>/` serves what `by-cik/<CIK>/` serves, and the CIK form is
+//! the canonical one — it is what `search/ciks/` takes and what `submissions.json`
+//! reports about itself.
+//!
+//! # What a listing costs
+//!
+//! Measured, because the sizes differ by two orders of magnitude:
+//!
+//! ```text
+//! submissions.json   161 KB
+//! concept/<tag>       42 KB
+//! facts.json           4 MB      ← every concept at once
+//! ```
+//!
+//! A directory read is followed by a getattr per entry, and none of these can be
+//! measured without being fetched. So `facts.json` is readable but not listed: naming
+//! it would spend four megabytes on an `ls` that wanted the filing history.
+
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    path::{Component, Path},
+    sync::Arc,
+};
+
+use cortex::{
+    BoxFuture,
+    fs::{Dirent, DirentKind, FileSystem, Stat},
+};
+
+use crate::apifs::{Fetcher, io_err, percent_decode, urlencode};
+
+const DATA: &str = "https://data.sec.gov";
+const WWW: &str = "https://www.sec.gov";
+const EFTS: &str = "https://efts.sec.gov/LATEST/search-index";
+
+/// Full-text search returns 100 hits a page and pages by offset, not by number.
+const HITS_PER_PAGE: usize = 100;
+
+/// The XBRL taxonomies a concept can come from. Fixed, so listing them is free.
+const TAXONOMIES: &[&str] = &["us-gaap", "dei", "ifrs-full", "srt", "invest"];
+
+/// The full-text search parameters that were confirmed to narrow a result set.
+///
+/// `locationCode` is absent on purpose: it is accepted and changes nothing, which is
+/// worse than a rejection because the count looks like an answer.
+const FILTERS: &[&str] = &["q", "forms", "ciks", "entityName", "startdt", "enddt"];
+
+/// What `/by-cik` says about itself.
+const BY_CIK_README: &str = r#"# /by-cik — addressed, not listed
+
+There is no listing here. If you know the number, name it.
+
+Not because the set is unknowable — the SEC publishes every CIK it has — but because a
+listing of them would be a million zero-padded numbers. Knowing one already lets you
+address it; not knowing one, the numbers do not say which company is which.
+
+So there are two ways to get a number. `/by-ticker/` lists every registrant that trades
+under a symbol, so `ls` or a glob finds it. `/search/entityName/<name>/pages/` searches
+filings by company name and reports the CIKs behind each hit. Both start from a name,
+which is what you actually have.
+
+    /by-cik/<CIK>/submissions.json          identifiers, addresses, filing history
+    /by-cik/<CIK>/concept/<taxonomy>/<tag>.json   one concept over time
+    /by-cik/<CIK>/facts.json                every concept at once — see below
+
+## The CIK is not padded everywhere
+
+The SEC's own URLs use `CIK0001045810`, while its ticker file writes `1045810`. Either
+form works as a directory name here, and both mean the same registrant.
+
+## What a registrant's directory holds
+
+    submissions/    identity, addresses, filing history      (~160 KB)
+    facts/          every XBRL concept it reports            (~4 MB)
+    concept/<taxonomy>/<tag>.json   one concept over time    (~40 KB)
+
+Each of the first two is a directory holding one file of the same name. That is not
+decoration: a directory read asks for every entry's size, a document's size is not
+knowable until it has been fetched, and a document sitting here directly would
+therefore be fetched merely to be listed. Wrapping it means `ls` shows what exists
+while the request waits until someone descends.
+
+So `ls submissions` costs one request and `submissions/submissions.json` is then free.
+The flat `submissions.json` beside it also works, for anyone who guesses it.
+
+Start with `submissions`. `filings.recent` inside it is column-oriented: parallel
+arrays, one per field, rather than a list of filings — zip them by index before reading
+a row. Use `facts` when the question is which concepts exist at all, and `concept/`
+when you already know the tag.
+
+## What does not connect to the rest
+
+`submissions.json` has an `lei` field and it is almost always null — fifteen
+registrants sampled across the ticker list had it empty, every one. There is no
+reliable key from here to the GLEIF store; crossing over means matching on name, and a
+name match is a candidate rather than a fact.
+"#;
+
+/// What `/by-ticker` says about itself.
+const BY_TICKER_README: &str = r#"# /by-ticker — one name per registrant
+
+    ls .            every registrant that trades under a symbol, ~8,000 of them
+    NVDA/           the same files as /by-cik/0001045810/
+
+A directory here serves exactly what the matching `by-cik` one serves. The CIK form is
+the canonical address — it is what `search/ciks/` takes — and `submissions.json` names
+its own CIK, so nothing is lost by arriving this way.
+
+## The listing is shorter than the ticker file
+
+A company with several share classes files once and trades several ways: Alphabet is
+GOOGL, GOOG, GOOGM and GOOGN, and all four are one registrant with one CIK. Listing all
+of them would say there are four companies.
+
+So the listing holds one ticker per registrant — the first the SEC's own file names,
+which orders them by size, so it is GOOGL rather than GOOG and BRK-B rather than BRK-A.
+
+**The others still open.** `GOOG/` works, it is simply not in the listing. A ticker
+that resolves to a registrant is a directory whether or not `ls` mentions it.
+
+## What is not here
+
+Filers without a ticker — subsidiaries, funds, foreign private issuers — and they are
+the majority. Use `/by-cik/` for those, and `/search/` to find their numbers.
+"#;
+
+/// The tree's entry point, served by the tree itself.
+const CATALOG: &str = r#"# SEC EDGAR, as a filesystem
+
+Every file here is one request to the SEC, answered live. Nothing is stored.
+
+    /by-ticker/<TICKER>/          a listed company, by the symbol it trades under
+    /by-cik/<CIK>/                any filer, by its SEC number
+    /search/<field>/<value>/…/    full-text search over filing documents
+
+## Which way in
+
+If it trades, `by-ticker` is listable — `ls` it, or glob it, and the directory serves
+the same files as the `by-cik` one. If it does not trade, or you already hold a number,
+use `by-cik`. Most SEC filers have no ticker, so `by-cik` is the larger door even
+though it cannot be listed.
+
+Identifiers are worth confirming rather than recalling: a wrong CIK answers with
+somebody else's filings rather than with an error.
+
+## Search narrows the same way as elsewhere
+
+AND is a directory, and the value is its own segment:
+
+    /search/q/lithium/forms/10-K/startdt/2025-01-01/enddt/2025-06-30/pages/
+
+`ls /search` lists the parameters that were confirmed to narrow a result set. A
+parameter that is not listed is not one this store rejects — it is a path that does not
+exist. Descending is free; the first request happens when `pages` is opened.
+
+Results are capped at 10,000 by the search backend, so a `total` of exactly 10000 means
+"at least", not "exactly". Narrow further before believing it.
+
+## Watch for
+
+`filings.recent` in `submissions.json` is column-oriented: parallel arrays, one per
+field, not a list of filings. Zip them by index before reading a row.
+
+The two files disagree about what a CIK is, and their names point the wrong way. The
+ticker index writes `"cik_str": 1652044` — an integer, under a name that says string.
+`submissions.json` answers `"cik": "0001652044"` — a zero-padded string, under a name
+that says neither. Compare them as numbers, or pad both, but do not compare them raw.
+"#;
+
+pub struct EdgarFs {
+    fetch: Fetcher,
+    index: std::sync::Mutex<Option<Arc<TickerIndex>>>,
+}
+
+/// Every ticker, and the subset worth listing.
+struct TickerIndex {
+    by_ticker: HashMap<String, String>,
+    /// One per registrant, in the order the SEC's file gives them.
+    listed: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Node {
+    Root,
+    Catalog,
+    /// `/by-ticker`
+    ByTickerRoot,
+    ByTickerReadme,
+    /// `/by-ticker/<TICKER>/…` — resolved to a `by-cik` path once the index is in.
+    Ticker(String, Vec<String>),
+    /// `/by-cik`
+    ByCikRoot,
+    ByCikReadme,
+    /// `/by-cik/<CIK>` — the CIK padded to the ten digits the SEC's URLs use.
+    Entity(String),
+    /// `/by-cik/<CIK>/submissions` — the wrapper, free to stat.
+    SubmissionsDir(String),
+    /// `/by-cik/<CIK>/submissions/submissions.json`, or the flat path beside it.
+    Submissions(String),
+    /// `/by-cik/<CIK>/facts`
+    FactsDir(String),
+    /// `/by-cik/<CIK>/facts/facts.json`, or the flat path.
+    Facts(String),
+    /// `/by-cik/<CIK>/concept`
+    ConceptRoot(String),
+    /// `/by-cik/<CIK>/concept/<taxonomy>`
+    Taxonomy(String, String),
+    /// `/by-cik/<CIK>/concept/<taxonomy>/<tag>.json`
+    Concept(String, String, String),
+    /// `/search`
+    SearchRoot,
+    /// A query so far, plus a parameter awaiting a value.
+    Field(Vec<(String, String)>, String),
+    Query(Vec<(String, String)>),
+    Pages(Vec<(String, String)>),
+    Page(Vec<(String, String)>, usize),
+}
+
+impl EdgarFs {
+    /// SEC answers **403 with an HTML page** unless the `User-Agent` identifies the
+    /// caller with a contact address — a product name alone is refused. Measured, and
+    /// the reason this is a parameter rather than a constant: the right value is
+    /// whoever is running this.
+    pub fn new(user_agent: &str) -> Self {
+        Self {
+            fetch: Fetcher::new(user_agent),
+            index: std::sync::Mutex::new(None),
+        }
+    }
+
+    pub fn calls(&self) -> usize {
+        self.fetch.calls()
+    }
+
+    pub fn breakdown(&self) -> Vec<(&'static str, usize)> {
+        self.fetch.breakdown()
+    }
+
+    pub fn hot_keys(&self, n: usize) -> Vec<(String, usize)> {
+        self.fetch.hot_keys(n)
+    }
+
+    pub fn distinct_keys(&self) -> usize {
+        self.fetch.distinct_keys()
+    }
+
+    fn parse(path: &Path) -> Option<Node> {
+        let segs: Vec<&str> = path
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(s) => s.to_str(),
+                _ => None,
+            })
+            .collect();
+
+        match segs.as_slice() {
+            [] => Some(Node::Root),
+            ["CATALOG.md"] => Some(Node::Catalog),
+            ["by-ticker"] => Some(Node::ByTickerRoot),
+            ["by-ticker", "_README.md"] => Some(Node::ByTickerReadme),
+            ["by-ticker", t, rest @ ..] if is_ticker(t) => Some(Node::Ticker(
+                t.to_ascii_uppercase(),
+                rest.iter().map(|s| s.to_string()).collect(),
+            )),
+            ["by-cik"] => Some(Node::ByCikRoot),
+            ["by-cik", "_README.md"] => Some(Node::ByCikReadme),
+            ["by-cik", cik, rest @ ..] => {
+                let cik = normalize_cik(cik)?;
+                match rest {
+                    [] => Some(Node::Entity(cik)),
+                    ["submissions"] => Some(Node::SubmissionsDir(cik)),
+                    ["facts"] => Some(Node::FactsDir(cik)),
+                    // Inside the wrapper, and the flat form beside it. The flat one is
+                    // never listed and costs nothing to keep: someone who guesses the
+                    // obvious name should not come away empty.
+                    ["submissions", "submissions.json"] | ["submissions.json"] => {
+                        Some(Node::Submissions(cik))
+                    }
+                    ["facts", "facts.json"] | ["facts.json"] => Some(Node::Facts(cik)),
+                    ["concept"] => Some(Node::ConceptRoot(cik)),
+                    ["concept", tax] if TAXONOMIES.contains(tax) => {
+                        Some(Node::Taxonomy(cik, tax.to_string()))
+                    }
+                    ["concept", tax, tag] if TAXONOMIES.contains(tax) && tag.ends_with(".json") => {
+                        Some(Node::Concept(
+                            cik,
+                            tax.to_string(),
+                            tag.trim_end_matches(".json").to_string(),
+                        ))
+                    }
+                    _ => None,
+                }
+            }
+            ["search"] => Some(Node::SearchRoot),
+            ["search", rest @ ..] => Self::parse_query(rest),
+            _ => None,
+        }
+    }
+
+    /// Same grammar as the GLEIF store's, for the same reason: AND by descending, and
+    /// a field and its value as separate segments so `/search` can list the fields.
+    fn parse_query(rest: &[&str]) -> Option<Node> {
+        let (pairs, tail) = match rest {
+            [init @ .., "pages", page] if page.starts_with("page-") && page.ends_with(".json") => {
+                let n: usize = page
+                    .trim_start_matches("page-")
+                    .trim_end_matches(".json")
+                    .parse()
+                    .ok()?;
+                if n == 0 {
+                    return None;
+                }
+                (init, Some(Some(n)))
+            }
+            [init @ .., "pages"] => (init, Some(None)),
+            _ => (rest, None),
+        };
+
+        if pairs.is_empty() {
+            return None;
+        }
+        let (pairs, dangling) = if pairs.len() % 2 == 1 {
+            if tail.is_some() {
+                return None;
+            }
+            (&pairs[..pairs.len() - 1], Some(pairs[pairs.len() - 1]))
+        } else {
+            (pairs, None)
+        };
+
+        let mut out: Vec<(String, String)> = Vec::with_capacity(pairs.len() / 2 + 1);
+        for pair in pairs.chunks(2) {
+            let (f, v) = (pair[0], pair[1]);
+            if !FILTERS.contains(&f) || out.iter().any(|(prev, _)| prev == f) {
+                return None;
+            }
+            out.push((f.to_string(), percent_decode(v)));
+        }
+        if let Some(field) = dangling {
+            if !FILTERS.contains(&field) || out.iter().any(|(prev, _)| prev == field) {
+                return None;
+            }
+            return Some(Node::Field(out, field.to_string()));
+        }
+        Some(match tail {
+            Some(Some(n)) => Node::Page(out, n),
+            Some(None) => Node::Pages(out),
+            None => Node::Query(out),
+        })
+    }
+
+    /// `page` is 1-based here; the API offsets by hits, so the two differ by a factor.
+    fn query_url(pairs: &[(String, String)], page: usize) -> String {
+        let mut url = format!("{EFTS}?from={}", (page - 1) * HITS_PER_PAGE);
+        let mut dated = false;
+        for (f, v) in pairs {
+            if f == "startdt" || f == "enddt" {
+                dated = true;
+            }
+            url.push_str(&format!("&{}={}", urlencode(f), urlencode(v)));
+        }
+        // The date bounds are ignored unless the range is declared custom, which is
+        // the API's own coupling rather than a choice — a caller naming `startdt` in a
+        // path means the dates to apply.
+        if dated {
+            url.push_str("&dateRange=custom");
+        }
+        url
+    }
+
+    /// Ticker to CIK, plus the tickers worth listing.
+    ///
+    /// One fetch per run. The map holds every ticker so any of them opens; the list
+    /// holds one per registrant, because a registrant with four share classes is one
+    /// company and four directories would say otherwise.
+    ///
+    /// Which one is listed is the file's own answer, not ours: `company_tickers.json`
+    /// is ordered by size — NVDA, AAPL, GOOGL, MSFT — so the first row naming a CIK is
+    /// the class that file puts first. That gives GOOGL over GOOG and BRK-B over
+    /// BRK-A, which is also how they trade. Choosing differently would mean keeping a
+    /// list of exceptions, and an exception nobody can see is a judgement the data
+    /// does not support.
+    async fn index(&self) -> io::Result<Arc<TickerIndex>> {
+        if let Some(hit) = self.index.lock().unwrap().clone() {
+            return Ok(hit);
+        }
+        let bytes = self
+            .fetch
+            .get(
+                "ticker index",
+                "/companies.json",
+                &format!("{WWW}/files/company_tickers.json"),
+            )
+            .await?;
+        // A refusal arrives as an HTML page under a 4xx, and parsing it as JSON would
+        // report a syntax error at column 1 — true, and useless. Say what came back.
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).map_err(|_| {
+            let head: String = String::from_utf8_lossy(&bytes)
+                .chars()
+                .take(120)
+                .collect();
+            io::Error::other(format!(
+                "SEC answered with something that is not JSON. A User-Agent naming no contact \
+                 gets 403 and an HTML page. Set SEC_USER_AGENT to something like \
+                 'name contact@example.com'. First bytes of the reply: {head}"
+            ))
+        })?;
+        let rows = doc.as_object().ok_or_else(|| io::Error::other("not an object"))?;
+
+        // The keys are the file's row numbers as strings, and string order is not
+        // numeric order — "10" sorts before "2". Sorting numerically is what keeps
+        // "first row" meaning first.
+        let mut ordered: Vec<(u64, &serde_json::Value)> = rows
+            .iter()
+            .filter_map(|(k, v)| Some((k.parse().ok()?, v)))
+            .collect();
+        ordered.sort_by_key(|(n, _)| *n);
+
+        let mut by_ticker = HashMap::new();
+        let mut listed = Vec::new();
+        let mut seen_cik = HashSet::new();
+        for (_, row) in ordered {
+            let (Some(t), Some(cik)) = (
+                row.get("ticker").and_then(|v| v.as_str()),
+                row.get("cik_str").and_then(|v| v.as_u64()),
+            ) else {
+                continue;
+            };
+            let cik = format!("{cik:0>10}");
+            if seen_cik.insert(cik.clone()) {
+                listed.push(t.to_ascii_uppercase());
+            }
+            by_ticker.insert(t.to_ascii_uppercase(), cik);
+        }
+        let idx = Arc::new(TickerIndex { by_ticker, listed });
+        *self.index.lock().unwrap() = Some(idx.clone());
+        Ok(idx)
+    }
+
+    /// A `by-ticker` path as the `by-cik` path it names.
+    async fn resolve(&self, ticker: &str, rest: &[String]) -> io::Result<Node> {
+        let idx = self.index().await?;
+        let cik = idx
+            .by_ticker
+            .get(ticker)
+            .ok_or(io::ErrorKind::NotFound)?;
+        let mut path = format!("/by-cik/{cik}");
+        for seg in rest {
+            path.push('/');
+            path.push_str(seg);
+        }
+        Self::parse(Path::new(&path)).ok_or_else(|| io::ErrorKind::NotFound.into())
+    }
+
+    /// What a request bought. Taken from the node rather than parsed back out of the
+    /// key, which is only a string that looks like a path.
+    fn kind(node: &Node) -> &'static str {
+        match node {
+            Node::Submissions(_) => "submissions",
+            Node::Facts(_) => "facts",
+            Node::Concept(..) => "concept",
+            Node::Page(..) => "search page",
+            _ => "other",
+        }
+    }
+
+    fn key(node: &Node) -> String {
+        match node {
+            Node::Submissions(cik) => format!("/by-cik/{cik}/submissions.json"),
+            Node::Facts(cik) => format!("/by-cik/{cik}/facts.json"),
+            Node::Concept(cik, tax, tag) => format!("/by-cik/{cik}/concept/{tax}/{tag}.json"),
+            Node::Page(pairs, n) => {
+                let mut sorted = pairs.clone();
+                sorted.sort();
+                let joined: Vec<String> =
+                    sorted.iter().map(|(f, v)| format!("{f}={v}")).collect();
+                format!("/search?{}#page-{n}", joined.join("&"))
+            }
+            _ => String::new(),
+        }
+    }
+
+    fn url(node: &Node) -> Option<String> {
+        Some(match node {
+            Node::Submissions(cik) => format!("{DATA}/submissions/CIK{cik}.json"),
+            Node::Facts(cik) => format!("{DATA}/api/xbrl/companyfacts/CIK{cik}.json"),
+            Node::Concept(cik, tax, tag) => {
+                format!("{DATA}/api/xbrl/companyconcept/CIK{cik}/{tax}/{tag}.json")
+            }
+            Node::Page(pairs, n) => Self::query_url(pairs, *n),
+            _ => return None,
+        })
+    }
+
+    async fn body(&self, node: &Node) -> io::Result<Arc<Vec<u8>>> {
+        match node {
+            Node::Catalog => Ok(Arc::new(CATALOG.as_bytes().to_vec())),
+            Node::ByCikReadme => Ok(Arc::new(BY_CIK_README.as_bytes().to_vec())),
+            Node::ByTickerReadme => Ok(Arc::new(BY_TICKER_README.as_bytes().to_vec())),
+            _ => {
+                let url = Self::url(node).ok_or(io::ErrorKind::IsADirectory)?;
+                self.fetch.get(Self::kind(node), &Self::key(node), &url).await
+            }
+        }
+    }
+
+    /// Whether a query has a page `n`, from the hit count the first page reports.
+    ///
+    /// Only page 1 is ever listed, so this answers about a page named directly.
+    async fn total_hits(&self, pairs: &[(String, String)]) -> io::Result<usize> {
+        let bytes = self.body(&Node::Page(pairs.to_vec(), 1)).await?;
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).map_err(io_err)?;
+        Ok(doc
+            .pointer("/hits/total/value")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize)
+    }
+}
+
+impl FileSystem for EdgarFs {
+    fn stat<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Stat>> {
+        Box::pin(async move {
+            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            if let Node::Ticker(t, rest) = &node {
+                node = self.resolve(t, rest).await?;
+            }
+            Ok(match &node {
+                Node::Catalog => Stat::new(DirentKind::File, CATALOG.len() as u64),
+                Node::ByTickerReadme => {
+                    Stat::new(DirentKind::File, BY_TICKER_README.len() as u64)
+                }
+                Node::ByCikReadme => Stat::new(DirentKind::File, BY_CIK_README.len() as u64),
+                Node::Submissions(_)
+                | Node::Facts(_)
+                | Node::Concept(..)
+                | Node::Page(..) => {
+                    let bytes = self.body(&node).await?;
+                    Stat::new(DirentKind::File, bytes.len() as u64)
+                }
+                _ => Stat::new(DirentKind::Dir, 0),
+            })
+        })
+    }
+
+    fn list<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Vec<Dirent>>> {
+        Box::pin(async move {
+            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            if let Node::Ticker(t, rest) = &node {
+                node = self.resolve(t, rest).await?;
+            }
+            let dir = |n: &str| Dirent::new(n, DirentKind::Dir);
+            let note = |n: &str, s: &str| {
+                Dirent::with_stat(n, Stat::new(DirentKind::File, s.len() as u64))
+            };
+            Ok(match node {
+                Node::Root => vec![
+                    note("CATALOG.md", CATALOG),
+                    dir("by-ticker"),
+                    dir("by-cik"),
+                    dir("search"),
+                ],
+                // One entry per registrant, not per ticker. A directory here is free to
+                // stat, so the kernel's getattr storm over eight thousand names costs
+                // nothing beyond the one fetch that built the index.
+                Node::ByTickerRoot => {
+                    let idx = self.index().await?;
+                    let mut out = vec![note("_README.md", BY_TICKER_README)];
+                    out.extend(idx.listed.iter().map(|t| {
+                        Dirent::with_stat(t.clone(), Stat::new(DirentKind::Dir, 0))
+                    }));
+                    out
+                }
+                Node::ByCikRoot => vec![note("_README.md", BY_CIK_README)],
+                // Every fetchable resource is wrapped in a directory, so this listing
+                // names what is available without asking for any of it. A directory
+                // read is followed by a getattr per entry; a directory's size is zero
+                // and a document's is not knowable without fetching it, so a file here
+                // would be fetched just to be listed. It was, once: naming
+                // `submissions.json` cost 742 requests in a single run, because an
+                // ordinary recursive pass over the ticker listing turned into one fetch
+                // per registrant.
+                Node::Entity(_) => vec![dir("submissions"), dir("facts"), dir("concept")],
+                // The cost lands here instead, where a caller has asked for the thing.
+                Node::SubmissionsDir(cik) => {
+                    let b = self.body(&Node::Submissions(cik.clone())).await?;
+                    vec![Dirent::with_stat(
+                        "submissions.json",
+                        Stat::new(DirentKind::File, b.len() as u64),
+                    )]
+                }
+                Node::FactsDir(cik) => {
+                    let b = self.body(&Node::Facts(cik.clone())).await?;
+                    vec![Dirent::with_stat(
+                        "facts.json",
+                        Stat::new(DirentKind::File, b.len() as u64),
+                    )]
+                }
+                Node::ConceptRoot(_) => TAXONOMIES.iter().map(|t| dir(t)).collect(),
+                // Which tags a registrant reports is in `facts.json`, and enumerating
+                // them here would mean fetching it for a listing.
+                Node::Taxonomy(..) => vec![],
+                Node::SearchRoot => FILTERS.iter().map(|f| dir(*f)).collect(),
+                Node::Field(..) => vec![],
+                // Free: the parameters are known and the results are one level down.
+                Node::Query(pairs) => {
+                    let mut out = vec![dir("pages")];
+                    out.extend(
+                        FILTERS
+                            .iter()
+                            .filter(|f| !pairs.iter().any(|(used, _)| used == *f))
+                            .map(|f| dir(*f)),
+                    );
+                    out
+                }
+                // One request, and it names only the page it already holds.
+                Node::Pages(pairs) => {
+                    let first = self.body(&Node::Page(pairs.clone(), 1)).await?;
+                    vec![Dirent::with_stat(
+                        "page-001.json",
+                        Stat::new(DirentKind::File, first.len() as u64),
+                    )]
+                }
+                _ => return Err(io::ErrorKind::NotADirectory.into()),
+            })
+        })
+    }
+
+    fn read_at<'a>(
+        &'a self,
+        path: &'a Path,
+        buf: &'a mut [u8],
+        offset: u64,
+    ) -> BoxFuture<'a, io::Result<usize>> {
+        Box::pin(async move {
+            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            if let Node::Ticker(t, rest) = &node {
+                node = self.resolve(t, rest).await?;
+            }
+            // A page past the end is not an error upstream — it answers with an empty
+            // hit list — but as a file it should simply not be there.
+            if let Node::Page(pairs, n) = &node {
+                let total = self.total_hits(pairs).await?;
+                if (*n - 1) * HITS_PER_PAGE >= total.max(1) {
+                    return Err(io::ErrorKind::NotFound.into());
+                }
+            }
+            let bytes = self.body(&node).await?;
+            let start = (offset as usize).min(bytes.len());
+            let n = buf.len().min(bytes.len() - start);
+            buf[..n].copy_from_slice(&bytes[start..start + n]);
+            Ok(n)
+        })
+    }
+}
+
+/// `1045810` and `CIK0001045810` and `0001045810` all name one registrant.
+///
+/// `companies.json` gives the unpadded number and the SEC's own URLs want ten digits,
+/// so a caller who read the list and formed a path from what it said would otherwise
+/// get nothing. Padding here costs a line; the alternative is a working identifier
+/// that does not work.
+fn is_ticker(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 12
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.')
+}
+
+fn normalize_cik(s: &str) -> Option<String> {
+    let digits = s.strip_prefix("CIK").unwrap_or(s);
+    if digits.is_empty() || digits.len() > 10 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(format!("{:0>10}", digits))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(p: &str) -> Option<Node> {
+        EdgarFs::parse(Path::new(p))
+    }
+
+    #[test]
+    fn a_cik_is_the_same_registrant_however_it_was_written() {
+        // The form `companies.json` hands out, the form the SEC's URLs use, and the
+        // padded number on its own.
+        let want = Some(Node::Entity("0001045810".into()));
+        assert_eq!(parse("/by-cik/1045810"), want);
+        assert_eq!(parse("/by-cik/CIK0001045810"), want);
+        assert_eq!(parse("/by-cik/0001045810"), want);
+        assert_eq!(parse("/by-cik/12345678901"), None);
+        assert_eq!(parse("/by-cik/NVDA"), None);
+    }
+
+    #[test]
+    fn facts_is_reachable_but_not_advertised() {
+        // Four megabytes. Addressable, because it is the only concept index there is.
+        assert_eq!(
+            parse("/by-cik/1045810/facts.json"),
+            Some(Node::Facts("0001045810".into()))
+        );
+    }
+
+    #[test]
+    fn concepts_are_taxonomy_scoped() {
+        assert_eq!(
+            parse("/by-cik/1045810/concept/us-gaap/Revenues.json"),
+            Some(Node::Concept(
+                "0001045810".into(),
+                "us-gaap".into(),
+                "Revenues".into()
+            ))
+        );
+        // A taxonomy the API does not serve is a path that does not exist.
+        assert_eq!(parse("/by-cik/1045810/concept/made-up/Revenues.json"), None);
+    }
+
+    #[test]
+    fn date_bounds_bring_their_own_range_mode() {
+        let Some(Node::Query(pairs)) = parse("/search/q/lithium/startdt/2025-01-01") else {
+            panic!("query")
+        };
+        let url = EdgarFs::query_url(&pairs, 1);
+        assert!(url.contains("dateRange=custom"), "{url}");
+        // And a query without dates does not carry it.
+        let Some(Node::Query(p2)) = parse("/search/q/lithium") else {
+            panic!("query")
+        };
+        assert!(!EdgarFs::query_url(&p2, 1).contains("dateRange"));
+    }
+
+    #[test]
+    fn pages_offset_by_hits_not_by_number() {
+        let Some(Node::Page(pairs, n)) = parse("/search/q/lithium/pages/page-003.json") else {
+            panic!("page")
+        };
+        assert_eq!(n, 3);
+        assert!(EdgarFs::query_url(&pairs, n).contains("from=200"));
+    }
+
+    #[test]
+    fn an_unconfirmed_parameter_is_not_a_path() {
+        // Accepted upstream and changes nothing, which is worse than a rejection: the
+        // count comes back looking like an answer.
+        assert_eq!(parse("/search/locationCode/CA"), None);
+        assert_eq!(parse("/search/nosuchparam/x"), None);
+    }
+
+    #[test]
+    fn a_ticker_path_is_a_path_before_anything_is_resolved() {
+        // Resolution needs the index, so parsing only says "this is a ticker and this
+        // is the rest of it"; case is folded here because the index is upper-case.
+        assert_eq!(
+            parse("/by-ticker/nvda/submissions.json"),
+            Some(Node::Ticker("NVDA".into(), vec!["submissions.json".into()]))
+        );
+        assert_eq!(parse("/by-ticker/BRK-B"), Some(Node::Ticker("BRK-B".into(), vec![])));
+        assert_eq!(parse("/by-ticker/_README.md"), Some(Node::ByTickerReadme));
+        // Not a symbol.
+        assert_eq!(parse("/by-ticker/this-is-far-too-long"), None);
+        assert_eq!(parse("/by-ticker/NV DA"), None);
+    }
+
+    /// The listing holds one ticker per registrant and the rest still open. Pinned
+    /// because the alternative — dropping them — answers "no such company" for a
+    /// symbol that trades, which is worse than a listing that omits it.
+    #[test]
+    fn an_unlisted_share_class_is_still_a_path() {
+        for t in ["GOOG", "GOOGM", "BRK-A"] {
+            assert!(
+                matches!(parse(&format!("/by-ticker/{t}")), Some(Node::Ticker(..))),
+                "{t}"
+            );
+        }
+    }
+
+    /// `by-ticker` for real: mounted, listed through the kernel, and read.
+    ///
+    /// Ignored by default — it mounts a filesystem and talks to the SEC. Run with
+    /// `cargo test -p company_analysis --bins by_ticker_resolves -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "needs a FUSE mount and network"]
+    fn by_ticker_resolves() {
+        use cortex::fs::{FuseTMount, Mount};
+        use std::fs;
+
+        // SEC refuses a `User-Agent` without a contact, so this test needs a real one
+        // rather than a placeholder that would fail for a reason unrelated to the tree.
+        let Ok(ua) = std::env::var("SEC_USER_AGENT") else {
+            eprintln!("SEC_USER_AGENT unset — skipping");
+            return;
+        };
+        let fs_arc = Arc::new(EdgarFs::new(&ua));
+        let dir = std::env::temp_dir().join("ailoy-edgar-mount-test");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("mountpoint");
+        let mount = FuseTMount::try_new(fs_arc.clone(), &dir).expect("mount");
+        let root = mount.mountpoint().to_path_buf();
+
+        let names: Vec<String> = fs::read_dir(root.join("by-ticker"))
+            .expect("read_dir by-ticker")
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        // One fetch built the whole listing.
+        assert_eq!(fs_arc.calls(), 1, "the index took more than one request");
+        assert!(names.contains(&"_README.md".to_string()));
+        assert!(names.len() > 7000, "the listing holds only {} entries", names.len());
+
+        // One per registrant: the class the SEC's own file names first, not all four.
+        assert!(names.contains(&"GOOGL".to_string()));
+        assert!(!names.contains(&"GOOG".to_string()), "a second share class of one registrant is listed");
+
+        // And the ones left out are still directories.
+        let goog = fs::read_to_string(root.join("by-ticker/GOOG/submissions/submissions.json"))
+            .expect("a ticker left out of the listing does not open");
+        let doc: serde_json::Value = serde_json::from_str(&goog).expect("json");
+        // `cik` here is a zero-padded *string*, whatever the name of `cik_str`
+        // elsewhere suggests.
+        assert_eq!(doc["cik"].as_str(), Some("0001652044"), "GOOG did not resolve to Alphabet");
+        assert_eq!(doc["name"].as_str(), Some("Alphabet Inc."));
+
+        // The two ways in name the same registrant.
+        let via_ticker =
+            fs::read_to_string(root.join("by-ticker/NVDA/submissions/submissions.json")).expect("NVDA");
+        let via_cik = fs::read_to_string(root.join("by-cik/1045810/submissions/submissions.json"))
+            .expect("by-cik");
+        assert_eq!(via_ticker, via_cik, "the two addresses serve different bytes");
+
+        println!(
+            "listed={} calls={} (index + GOOG + NVDA, by-cik was cached)",
+            names.len() - 1,
+            fs_arc.calls()
+        );
+
+        drop(mount);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Listing a registrant must not fetch anything, and must still say what is there.
+    ///
+    /// Both halves matter. It fetched once: `submissions.json` sat in this listing, its
+    /// size is only knowable by fetching, and a directory read asks for every entry's
+    /// size — so one ordinary recursive pass over the ticker listing spent 742
+    /// requests. Hiding the file fixed the cost and lost the discovery; wrapping it in
+    /// a directory keeps both.
+    #[tokio::test]
+    async fn listing_a_registrant_names_everything_and_fetches_nothing() {
+        let fs = EdgarFs::new("test");
+        let entries = fs.list(Path::new("/by-cik/1045810")).await.expect("list");
+        assert_eq!(fs.calls(), 0, "listing a registrant sent a request");
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, ["submissions", "facts", "concept"]);
+        assert!(entries.iter().all(|e| e.kind == DirentKind::Dir));
+    }
+
+    #[test]
+    fn a_resource_opens_wrapped_or_flat() {
+        // The listed path, and the one someone guesses. Only the first is advertised;
+        // the second costs nothing to keep and saves a caller from coming away empty.
+        let want = Some(Node::Submissions("0001045810".into()));
+        assert_eq!(parse("/by-cik/1045810/submissions/submissions.json"), want);
+        assert_eq!(parse("/by-cik/1045810/submissions.json"), want);
+        assert_eq!(
+            parse("/by-cik/1045810/facts"),
+            Some(Node::FactsDir("0001045810".into()))
+        );
+        // The wrapper holds one file, named after it — nothing else.
+        assert_eq!(parse("/by-cik/1045810/submissions/facts.json"), None);
+    }
+
+    #[tokio::test]
+    async fn narrowing_sends_no_requests() {
+        let fs = EdgarFs::new("test");
+        for p in [
+            "/",
+            "/by-cik",
+            "/by-cik/1045810",
+            "/by-cik/1045810/concept",
+            "/by-cik/1045810/concept/us-gaap",
+            "/search",
+            "/search/q",
+            "/search/q/lithium",
+            "/search/q/lithium/forms/10-K",
+            // `by-ticker` is deliberately absent: listing it needs the index, which is
+            // one fetch. That is the exception, and it is why the tree keeps it to one.
+        ] {
+            fs.list(Path::new(p))
+                .await
+                .unwrap_or_else(|e| panic!("list {p}: {e}"));
+        }
+        assert_eq!(fs.calls(), 0, "narrowing sent a request");
+    }
+
+    #[tokio::test]
+    async fn every_advertised_directory_can_be_entered() {
+        let fs = EdgarFs::new("test");
+        for base in ["/", "/by-cik/1045810", "/search/q/lithium"] {
+            for e in fs.list(Path::new(base)).await.expect("list") {
+                if e.name == "pages" || e.name == "companies.json" {
+                    continue; // those would ask the API
+                }
+                let child = format!("{}/{}", base.trim_end_matches('/'), e.name);
+                assert!(
+                    EdgarFs::parse(Path::new(&child)).is_some(),
+                    "listed but not enterable: {child}"
+                );
+            }
+        }
+    }
+}
+

--- a/examples/company_analysis/src/edgar.rs
+++ b/examples/company_analysis/src/edgar.rs
@@ -1,7 +1,6 @@
 //! SEC EDGAR projected onto a read-only [`FileSystem`].
 //!
 //! ```text
-//! /by-ticker/<TICKER>/                 the same registrant, reached by what it trades as
 //! /by-cik/<CIK>/submissions.json       one registrant: identifiers, addresses, filings
 //! /by-cik/<CIK>/concept/<tax>/<tag>.json   one XBRL concept's history
 //! /search/<field>/<value>/…/pages/      full-text search over filings
@@ -13,17 +12,18 @@
 //! trip. EDGAR's list is a stub — cik, ticker, title — and everything else needs the
 //! registrant fetched by CIK.
 //!
-//! # Two ways in, and why both exist
+//! # One address, one way to find it
 //!
-//! `by-ticker` is listable: eight thousand names, one per registrant, so `ls` and
-//! `glob` find a company without anyone knowing its number. `by-cik` is not listable
-//! and cannot be — most of what files with the SEC has no ticker at all. In one
-//! full-text search, eleven of the twenty-three CIKs that came back were absent from
-//! the ticker file. Dropping `by-cik` would leave those results with nowhere to go.
+//! A registrant is addressed by CIK and nothing else. There is no door keyed by ticker
+//! because nothing needs one: `search/entityName/` takes a symbol and answers with the
+//! registrant — the SEC indexes a filer's display name with its ticker in it, so
+//! `entityName/NVDA` lands on NVIDIA CORP more squarely than `entityName/NVIDIA`, which
+//! returns individuals of that name first.
 //!
-//! So `by-ticker/<TICKER>/` serves what `by-cik/<CIK>/` serves, and the CIK form is
-//! the canonical one — it is what `search/ciks/` takes and what `submissions.json`
-//! reports about itself.
+//! A second door would also be a second listing, and a listing here is a place for a
+//! `find` or a glob to start walking. Every registrant a walk reaches costs a
+//! `submissions.json` and a four-megabyte `facts.json`, so an entry point that can be
+//! enumerated is an entry point that can spend thousands of requests nobody asked for.
 //!
 //! # What a listing costs
 //!
@@ -40,7 +40,6 @@
 //! it would spend four megabytes on an `ls` that wanted the filing history.
 
 use std::{
-    collections::{HashMap, HashSet},
     io,
     path::{Component, Path},
     sync::Arc,
@@ -54,7 +53,6 @@ use cortex::{
 use crate::apifs::{Fetcher, io_err, percent_decode, urlencode};
 
 const DATA: &str = "https://data.sec.gov";
-const WWW: &str = "https://www.sec.gov";
 const EFTS: &str = "https://efts.sec.gov/LATEST/search-index";
 
 /// Full-text search returns 100 hits a page and pages by offset, not by number.
@@ -78,10 +76,10 @@ Not because the set is unknowable — the SEC publishes every CIK it has — but
 listing of them would be a million zero-padded numbers. Knowing one already lets you
 address it; not knowing one, the numbers do not say which company is which.
 
-So there are two ways to get a number. `/by-ticker/` lists every registrant that trades
-under a symbol, so `ls` or a glob finds it. `/search/entityName/<name>/pages/` searches
-filings by company name and reports the CIKs behind each hit. Both start from a name,
-which is what you actually have.
+To get one, search. `/search/entityName/<name>/pages/` searches filings by company name
+and reports the CIK behind each hit. A ticker works there as well as a name, and often
+better: the SEC writes the symbol into the filer's display name, so `entityName/NVDA`
+lands on NVIDIA CORP while `entityName/NVIDIA` returns individuals of that name first.
 
     /by-cik/<CIK>/submissions.json          identifiers, addresses, filing history
     /by-cik/<CIK>/concept/<taxonomy>/<tag>.json   one concept over time
@@ -120,49 +118,18 @@ reliable key from here to the GLEIF store; crossing over means matching on name,
 name match is a candidate rather than a fact.
 "#;
 
-/// What `/by-ticker` says about itself.
-const BY_TICKER_README: &str = r#"# /by-ticker — one name per registrant
-
-    ls .            every registrant that trades under a symbol, ~8,000 of them
-    NVDA/           the same files as /by-cik/0001045810/
-
-A directory here serves exactly what the matching `by-cik` one serves. The CIK form is
-the canonical address — it is what `search/ciks/` takes — and `submissions.json` names
-its own CIK, so nothing is lost by arriving this way.
-
-## The listing is shorter than the ticker file
-
-A company with several share classes files once and trades several ways: Alphabet is
-GOOGL, GOOG, GOOGM and GOOGN, and all four are one registrant with one CIK. Listing all
-of them would say there are four companies.
-
-So the listing holds one ticker per registrant — the first the SEC's own file names,
-which orders them by size, so it is GOOGL rather than GOOG and BRK-B rather than BRK-A.
-
-**The others still open.** `GOOG/` works, it is simply not in the listing. A ticker
-that resolves to a registrant is a directory whether or not `ls` mentions it.
-
-## What is not here
-
-Filers without a ticker — subsidiaries, funds, foreign private issuers — and they are
-the majority. Use `/by-cik/` for those, and `/search/` to find their numbers.
-"#;
-
 /// The tree's entry point, served by the tree itself.
 const CATALOG: &str = r#"# SEC EDGAR, as a filesystem
 
 Every file here is one request to the SEC, answered live. Nothing is stored.
 
-    /by-ticker/<TICKER>/          a listed company, by the symbol it trades under
     /by-cik/<CIK>/                any filer, by its SEC number
     /search/<field>/<value>/…/    full-text search over filing documents
 
 ## Which way in
 
-If it trades, `by-ticker` is listable — `ls` it, or glob it, and the directory serves
-the same files as the `by-cik` one. If it does not trade, or you already hold a number,
-use `by-cik`. Most SEC filers have no ticker, so `by-cik` is the larger door even
-though it cannot be listed.
+A registrant is addressed by CIK. If you do not have one, `/search/entityName/` takes a
+company name or a ticker and reports the CIK behind each hit.
 
 Identifiers are worth confirming rather than recalling: a wrong CIK answers with
 somebody else's filings rather than with an error.
@@ -185,33 +152,20 @@ Results are capped at 10,000 by the search backend, so a `total` of exactly 1000
 `filings.recent` in `submissions.json` is column-oriented: parallel arrays, one per
 field, not a list of filings. Zip them by index before reading a row.
 
-The two files disagree about what a CIK is, and their names point the wrong way. The
-ticker index writes `"cik_str": 1652044` — an integer, under a name that says string.
-`submissions.json` answers `"cik": "0001652044"` — a zero-padded string, under a name
-that says neither. Compare them as numbers, or pad both, but do not compare them raw.
+A search hit carries the CIK twice, and only one of them is meant to be parsed.
+`ciks` is a list of zero-padded strings — `["0001045810"]` — and that is the one to use.
+`display_names` reads `NVIDIA CORP  (NVDA)  (CIK 0001045810)`, which is for a person to
+read; the spacing is not a contract.
 "#;
 
 pub struct EdgarFs {
     fetch: Fetcher,
-    index: std::sync::Mutex<Option<Arc<TickerIndex>>>,
-}
-
-/// Every ticker, and the subset worth listing.
-struct TickerIndex {
-    by_ticker: HashMap<String, String>,
-    /// One per registrant, in the order the SEC's file gives them.
-    listed: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 enum Node {
     Root,
     Catalog,
-    /// `/by-ticker`
-    ByTickerRoot,
-    ByTickerReadme,
-    /// `/by-ticker/<TICKER>/…` — resolved to a `by-cik` path once the index is in.
-    Ticker(String, Vec<String>),
     /// `/by-cik`
     ByCikRoot,
     ByCikReadme,
@@ -248,7 +202,6 @@ impl EdgarFs {
     pub fn new(user_agent: &str) -> Self {
         Self {
             fetch: Fetcher::new(user_agent),
-            index: std::sync::Mutex::new(None),
         }
     }
 
@@ -280,12 +233,6 @@ impl EdgarFs {
         match segs.as_slice() {
             [] => Some(Node::Root),
             ["CATALOG.md"] => Some(Node::Catalog),
-            ["by-ticker"] => Some(Node::ByTickerRoot),
-            ["by-ticker", "_README.md"] => Some(Node::ByTickerReadme),
-            ["by-ticker", t, rest @ ..] if is_ticker(t) => Some(Node::Ticker(
-                t.to_ascii_uppercase(),
-                rest.iter().map(|s| s.to_string()).collect(),
-            )),
             ["by-cik"] => Some(Node::ByCikRoot),
             ["by-cik", "_README.md"] => Some(Node::ByCikReadme),
             ["by-cik", cik, rest @ ..] => {
@@ -392,90 +339,6 @@ impl EdgarFs {
         url
     }
 
-    /// Ticker to CIK, plus the tickers worth listing.
-    ///
-    /// One fetch per run. The map holds every ticker so any of them opens; the list
-    /// holds one per registrant, because a registrant with four share classes is one
-    /// company and four directories would say otherwise.
-    ///
-    /// Which one is listed is the file's own answer, not ours: `company_tickers.json`
-    /// is ordered by size — NVDA, AAPL, GOOGL, MSFT — so the first row naming a CIK is
-    /// the class that file puts first. That gives GOOGL over GOOG and BRK-B over
-    /// BRK-A, which is also how they trade. Choosing differently would mean keeping a
-    /// list of exceptions, and an exception nobody can see is a judgement the data
-    /// does not support.
-    async fn index(&self) -> io::Result<Arc<TickerIndex>> {
-        if let Some(hit) = self.index.lock().unwrap().clone() {
-            return Ok(hit);
-        }
-        let bytes = self
-            .fetch
-            .get(
-                "ticker index",
-                "/companies.json",
-                &format!("{WWW}/files/company_tickers.json"),
-            )
-            .await?;
-        // A refusal arrives as an HTML page under a 4xx, and parsing it as JSON would
-        // report a syntax error at column 1 — true, and useless. Say what came back.
-        let doc: serde_json::Value = serde_json::from_slice(&bytes).map_err(|_| {
-            let head: String = String::from_utf8_lossy(&bytes)
-                .chars()
-                .take(120)
-                .collect();
-            io::Error::other(format!(
-                "SEC answered with something that is not JSON. A User-Agent naming no contact \
-                 gets 403 and an HTML page. Set SEC_USER_AGENT to something like \
-                 'name contact@example.com'. First bytes of the reply: {head}"
-            ))
-        })?;
-        let rows = doc.as_object().ok_or_else(|| io::Error::other("not an object"))?;
-
-        // The keys are the file's row numbers as strings, and string order is not
-        // numeric order — "10" sorts before "2". Sorting numerically is what keeps
-        // "first row" meaning first.
-        let mut ordered: Vec<(u64, &serde_json::Value)> = rows
-            .iter()
-            .filter_map(|(k, v)| Some((k.parse().ok()?, v)))
-            .collect();
-        ordered.sort_by_key(|(n, _)| *n);
-
-        let mut by_ticker = HashMap::new();
-        let mut listed = Vec::new();
-        let mut seen_cik = HashSet::new();
-        for (_, row) in ordered {
-            let (Some(t), Some(cik)) = (
-                row.get("ticker").and_then(|v| v.as_str()),
-                row.get("cik_str").and_then(|v| v.as_u64()),
-            ) else {
-                continue;
-            };
-            let cik = format!("{cik:0>10}");
-            if seen_cik.insert(cik.clone()) {
-                listed.push(t.to_ascii_uppercase());
-            }
-            by_ticker.insert(t.to_ascii_uppercase(), cik);
-        }
-        let idx = Arc::new(TickerIndex { by_ticker, listed });
-        *self.index.lock().unwrap() = Some(idx.clone());
-        Ok(idx)
-    }
-
-    /// A `by-ticker` path as the `by-cik` path it names.
-    async fn resolve(&self, ticker: &str, rest: &[String]) -> io::Result<Node> {
-        let idx = self.index().await?;
-        let cik = idx
-            .by_ticker
-            .get(ticker)
-            .ok_or(io::ErrorKind::NotFound)?;
-        let mut path = format!("/by-cik/{cik}");
-        for seg in rest {
-            path.push('/');
-            path.push_str(seg);
-        }
-        Self::parse(Path::new(&path)).ok_or_else(|| io::ErrorKind::NotFound.into())
-    }
-
     /// What a request bought. Taken from the node rather than parsed back out of the
     /// key, which is only a string that looks like a path.
     fn kind(node: &Node) -> &'static str {
@@ -520,7 +383,6 @@ impl EdgarFs {
         match node {
             Node::Catalog => Ok(Arc::new(CATALOG.as_bytes().to_vec())),
             Node::ByCikReadme => Ok(Arc::new(BY_CIK_README.as_bytes().to_vec())),
-            Node::ByTickerReadme => Ok(Arc::new(BY_TICKER_README.as_bytes().to_vec())),
             _ => {
                 let url = Self::url(node).ok_or(io::ErrorKind::IsADirectory)?;
                 self.fetch.get(Self::kind(node), &Self::key(node), &url).await
@@ -544,15 +406,9 @@ impl EdgarFs {
 impl FileSystem for EdgarFs {
     fn stat<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Stat>> {
         Box::pin(async move {
-            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
-            if let Node::Ticker(t, rest) = &node {
-                node = self.resolve(t, rest).await?;
-            }
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
             Ok(match &node {
                 Node::Catalog => Stat::new(DirentKind::File, CATALOG.len() as u64),
-                Node::ByTickerReadme => {
-                    Stat::new(DirentKind::File, BY_TICKER_README.len() as u64)
-                }
                 Node::ByCikReadme => Stat::new(DirentKind::File, BY_CIK_README.len() as u64),
                 Node::Submissions(_)
                 | Node::Facts(_)
@@ -568,10 +424,7 @@ impl FileSystem for EdgarFs {
 
     fn list<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Vec<Dirent>>> {
         Box::pin(async move {
-            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
-            if let Node::Ticker(t, rest) = &node {
-                node = self.resolve(t, rest).await?;
-            }
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
             let dir = |n: &str| Dirent::new(n, DirentKind::Dir);
             let note = |n: &str, s: &str| {
                 Dirent::with_stat(n, Stat::new(DirentKind::File, s.len() as u64))
@@ -579,21 +432,12 @@ impl FileSystem for EdgarFs {
             Ok(match node {
                 Node::Root => vec![
                     note("CATALOG.md", CATALOG),
-                    dir("by-ticker"),
                     dir("by-cik"),
                     dir("search"),
                 ],
-                // One entry per registrant, not per ticker. A directory here is free to
+                // A directory here is free to
                 // stat, so the kernel's getattr storm over eight thousand names costs
                 // nothing beyond the one fetch that built the index.
-                Node::ByTickerRoot => {
-                    let idx = self.index().await?;
-                    let mut out = vec![note("_README.md", BY_TICKER_README)];
-                    out.extend(idx.listed.iter().map(|t| {
-                        Dirent::with_stat(t.clone(), Stat::new(DirentKind::Dir, 0))
-                    }));
-                    out
-                }
                 Node::ByCikRoot => vec![note("_README.md", BY_CIK_README)],
                 // Every fetchable resource is wrapped in a directory, so this listing
                 // names what is available without asking for any of it. A directory
@@ -601,7 +445,7 @@ impl FileSystem for EdgarFs {
                 // and a document's is not knowable without fetching it, so a file here
                 // would be fetched just to be listed. It was, once: naming
                 // `submissions.json` cost 742 requests in a single run, because an
-                // ordinary recursive pass over the ticker listing turned into one fetch
+                // ordinary recursive pass over a listing turned into one fetch
                 // per registrant.
                 Node::Entity(_) => vec![dir("submissions"), dir("facts"), dir("concept")],
                 // The cost lands here instead, where a caller has asked for the thing.
@@ -656,10 +500,7 @@ impl FileSystem for EdgarFs {
         offset: u64,
     ) -> BoxFuture<'a, io::Result<usize>> {
         Box::pin(async move {
-            let mut node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
-            if let Node::Ticker(t, rest) = &node {
-                node = self.resolve(t, rest).await?;
-            }
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
             // A page past the end is not an error upstream — it answers with an empty
             // hit list — but as a file it should simply not be there.
             if let Node::Page(pairs, n) = &node {
@@ -683,13 +524,6 @@ impl FileSystem for EdgarFs {
 /// so a caller who read the list and formed a path from what it said would otherwise
 /// get nothing. Padding here costs a line; the alternative is a working identifier
 /// that does not work.
-fn is_ticker(s: &str) -> bool {
-    !s.is_empty()
-        && s.len() <= 12
-        && s.bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.')
-}
-
 fn normalize_cik(s: &str) -> Option<String> {
     let digits = s.strip_prefix("CIK").unwrap_or(s);
     if digits.is_empty() || digits.len() > 10 || !digits.bytes().all(|b| b.is_ascii_digit()) {
@@ -772,94 +606,13 @@ mod tests {
         assert_eq!(parse("/search/nosuchparam/x"), None);
     }
 
+    /// A ticker is not an address here. Nothing under `by-ticker` parses, so naming
+    /// one is a missing directory rather than a request that goes nowhere.
     #[test]
-    fn a_ticker_path_is_a_path_before_anything_is_resolved() {
-        // Resolution needs the index, so parsing only says "this is a ticker and this
-        // is the rest of it"; case is folded here because the index is upper-case.
-        assert_eq!(
-            parse("/by-ticker/nvda/submissions.json"),
-            Some(Node::Ticker("NVDA".into(), vec!["submissions.json".into()]))
-        );
-        assert_eq!(parse("/by-ticker/BRK-B"), Some(Node::Ticker("BRK-B".into(), vec![])));
-        assert_eq!(parse("/by-ticker/_README.md"), Some(Node::ByTickerReadme));
-        // Not a symbol.
-        assert_eq!(parse("/by-ticker/this-is-far-too-long"), None);
-        assert_eq!(parse("/by-ticker/NV DA"), None);
-    }
-
-    /// The listing holds one ticker per registrant and the rest still open. Pinned
-    /// because the alternative — dropping them — answers "no such company" for a
-    /// symbol that trades, which is worse than a listing that omits it.
-    #[test]
-    fn an_unlisted_share_class_is_still_a_path() {
-        for t in ["GOOG", "GOOGM", "BRK-A"] {
-            assert!(
-                matches!(parse(&format!("/by-ticker/{t}")), Some(Node::Ticker(..))),
-                "{t}"
-            );
+    fn a_ticker_is_not_a_path() {
+        for p in ["/by-ticker", "/by-ticker/NVDA", "/by-ticker/NVDA/submissions.json"] {
+            assert_eq!(parse(p), None, "{p}");
         }
-    }
-
-    /// `by-ticker` for real: mounted, listed through the kernel, and read.
-    ///
-    /// Ignored by default — it mounts a filesystem and talks to the SEC. Run with
-    /// `cargo test -p company_analysis --bins by_ticker_resolves -- --ignored --nocapture`.
-    #[test]
-    #[ignore = "needs a FUSE mount and network"]
-    fn by_ticker_resolves() {
-        use cortex::fs::{FuseTMount, Mount};
-        use std::fs;
-
-        // SEC refuses a `User-Agent` without a contact, so this test needs a real one
-        // rather than a placeholder that would fail for a reason unrelated to the tree.
-        let Ok(ua) = std::env::var("SEC_USER_AGENT") else {
-            eprintln!("SEC_USER_AGENT unset — skipping");
-            return;
-        };
-        let fs_arc = Arc::new(EdgarFs::new(&ua));
-        let dir = std::env::temp_dir().join("ailoy-edgar-mount-test");
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("mountpoint");
-        let mount = FuseTMount::try_new(fs_arc.clone(), &dir).expect("mount");
-        let root = mount.mountpoint().to_path_buf();
-
-        let names: Vec<String> = fs::read_dir(root.join("by-ticker"))
-            .expect("read_dir by-ticker")
-            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
-        // One fetch built the whole listing.
-        assert_eq!(fs_arc.calls(), 1, "the index took more than one request");
-        assert!(names.contains(&"_README.md".to_string()));
-        assert!(names.len() > 7000, "the listing holds only {} entries", names.len());
-
-        // One per registrant: the class the SEC's own file names first, not all four.
-        assert!(names.contains(&"GOOGL".to_string()));
-        assert!(!names.contains(&"GOOG".to_string()), "a second share class of one registrant is listed");
-
-        // And the ones left out are still directories.
-        let goog = fs::read_to_string(root.join("by-ticker/GOOG/submissions/submissions.json"))
-            .expect("a ticker left out of the listing does not open");
-        let doc: serde_json::Value = serde_json::from_str(&goog).expect("json");
-        // `cik` here is a zero-padded *string*, whatever the name of `cik_str`
-        // elsewhere suggests.
-        assert_eq!(doc["cik"].as_str(), Some("0001652044"), "GOOG did not resolve to Alphabet");
-        assert_eq!(doc["name"].as_str(), Some("Alphabet Inc."));
-
-        // The two ways in name the same registrant.
-        let via_ticker =
-            fs::read_to_string(root.join("by-ticker/NVDA/submissions/submissions.json")).expect("NVDA");
-        let via_cik = fs::read_to_string(root.join("by-cik/1045810/submissions/submissions.json"))
-            .expect("by-cik");
-        assert_eq!(via_ticker, via_cik, "the two addresses serve different bytes");
-
-        println!(
-            "listed={} calls={} (index + GOOG + NVDA, by-cik was cached)",
-            names.len() - 1,
-            fs_arc.calls()
-        );
-
-        drop(mount);
-        let _ = fs::remove_dir_all(&dir);
     }
 
     /// Listing a registrant must not fetch anything, and must still say what is there.
@@ -907,8 +660,7 @@ mod tests {
             "/search/q",
             "/search/q/lithium",
             "/search/q/lithium/forms/10-K",
-            // `by-ticker` is deliberately absent: listing it needs the index, which is
-            // one fetch. That is the exception, and it is why the tree keeps it to one.
+            "/by-cik",
         ] {
             fs.list(Path::new(p))
                 .await
@@ -922,7 +674,7 @@ mod tests {
         let fs = EdgarFs::new("test");
         for base in ["/", "/by-cik/1045810", "/search/q/lithium"] {
             for e in fs.list(Path::new(base)).await.expect("list") {
-                if e.name == "pages" || e.name == "companies.json" {
+                if e.name == "pages" {
                     continue; // those would ask the API
                 }
                 let child = format!("{}/{}", base.trim_end_matches('/'), e.name);

--- a/examples/company_analysis/src/gleif.rs
+++ b/examples/company_analysis/src/gleif.rs
@@ -152,19 +152,13 @@ them would spend one request per page before anything had been read.
 
 ## How many pages there are
 
-Read `page-001.json` and look at `meta.pagination`:
+The line above this note says so. `page-001.json` carries the same in
+`meta.pagination` — `lastPage`, `total`, `perPage` (200 here, the API's ceiling) — and
+`links.next` as a URL, but reading a page to count them costs two hundred records in
+view. Either way, `page-002.json` is the path.
 
-    lastPage    how many pages this query has
-    total       how many records
-    perPage     how many per page (200 here, the API's ceiling)
-
-`links.next` carries the same thing as a URL. Either way, `page-002.json` is the path.
-
-## Before paging through everything
-
-A narrower query is cheaper than more pages. The directory above this one lists the
-fields still available, and each one is free to descend into — nothing is requested
-until a `pages` directory is opened.
+Paging is the expensive way to read a large result. The directory above this one still
+lists fields to narrow by, and descending into them costs nothing.
 "#;
 
 /// What `/by-lei` says about itself.
@@ -218,7 +212,7 @@ enum Node {
     /// `/by-lei/_README.md`
     ByLeiReadme,
     /// `…/pages/_README.md`
-    PagesReadme,
+    PagesReadme(Vec<(String, String)>),
     /// `/CATALOG.md`
     Catalog,
     /// `/by-lei/<LEI>`
@@ -310,7 +304,7 @@ impl GleifFs {
     /// field awaiting a value.
     fn parse_query(rest: &[&str]) -> Option<Node> {
         // Peel the results suffix off the end; what remains is the query itself.
-        let (pairs, tail) = match rest {
+        let (pairs, tail, readme) = match rest {
             [init @ .., "pages", page] if page.starts_with("page-") && page.ends_with(".json") => {
                 let n: usize = page
                     .trim_start_matches("page-")
@@ -320,11 +314,13 @@ impl GleifFs {
                 if n == 0 {
                     return None;
                 }
-                (init, Some(Some(n)))
+                (init, Some(Some(n)), false)
             }
-            [.., "pages", "_README.md"] => return Some(Node::PagesReadme),
-            [init @ .., "pages"] => (init, Some(None)),
-            _ => (rest, None),
+            // The note belongs to this query, not to `pages` in general: it reports the
+            // query's own size, which the listing has already paid for.
+            [init @ .., "pages", "_README.md"] => (init, Some(None), true),
+            [init @ .., "pages"] => (init, Some(None), false),
+            _ => (rest, None, false),
         };
 
         if pairs.is_empty() {
@@ -369,9 +365,33 @@ impl GleifFs {
 
         Some(match tail {
             Some(Some(n)) => Node::Page(out, n),
+            Some(None) if readme => Node::PagesReadme(out),
             Some(None) => Node::Pages(out),
             None => Node::Query(out),
         })
+    }
+
+    /// The note for one query's `pages`, with that query's own size in it.
+    ///
+    /// The count comes from page 1, which the listing has already fetched, so reading it
+    /// here is a cache hit. Without it the note can only say where the count is, and the
+    /// caller pulls two hundred records into view to read one number.
+    async fn pages_note(&self, pairs: &[(String, String)]) -> io::Result<Arc<Vec<u8>>> {
+        let first = self
+            .body(&Node::Page(pairs.to_vec(), 1), &page_key(pairs, 1))
+            .await?;
+        let doc: serde_json::Value = serde_json::from_slice(&first).map_err(io_err)?;
+        let at = |k: &str| {
+            doc.pointer(&format!("/meta/pagination/{k}"))
+                .and_then(|v| v.as_u64())
+        };
+        let head = match (at("lastPage"), at("total")) {
+            (Some(last), Some(total)) => {
+                format!("This query has {last} page(s), {total} record(s).\n\n")
+            }
+            _ => String::new(),
+        };
+        Ok(Arc::new(format!("{head}{PAGES_README}").into_bytes()))
     }
 
     /// The URL a query's page comes from. `page` is 1-based, as the API counts.
@@ -467,7 +487,10 @@ impl FileSystem for GleifFs {
             match &node {
                 // Written here, so their sizes cost nothing to report.
                 Node::ByLeiReadme => Ok(Stat::new(DirentKind::File, BY_LEI_README.len() as u64)),
-                Node::PagesReadme => Ok(Stat::new(DirentKind::File, PAGES_README.len() as u64)),
+                Node::PagesReadme(pairs) => {
+                    let note = self.pages_note(pairs).await?;
+                    Ok(Stat::new(DirentKind::File, note.len() as u64))
+                }
                 Node::Catalog => Ok(Stat::new(DirentKind::File, CATALOG.len() as u64)),
                 Node::EntityFile(..) | Node::Page(..) => {
                     let bytes = self.body(&node, &node_key(&node)).await?;
@@ -522,7 +545,7 @@ impl FileSystem for GleifFs {
                     )]
                 }
                 Node::ByLeiReadme
-                | Node::PagesReadme
+                | Node::PagesReadme(..)
                 | Node::Catalog
                 | Node::EntityFile(..)
                 | Node::Page(..) => {
@@ -561,7 +584,7 @@ impl FileSystem for GleifFs {
                         ),
                         Dirent::with_stat(
                             "_README.md",
-                            Stat::new(DirentKind::File, PAGES_README.len() as u64),
+                            Stat::new(DirentKind::File, self.pages_note(&pairs).await?.len() as u64),
                         ),
                     ]
                 }
@@ -579,7 +602,7 @@ impl FileSystem for GleifFs {
             let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
             let bytes: Arc<Vec<u8>> = match &node {
                 Node::ByLeiReadme => Arc::new(BY_LEI_README.as_bytes().to_vec()),
-                Node::PagesReadme => Arc::new(PAGES_README.as_bytes().to_vec()),
+                Node::PagesReadme(pairs) => self.pages_note(pairs).await?,
                 Node::Catalog => Arc::new(CATALOG.as_bytes().to_vec()),
                 Node::EntityFile(..) | Node::Page(..) => {
                     self.body(&node, &node_key(&node)).await?
@@ -725,6 +748,22 @@ mod tests {
     /// Whatever a query directory offers must be enterable. The two were allowed to
     /// disagree once, and a listing that advertises a dead end is worse than one that
     /// advertises nothing.
+    /// The note under `pages` belongs to its query, so it can report that query's own
+    /// size. Parsing has to keep the pairs for that; dropping them is how it silently
+    /// becomes the same note everywhere.
+    #[test]
+    fn the_pages_note_keeps_its_query() {
+        let Some(Node::PagesReadme(pairs)) = parse("/search/entity.legalName/NVIDIA/pages/_README.md") else {
+            panic!("the note did not parse as a query's own")
+        };
+        assert!(!pairs.is_empty(), "the note lost the query it belongs to");
+        // The same query with and without the note names one query, not two.
+        let Some(Node::Pages(same)) = parse("/search/entity.legalName/NVIDIA/pages") else {
+            panic!("pages")
+        };
+        assert_eq!(pairs, same);
+    }
+
     #[tokio::test]
     async fn every_advertised_directory_can_be_entered() {
         let fs = GleifFs::new();

--- a/examples/company_analysis/src/gleif.rs
+++ b/examples/company_analysis/src/gleif.rs
@@ -97,6 +97,14 @@ stored; a listing is what the API would say now.
     /search/…/pages/              its results
     /by-lei/<LEI>/                one entity, addressed by its LEI
 
+## Which way in
+
+An entity is addressed, not found by listing: `ls /by-lei` names nothing but its own
+note. An LEI comes from a search page here, or from `owns`/`ownedBy` on another record.
+
+Identifiers are worth confirming rather than recalling: a wrong LEI answers with
+somebody else's entity rather than with an error.
+
 ## Two rules that are not obvious
 
 **AND is a directory, OR is a comma.** The API takes repeated filters as AND and reads

--- a/examples/company_analysis/src/gleif.rs
+++ b/examples/company_analysis/src/gleif.rs
@@ -1,0 +1,902 @@
+//! GLEIF's LEI API projected onto a read-only [`FileSystem`].
+//!
+//! ```text
+//! /by-lei/<LEI>/record.json              the LEI record
+//! /by-lei/<LEI>/<resource>.json          whatever that record's `relationships` links to
+//! /search/<field>/<value>/…/           a filtered query, narrowed by descending
+//! /search/<field>/<value>/…/pages/     its results, one file per page
+//! ```
+//!
+//! # Why the search path is nested
+//!
+//! GLEIF combines filters with repeated `filter[..]` parameters and reads a comma
+//! inside one value as OR. So a comma is already taken, and AND has to be spelled
+//! some other way — here it is directory nesting, which leaves the comma meaning
+//! exactly what it means upstream:
+//!
+//! ```text
+//! /search/entity.legalAddress.country/KR,JP/entity.status/ACTIVE/
+//!         └─ OR inside the value ─┘  └─ AND by descending ─┘
+//! ```
+//!
+//! Splitting `field` and `value` into two segments is what makes the tree
+//! self-describing: listing `/search` yields the field names, which is the part a
+//! caller cannot guess. The attribute paths that look plausible and answer 400
+//! (`entity.legalAddress.city`, every `headquartersAddress`, every date) are simply
+//! absent, so a wrong field is a missing directory rather than a request.
+//!
+//! Values are not listable — they are unbounded — so a value directory is reached by
+//! naming it. That is a lookup with the key already in hand: countries, statuses and
+//! LEIs all come from a file the caller has read.
+//!
+//! # What costs a request
+//!
+//! Narrowing does not. The fields are known here and the field listing is a constant,
+//! so walking down `country/KR/entity.status/ACTIVE/…` asks the API nothing — which
+//! matters because narrowing is the step a caller repeats. The results sit one level
+//! further down, behind `pages`, and that listing is the one that has to ask: how many
+//! pages a query has is something only the API knows. It answers with page 1, which is
+//! cached, so reading `pages/page-001.json` afterwards is free.
+//!
+//! # Sizes
+//!
+//! A kernel asks for a size before it opens anything, and an API answers only when
+//! asked. So a fetch fills a cache and the reads that follow are served from it —
+//! otherwise the file would appear to end wherever the first read stopped. The cache
+//! lasts as long as the store, which is one run: a citation written at turn 5 has to
+//! still mean the same bytes at turn 40.
+
+use std::{collections::HashMap, io, path::{Component, Path}, sync::Arc};
+
+use cortex::{
+    BoxFuture,
+    fs::{Dirent, DirentKind, FileSystem, Stat},
+};
+
+use crate::apifs::{Fetcher, io_err, percent_decode, urlencode};
+
+const API: &str = "https://api.gleif.org/api/v1/lei-records";
+
+/// GLEIF's ceiling. 250 is a 400, so this is the fewest round trips available.
+const PAGE_SIZE: usize = 200;
+
+/// The filter fields this tree offers.
+///
+/// A subset of what the API accepts, confirmed by asking it. Kept as a list rather than
+/// a guess because it is also the directory listing for `/search`: a field that is not
+/// here is a path that does not exist rather than a 400 waiting to happen.
+///
+/// What is left out is vendor cross-references and the registry's own bookkeeping —
+/// real fields, but ones that answer questions about GLEIF rather than about a company.
+const FILTERS: &[&str] = &[
+    "entity.category",
+    "entity.jurisdiction",
+    "entity.legalAddress.country",
+    "entity.legalName",
+    "entity.otherNames",
+    "entity.registeredAs",
+    "entity.status",
+    "fulltext",
+    "isin",
+    "lei",
+    "owns",
+    "ownedBy",
+];
+
+/// The tree's entry point, served by the tree itself.
+///
+/// A store that answers over the network has no place to leave a README on disk, and
+/// a caller landing at the root has no other way to learn that a listing here is not
+/// a promise of completeness. So the catalogue is a node like any other.
+const CATALOG: &str = r#"# GLEIF, as a filesystem
+
+Every file here is one request to the Global LEI Index, answered live. Nothing is
+stored; a listing is what the API would say now.
+
+    /search/<field>/<value>/…/    narrow a query by descending
+    /search/…/pages/              its results
+    /by-lei/<LEI>/                one entity, addressed by its LEI
+
+## Two rules that are not obvious
+
+**AND is a directory, OR is a comma.** The API takes repeated filters as AND and reads
+a comma inside one value as OR, so the comma is spoken for and nesting carries the
+rest:
+
+    /search/entity.legalAddress.country/KR,JP/entity.status/ACTIVE/pages/
+
+**Descending is free; opening `pages` is not.** The fields are known here, so walking
+down a query asks nothing. The first request happens when a `pages` directory is read,
+because only the API knows how many results there are. Narrow first, then open.
+
+## What you can filter on
+
+`ls /search` names them. A field that is not listed is a path that does not exist, so
+naming one costs no request. Fifteen plausible-looking ones (`entity.legalAddress.city`,
+anything under `headquartersAddress`, any date) are absent because the API rejects them;
+the rest of what it accepts is vendor cross-references and registry bookkeeping, left
+out because no question about a company needs them.
+
+Values are not listable. They come from data you have already read: a country code, a
+status, an LEI from a search result or another registry.
+
+## When an answer is an error
+
+A rejected request is served as the file's contents, JSON and all, rather than as a
+missing file. Read it — it says which parameter was wrong.
+"#;
+
+/// What a `pages` directory says about itself.
+///
+/// Only page 1 is listed, which needs saying: the missing names are not missing
+/// results. A directory read is followed by a getattr for each entry, a page's size
+/// cannot be known without fetching that page, and so naming every page would spend
+/// one request per page before a caller had read anything.
+const PAGES_README: &str = r#"# pages — page 1 is listed, the rest are named
+
+    page-001.json   the first page of results
+    page-002.json   the second, and so on — 1-based, three digits
+
+Only `page-001.json` appears in the listing. The others exist and are read the same
+way; they are left out because a directory read makes the kernel ask for every entry's
+size, and a page's size is not known until that page has been fetched. Listing all of
+them would spend one request per page before anything had been read.
+
+## How many pages there are
+
+Read `page-001.json` and look at `meta.pagination`:
+
+    lastPage    how many pages this query has
+    total       how many records
+    perPage     how many per page (200 here, the API's ceiling)
+
+`links.next` carries the same thing as a URL. Either way, `page-002.json` is the path.
+
+## Before paging through everything
+
+A narrower query is cheaper than more pages. The directory above this one lists the
+fields still available, and each one is free to descend into — nothing is requested
+until a `pages` directory is opened.
+"#;
+
+/// What `/by-lei` says about itself.
+///
+/// A listing that comes back empty reads as "nothing here", which is the one thing a
+/// caller must not conclude: the entries are all there, and none of them is
+/// discoverable. So the directory holds one file that says so, and — the part that
+/// makes it actionable — says where an LEI comes from.
+const BY_LEI_README: &str = r#"# /by-lei — addressed, not listed
+
+This directory has no listing. There are millions of LEIs and which ones matter
+depends on the question, so an entity here is opened by **naming an LEI you already
+have**.
+
+    /by-lei/<LEI>/                what this entity has (use ls)
+    /by-lei/<LEI>/record/         its GLEIF record
+
+The 20 characters have to be right. A failed checksum means **the directory does not
+exist** — not an empty answer, a missing path.
+
+## Where an LEI comes from
+
+- `/search/<field>/<value>/…/pages/page-001.json`
+  Every item there carries its LEI in `id`, and the item is **byte for byte what
+  `record.json` returns**. If the record is all you need, the search page is the end
+  of the trip.
+- A relationship resource answers with the other party's LEI. That is the path for
+  walking ownership: LEI to LEI.
+- Another registry's record, when it carries an LEI field, gives you one directly.
+
+## Relationships read from two sides
+
+    /by-lei/<LEI>/            what this record links to itself (issuer, parent, …)
+    /search/ownedBy/<LEI>/    the entities this one owns
+    /search/owns/<LEI>/       the entity that owns this one
+
+`ownedBy` returns children and `owns` returns the parent. The names invite the
+opposite reading, so check the direction before drawing a tree.
+"#;
+
+pub struct GleifFs {
+    fetch: Fetcher,
+}
+
+/// What a path in this tree denotes.
+#[derive(Debug, PartialEq, Eq)]
+enum Node {
+    Root,
+    /// `/by-lei` — holds nothing but the note that explains itself.
+    ByLeiRoot,
+    /// `/by-lei/_README.md`
+    ByLeiReadme,
+    /// `…/pages/_README.md`
+    PagesReadme,
+    /// `/CATALOG.md`
+    Catalog,
+    /// `/by-lei/<LEI>`
+    Entity(String),
+    /// `/by-lei/<LEI>/<resource>` — the wrapper, free to stat.
+    ResourceDir(String, String),
+    /// `/by-lei/<LEI>/<resource>/<resource>.json`, or the flat path beside it.
+    EntityFile(String, String),
+    /// `/search`
+    SearchRoot,
+    /// A query so far, plus a field named but not yet given a value — which is what
+    /// every narrowing step passes through, since a query directory advertises the
+    /// fields still available as directories of their own.
+    Field(Vec<(String, String)>, String),
+    /// `/search/<f>/<v>/…` — one or more complete pairs.
+    Query(Vec<(String, String)>),
+    /// `…/pages` — the results of the query above it.
+    Pages(Vec<(String, String)>),
+    /// `…/pages/page-NNN.json`
+    Page(Vec<(String, String)>, usize),
+}
+
+impl GleifFs {
+    pub fn new() -> Self {
+        Self {
+            fetch: Fetcher::new(concat!(
+                "ailoy-company-analysis/",
+                env!("CARGO_PKG_VERSION")
+            )),
+        }
+    }
+
+    /// How many requests this store has sent. A cache hit is not one.
+    pub fn calls(&self) -> usize {
+        self.fetch.calls()
+    }
+
+    pub fn breakdown(&self) -> Vec<(&'static str, usize)> {
+        self.fetch.breakdown()
+    }
+
+    pub fn hot_keys(&self, n: usize) -> Vec<(String, usize)> {
+        self.fetch.hot_keys(n)
+    }
+
+    pub fn distinct_keys(&self) -> usize {
+        self.fetch.distinct_keys()
+    }
+
+    /// Parse a path into what it denotes, or `None` when it denotes nothing.
+    ///
+    /// Rejecting here rather than at the API is the difference between a missing
+    /// directory and a failed request: an unknown filter field never becomes a call.
+    fn parse(path: &Path) -> Option<Node> {
+        let segs: Vec<&str> = path
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(s) => s.to_str(),
+                _ => None,
+            })
+            .collect();
+
+        match segs.as_slice() {
+            [] => Some(Node::Root),
+            ["CATALOG.md"] => Some(Node::Catalog),
+            ["by-lei"] => Some(Node::ByLeiRoot),
+            ["by-lei", "_README.md"] => Some(Node::ByLeiReadme),
+            ["by-lei", lei] if is_lei(lei) => Some(Node::Entity(lei.to_string())),
+            // A resource is a directory holding one file of the same name, and the
+            // flat form beside it also opens — it is simply never listed.
+            ["by-lei", lei, res, file]
+                if is_lei(lei) && file.trim_end_matches(".json") == *res =>
+            {
+                Some(Node::EntityFile(lei.to_string(), res.to_string()))
+            }
+            ["by-lei", lei, file] if is_lei(lei) && file.ends_with(".json") => Some(
+                Node::EntityFile(lei.to_string(), file.trim_end_matches(".json").to_string()),
+            ),
+            ["by-lei", lei, res] if is_lei(lei) => {
+                Some(Node::ResourceDir(lei.to_string(), res.to_string()))
+            }
+            ["search"] => Some(Node::SearchRoot),
+            ["search", rest @ ..] => Self::parse_query(rest),
+            _ => None,
+        }
+    }
+
+    /// `(f/v)+`, optionally followed by `pages` or `pages/page-NNN.json`, or a lone
+    /// field awaiting a value.
+    fn parse_query(rest: &[&str]) -> Option<Node> {
+        // Peel the results suffix off the end; what remains is the query itself.
+        let (pairs, tail) = match rest {
+            [init @ .., "pages", page] if page.starts_with("page-") && page.ends_with(".json") => {
+                let n: usize = page
+                    .trim_start_matches("page-")
+                    .trim_end_matches(".json")
+                    .parse()
+                    .ok()?;
+                if n == 0 {
+                    return None;
+                }
+                (init, Some(Some(n)))
+            }
+            [.., "pages", "_README.md"] => return Some(Node::PagesReadme),
+            [init @ .., "pages"] => (init, Some(None)),
+            _ => (rest, None),
+        };
+
+        if pairs.is_empty() {
+            return None;
+        }
+        // An odd tail is a field awaiting a value. It can appear at any depth, because
+        // a query directory lists the fields still available — refusing it here would
+        // advertise a directory nothing can enter.
+        let (pairs, dangling) = if pairs.len() % 2 == 1 {
+            // Results hang off a complete query, never off a field with no value.
+            if tail.is_some() {
+                return None;
+            }
+            (&pairs[..pairs.len() - 1], Some(pairs[pairs.len() - 1]))
+        } else {
+            (pairs, None)
+        };
+
+        let mut out: Vec<(String, String)> = Vec::with_capacity(pairs.len() / 2 + 1);
+        for pair in pairs.chunks(2) {
+            let (f, v) = (pair[0], pair[1]);
+            if !FILTERS.contains(&f) {
+                return None;
+            }
+            // The same field twice would silently drop one condition upstream — the API
+            // takes the last `filter[..]` and ignores the earlier. A caller nesting them
+            // meant AND, so refuse rather than answer a different question.
+            if out.iter().any(|(prev, _): &(String, String)| prev == f) {
+                return None;
+            }
+            out.push((f.to_string(), percent_decode(v)));
+        }
+
+        if let Some(field) = dangling {
+            // The same constraints as a valued pair: a real field, and not one this
+            // query already fixed.
+            if !FILTERS.contains(&field) || out.iter().any(|(prev, _)| prev == field) {
+                return None;
+            }
+            return Some(Node::Field(out, field.to_string()));
+        }
+
+        Some(match tail {
+            Some(Some(n)) => Node::Page(out, n),
+            Some(None) => Node::Pages(out),
+            None => Node::Query(out),
+        })
+    }
+
+    /// The URL a query's page comes from. `page` is 1-based, as the API counts.
+    fn query_url(pairs: &[(String, String)], page: usize, size: usize) -> String {
+        let mut url = format!("{API}?page%5Bnumber%5D={page}&page%5Bsize%5D={size}");
+        for (f, v) in pairs {
+            url.push_str(&format!(
+                "&filter%5B{}%5D={}",
+                urlencode(f),
+                urlencode(v)
+            ));
+        }
+        url
+    }
+
+    /// The record itself. Split out so [`resources`](Self::resources) can read it
+    /// without going back through [`body`](Self::body), which would make the two
+    /// mutually recursive for no gain.
+    async fn record_bytes(&self, lei: &str) -> io::Result<Arc<Vec<u8>>> {
+        self.fetch
+            .get(
+                "lei record",
+                &format!("/by-lei/{lei}/record.json"),
+                &format!("{API}/{lei}"),
+            )
+            .await
+    }
+
+    /// The bytes a file path serves.
+    async fn body(&self, node: &Node, key: &str) -> io::Result<Arc<Vec<u8>>> {
+        match node {
+            Node::EntityFile(lei, file) if file == "record" => self.record_bytes(lei).await,
+            Node::EntityFile(lei, file) => {
+                let url = self
+                    .resources(lei)
+                    .await?
+                    .get(file.as_str())
+                    .cloned()
+                    .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+                self.fetch.get("linked resource", key, &url).await
+            }
+            Node::Page(pairs, n) => {
+                self.fetch
+                    .get("search page", key, &Self::query_url(pairs, *n, PAGE_SIZE))
+                    .await
+            }
+            _ => Err(io::ErrorKind::IsADirectory.into()),
+        }
+    }
+
+    /// The sub-resources one record links to: file name → URL.
+    ///
+    /// Taken from the record's own `relationships`, so the listing is the API's
+    /// hypermedia rather than a table kept in step with it by hand. The file name is
+    /// the URL's last segment, which is why a record with no parent shows
+    /// `direct-parent-reporting-exception.json` and one with a parent shows
+    /// `direct-parent.json` — the difference is a fact about the entity.
+    async fn resources(&self, lei: &str) -> io::Result<HashMap<String, String>> {
+        let bytes = self.record_bytes(lei).await?;
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).map_err(io_err)?;
+        let rels = doc
+            .pointer("/data/relationships")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+
+        let mut out = HashMap::new();
+        for (_, entry) in rels {
+            let Some(links) = entry.get("links").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            for (_, url) in links {
+                if let Some(url) = url.as_str() {
+                    if let Some(name) = url.rsplit('/').next() {
+                        out.insert(name.to_string(), url.to_string());
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl Default for GleifFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileSystem for GleifFs {
+    fn stat<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Stat>> {
+        Box::pin(async move {
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            match &node {
+                // Written here, so their sizes cost nothing to report.
+                Node::ByLeiReadme => Ok(Stat::new(DirentKind::File, BY_LEI_README.len() as u64)),
+                Node::PagesReadme => Ok(Stat::new(DirentKind::File, PAGES_README.len() as u64)),
+                Node::Catalog => Ok(Stat::new(DirentKind::File, CATALOG.len() as u64)),
+                Node::EntityFile(..) | Node::Page(..) => {
+                    let bytes = self.body(&node, &node_key(&node)).await?;
+                    Ok(Stat::new(DirentKind::File, bytes.len() as u64))
+                }
+                // Directories cost nothing to confirm: the path grammar already
+                // decided, and a round trip here would make every `ls` pay for a
+                // question it did not ask.
+                _ => Ok(Stat::new(DirentKind::Dir, 0)),
+            }
+        })
+    }
+
+    fn list<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, io::Result<Vec<Dirent>>> {
+        Box::pin(async move {
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            let dir = |n: &str| Dirent::new(n, DirentKind::Dir);
+            Ok(match node {
+                Node::Root => vec![
+                    Dirent::with_stat(
+                        "CATALOG.md",
+                        Stat::new(DirentKind::File, CATALOG.len() as u64),
+                    ),
+                    dir("by-lei"),
+                    dir("search"),
+                ],
+                Node::ByLeiRoot => vec![Dirent::with_stat(
+                    "_README.md",
+                    Stat::new(DirentKind::File, BY_LEI_README.len() as u64),
+                )],
+                // Directories, so this listing costs the one fetch it already needs —
+                // which resources exist is a fact only the record carries — and not one
+                // per resource on top of it. A file here would be fetched to be listed,
+                // because a directory read asks for every entry's size.
+                //
+                // The names are the record's own links, so what appears is what exists
+                // for this entity: a record with no parent shows a reporting exception
+                // where one with a parent shows a parent.
+                Node::Entity(lei) => {
+                    let mut names: Vec<String> = self.resources(&lei).await?.into_keys().collect();
+                    names.push("record".to_string());
+                    names.sort();
+                    names.into_iter().map(|n| dir(&n)).collect()
+                }
+                // Where the cost lands, once a caller has asked for the resource.
+                Node::ResourceDir(lei, res) => {
+                    let node = Node::EntityFile(lei.clone(), res.clone());
+                    let b = self.body(&node, &node_key(&node)).await?;
+                    vec![Dirent::with_stat(
+                        format!("{res}.json"),
+                        Stat::new(DirentKind::File, b.len() as u64),
+                    )]
+                }
+                Node::ByLeiReadme
+                | Node::PagesReadme
+                | Node::Catalog
+                | Node::EntityFile(..)
+                | Node::Page(..) => {
+                    return Err(io::ErrorKind::NotADirectory.into());
+                }
+                Node::SearchRoot => FILTERS.iter().map(|f| dir(*f)).collect(),
+                // Values are unbounded, so naming one is the only way in.
+                Node::Field(..) => vec![],
+                // Free. Narrowing is what a caller does most, and none of it is a
+                // question for the API — the fields are known and the results are one
+                // level down, behind `pages`. Listing the pages here instead would
+                // charge a request for every step of a walk that wanted none.
+                Node::Query(pairs) => {
+                    let mut out = vec![dir("pages")];
+                    out.extend(
+                        FILTERS
+                            .iter()
+                            .filter(|f| !pairs.iter().any(|(used, _)| used == *f))
+                            .map(|f| dir(*f)),
+                    );
+                    out
+                }
+                // Only page 1, and only because this is the one listing that has to
+                // ask the API anyway. Naming all thirteen pages of a result would be
+                // worse than useless: a directory read is followed by a getattr per
+                // entry, a page's size is not knowable without fetching it, and so a
+                // listing of N pages costs N requests before anything has been read.
+                // Measured — an early version answered 13 for a caller that wanted 1.
+                Node::Pages(pairs) => {
+                    let key = page_key(&pairs, 1);
+                    let first = self.body(&Node::Page(pairs.clone(), 1), &key).await?;
+                    vec![
+                        Dirent::with_stat(
+                            "page-001.json",
+                            Stat::new(DirentKind::File, first.len() as u64),
+                        ),
+                        Dirent::with_stat(
+                            "_README.md",
+                            Stat::new(DirentKind::File, PAGES_README.len() as u64),
+                        ),
+                    ]
+                }
+            })
+        })
+    }
+
+    fn read_at<'a>(
+        &'a self,
+        path: &'a Path,
+        buf: &'a mut [u8],
+        offset: u64,
+    ) -> BoxFuture<'a, io::Result<usize>> {
+        Box::pin(async move {
+            let node = Self::parse(path).ok_or(io::ErrorKind::NotFound)?;
+            let bytes: Arc<Vec<u8>> = match &node {
+                Node::ByLeiReadme => Arc::new(BY_LEI_README.as_bytes().to_vec()),
+                Node::PagesReadme => Arc::new(PAGES_README.as_bytes().to_vec()),
+                Node::Catalog => Arc::new(CATALOG.as_bytes().to_vec()),
+                Node::EntityFile(..) | Node::Page(..) => {
+                    self.body(&node, &node_key(&node)).await?
+                }
+                _ => return Err(io::ErrorKind::IsADirectory.into()),
+            };
+            let start = (offset as usize).min(bytes.len());
+            let n = buf.len().min(bytes.len() - start);
+            buf[..n].copy_from_slice(&bytes[start..start + n]);
+            Ok(n)
+        })
+    }
+}
+
+/// Cache key for a node. Query pairs are sorted, so the two orders a caller might
+/// descend in share one entry instead of fetching the same page twice.
+fn node_key(node: &Node) -> String {
+    match node {
+        Node::EntityFile(lei, file) => format!("/by-lei/{lei}/{file}.json"),
+        Node::Page(pairs, n) => page_key(pairs, *n),
+        _ => String::new(),
+    }
+}
+
+fn page_key(pairs: &[(String, String)], n: usize) -> String {
+    let mut sorted = pairs.to_vec();
+    sorted.sort();
+    let joined: Vec<String> = sorted.iter().map(|(f, v)| format!("{f}={v}")).collect();
+    format!("/search?{}#page-{n}", joined.join("&"))
+}
+
+/// ISO 17442: 18 alphanumerics and a mod 97-10 check pair.
+///
+/// Checked here so a typo is a missing directory rather than a request that comes
+/// back empty and looks like an answer.
+fn is_lei(s: &str) -> bool {
+    if s.len() != 20 || !s.bytes().all(|b| b.is_ascii_alphanumeric()) {
+        return false;
+    }
+    let mut rem: u32 = 0;
+    for b in s.bytes() {
+        let v = if b.is_ascii_digit() {
+            (b - b'0') as u32
+        } else {
+            (b.to_ascii_uppercase() - b'A') as u32 + 10
+        };
+        // Two digits at a time for a letter, one for a digit — the same widening the
+        // spec's "convert to numeric then mod 97" describes, without the big integer.
+        rem = if v >= 10 {
+            (rem * 100 + v) % 97
+        } else {
+            (rem * 10 + v) % 97
+        };
+    }
+    rem == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(p: &str) -> Option<Node> {
+        GleifFs::parse(Path::new(p))
+    }
+
+    /// A real LEI, and the same string with one character moved.
+    const SAMSUNG: &str = "9884007ER46L6N7EI764";
+
+    #[test]
+    fn lei_checksum_rejects_a_typo() {
+        assert!(is_lei(SAMSUNG));
+        assert!(is_lei("984500459FE6BED64E36"));
+        // Right shape, wrong check digits — the case a length test would let through.
+        assert!(!is_lei("9884007ER46L6N7EI765"));
+        assert!(!is_lei("TOOSHORT"));
+        assert!(!is_lei("9884007ER46L6N7EI76!"));
+    }
+
+    #[test]
+    fn paths_denote_what_they_look_like() {
+        assert_eq!(parse("/"), Some(Node::Root));
+        assert_eq!(parse("/by-lei"), Some(Node::ByLeiRoot));
+        assert_eq!(parse(&format!("/by-lei/{SAMSUNG}")), Some(Node::Entity(SAMSUNG.into())));
+        assert_eq!(
+            parse(&format!("/by-lei/{SAMSUNG}/record.json")),
+            Some(Node::EntityFile(SAMSUNG.into(), "record".into()))
+        );
+        assert_eq!(parse("/search"), Some(Node::SearchRoot));
+        // A bad LEI is not a path at all, so no request is ever made for it.
+        assert_eq!(parse("/by-lei/NOTALEI"), None);
+    }
+
+    #[test]
+    fn and_nests_while_or_stays_in_the_value() {
+        let q = parse("/search/entity.legalAddress.country/KR,JP/entity.status/ACTIVE");
+        assert_eq!(
+            q,
+            Some(Node::Query(vec![
+                ("entity.legalAddress.country".into(), "KR,JP".into()),
+                ("entity.status".into(), "ACTIVE".into()),
+            ]))
+        );
+        // The comma survives into the request, because upstream reads it as OR.
+        let Some(Node::Query(pairs)) = q else { unreachable!() };
+        assert!(GleifFs::query_url(&pairs, 1, PAGE_SIZE).contains("=KR,JP"));
+    }
+
+    #[test]
+    fn unknown_field_is_not_a_path() {
+        // One of the 15 that answer 400. Rejected here, so it never becomes a request.
+        assert_eq!(parse("/search/entity.legalAddress.city/Seoul"), None);
+        assert_eq!(parse("/search/nosuchfield/x"), None);
+        assert_eq!(parse("/search/entity.legalAddress.city"), None);
+    }
+
+    #[test]
+    fn the_same_field_twice_is_refused() {
+        // Upstream would keep the last and drop the first, answering a question the
+        // caller did not ask. Better to have no such path.
+        assert_eq!(
+            parse("/search/entity.status/ACTIVE/entity.status/INACTIVE"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_field_may_dangle_at_any_depth() {
+        assert_eq!(parse("/search/fulltext"), Some(Node::Field(vec![], "fulltext".into())));
+        // The narrowing step every query directory advertises. Refusing it would list a
+        // directory nothing can enter.
+        assert_eq!(
+            parse("/search/entity.status/ACTIVE/fulltext"),
+            Some(Node::Field(
+                vec![("entity.status".into(), "ACTIVE".into())],
+                "fulltext".into()
+            ))
+        );
+        // Still not a field the query already fixed, and still not an unknown one.
+        assert_eq!(parse("/search/entity.status/ACTIVE/entity.status"), None);
+        assert_eq!(parse("/search/entity.status/ACTIVE/nosuchfield"), None);
+    }
+
+    /// Whatever a query directory offers must be enterable. The two were allowed to
+    /// disagree once, and a listing that advertises a dead end is worse than one that
+    /// advertises nothing.
+    #[tokio::test]
+    async fn every_advertised_directory_can_be_entered() {
+        let fs = GleifFs::new();
+        let base = "/search/entity.legalAddress.country/KR";
+        for e in fs.list(Path::new(base)).await.expect("list") {
+            let child = format!("{base}/{}", e.name);
+            if e.name == "pages" {
+                continue; // that one would ask the API
+            }
+            assert!(
+                GleifFs::parse(Path::new(&child)).is_some(),
+                "listed but not enterable: {child}"
+            );
+        }
+    }
+
+    #[test]
+    fn pages_are_one_based() {
+        assert_eq!(
+            parse("/search/fulltext/samsung/pages/page-001.json"),
+            Some(Node::Page(vec![("fulltext".into(), "samsung".into())], 1))
+        );
+        assert_eq!(parse("/search/fulltext/samsung/pages/page-000.json"), None);
+        assert_eq!(parse("/search/fulltext/pages/page-001.json"), None);
+    }
+
+    #[test]
+    fn by_lei_explains_itself_instead_of_listing_nothing() {
+        assert_eq!(parse("/by-lei/_README.md"), Some(Node::ByLeiReadme));
+        // The two things a caller needs next: how to address an entity, and where an
+        // LEI comes from. Pinned because an empty listing is the failure this replaces.
+        assert!(BY_LEI_README.contains("/by-lei/<LEI>/"));
+        assert!(BY_LEI_README.contains("/search/"));
+        // `ownedBy` is the child query and reads backwards, so the note says so.
+        assert!(BY_LEI_README.contains("ownedBy"));
+    }
+
+    #[test]
+    fn results_hang_off_pages_not_off_the_query() {
+        let q = "/search/entity.legalAddress.country/KR";
+        assert!(matches!(parse(q), Some(Node::Query(_))));
+        assert!(matches!(parse(&format!("{q}/pages")), Some(Node::Pages(_))));
+        // `pages` only follows a complete query, never a field with no value.
+        assert_eq!(parse("/search/fulltext/pages"), None);
+        // And a page never hangs directly off the query.
+        assert_eq!(parse(&format!("{q}/page-001.json")), None);
+    }
+
+    /// The design claim, checked rather than asserted in prose: walking down a
+    /// narrowing chain asks the API nothing.
+    ///
+    /// No network and no mount, because none is needed — if any of these listings
+    /// sent a request the counter would say so, and the test would fail offline too.
+    #[tokio::test]
+    async fn narrowing_sends_no_requests() {
+        let fs = GleifFs::new();
+        for p in [
+            "/",
+            "/by-lei",
+            "/search",
+            "/search/entity.legalAddress.country",
+            "/search/entity.legalAddress.country/KR",
+            "/search/entity.legalAddress.country/KR/entity.status",
+            "/search/entity.legalAddress.country/KR/entity.status/ACTIVE",
+            "/search/entity.legalAddress.country/KR/entity.status/ACTIVE/entity.category/FUND",
+        ] {
+            fs.list(Path::new(p))
+                .await
+                .unwrap_or_else(|e| panic!("list {p}: {e}"));
+            fs.stat(Path::new(p)).await.unwrap_or_else(|e| panic!("stat {p}: {e}"));
+        }
+        assert_eq!(fs.calls(), 0, "narrowing sent a request");
+
+        // The note is written here too, so reading it is also free.
+        let mut buf = [0u8; 64];
+        fs.read_at(Path::new("/by-lei/_README.md"), &mut buf, 0)
+            .await
+            .expect("read _README.md");
+        assert_eq!(fs.calls(), 0, "reading a file written here sent a request");
+    }
+
+    /// The whole chain, for real: a tree served over FUSE, read with `std::fs`.
+    ///
+    /// Ignored by default — it mounts a filesystem and talks to GLEIF, neither of
+    /// which belongs in a plain `cargo test`. Run it with
+    /// `cargo test -p company_analysis --bins mounts_and_reads -- --ignored --nocapture`.
+    ///
+    /// Not a `#[tokio::test]`: the binding serves the store from its own thread on its
+    /// own runtime, and the reads below go through the kernel. Blocking a test runtime
+    /// on a mount that is waiting for that runtime is how this deadlocks.
+    #[test]
+    #[ignore = "needs a FUSE mount and network"]
+    fn mounts_and_reads() {
+        use cortex::fs::{FuseTMount, Mount};
+        use std::fs;
+
+        let fs_arc = Arc::new(GleifFs::new());
+        let dir = std::env::temp_dir().join("ailoy-gleif-mount-test");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("mountpoint");
+
+        let mount = FuseTMount::try_new(fs_arc.clone(), &dir).expect("mount");
+        let root = mount.mountpoint().to_path_buf();
+
+        let names = |p: &std::path::Path| {
+            let mut v: Vec<String> = fs::read_dir(p)
+                .unwrap_or_else(|e| panic!("read_dir {}: {e}", p.display()))
+                .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
+            v.sort();
+            v
+        };
+
+        assert_eq!(names(&root), ["CATALOG.md", "by-lei", "search"]);
+        // The tree carries its own entry point, so an agent told to read
+        // `<data>/CATALOG.md` finds one whether the store is on disk or on the wire.
+        let catalog = fs::read_to_string(root.join("CATALOG.md")).expect("catalog");
+        assert!(catalog.contains("AND is a directory, OR is a comma"));
+        assert_eq!(names(&root.join("by-lei")), ["_README.md"]);
+
+        let note = fs::read_to_string(root.join("by-lei/_README.md")).expect("note");
+        assert!(note.contains("addressed, not listed"));
+
+        // Narrowing, through the kernel this time.
+        let q = root.join("search/entity.legalAddress.country/KR/entity.status/ACTIVE");
+        assert!(names(&q).contains(&"pages".to_string()));
+        assert_eq!(fs_arc.calls(), 0, "narrowing sent a request");
+
+        // The one listing that has to ask — and it asks exactly once, because it names
+        // only the page it already holds.
+        let pages = names(&q.join("pages"));
+        assert_eq!(pages, ["_README.md", "page-001.json"]);
+        assert_eq!(fs_arc.calls(), 1, "listing the pages took more than one request");
+
+        // And the page it asked with is the page we read, so this is still one request.
+        let page = q.join("pages/page-001.json");
+        let size = fs::metadata(&page).expect("metadata").len();
+        let body = fs::read(&page).expect("read page");
+        assert_eq!(fs_arc.calls(), 1, "a page already held was fetched again");
+        assert_eq!(
+            body.len() as u64, size,
+            "the size stat reported and the bytes read disagree — the cache did not hold"
+        );
+
+        let doc: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert!(doc["data"].as_array().is_some_and(|a| !a.is_empty()));
+        // The page itself says how many there are, which is why the listing need not.
+        let last = doc["meta"]["pagination"]["lastPage"].as_u64().unwrap_or(0);
+        assert!(last > 1, "this check is only meaningful on a query with several pages");
+        // A page that was never listed is still readable by name.
+        let second = fs::read(q.join("pages/page-002.json")).expect("read page 2");
+        assert!(!second.is_empty());
+        assert_eq!(fs_arc.calls(), 2, "opening a page by name took more than one request");
+
+        println!(
+            "lastPage={last} first={} calls={}",
+            doc["data"][0]["id"].as_str().unwrap_or("?"),
+            fs_arc.calls()
+        );
+
+        drop(mount); // dropping unmounts, which is the contract
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_key_is_order_insensitive() {
+        let a = parse("/search/entity.status/ACTIVE/fulltext/x/pages/page-002.json").unwrap();
+        let b = parse("/search/fulltext/x/entity.status/ACTIVE/pages/page-002.json").unwrap();
+        assert_ne!(a, b, "the two paths differ");
+        assert_eq!(node_key(&a), node_key(&b), "but they are the same request");
+    }
+
+    #[test]
+    fn a_value_can_carry_a_slash_when_encoded() {
+        let q = parse("/search/entity.legalName/A%2FB").unwrap();
+        assert_eq!(
+            q,
+            Node::Query(vec![("entity.legalName".into(), "A/B".into())])
+        );
+        let Node::Query(pairs) = &q else { unreachable!() };
+        assert!(GleifFs::query_url(pairs, 1, 1).contains("A%2FB"));
+    }
+}

--- a/examples/company_analysis/src/guard.rs
+++ b/examples/company_analysis/src/guard.rs
@@ -1,0 +1,101 @@
+//! Where a run is allowed to write.
+//!
+//! The stores under `live/` refuse writes themselves, so nothing here needs to guard
+//! them. What is left is the ordinary part of the tree: the directory the mounts sit
+//! in, and everything else the session can see. An agent told to write only under
+//! `artifacts/` and `workspace/` might still not, and this is what notices.
+//!
+//! Detection rather than prevention, because commands run on the host with the
+//! session's own rights. Saying that plainly is the point — a check described as
+//! enforcement would be believed.
+
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Result, bail};
+
+/// The directories a run may write into.
+pub struct WriteBoundary {
+    allowed: Vec<PathBuf>,
+}
+
+impl WriteBoundary {
+    pub fn new(allowed: impl IntoIterator<Item = PathBuf>) -> Self {
+        Self {
+            allowed: allowed.into_iter().map(|p| normalize(&p)).collect(),
+        }
+    }
+
+    /// Whether `path` falls inside one of the allowed directories.
+    pub fn permits(&self, path: &Path) -> bool {
+        let p = normalize(path);
+        self.allowed.iter().any(|a| p.starts_with(a))
+    }
+
+    /// Like [`permits`](Self::permits), but says which path and against what.
+    pub fn check(&self, path: &Path) -> Result<()> {
+        if !self.permits(path) {
+            bail!(
+                "{} is outside the writable set {:?}",
+                path.display(),
+                self.allowed
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Fold `.` and `..` by hand, without asking the filesystem.
+///
+/// [`canonicalize`](std::fs::canonicalize) would be the obvious way and cannot be used:
+/// it fails on a path that does not exist yet, and the paths being checked are mostly
+/// files a run is about to create. Resolving textually also means a `..` cannot escape
+/// by pointing through a symlink the check never sees.
+fn normalize(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for c in p.components() {
+        match c {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn boundary() -> WriteBoundary {
+        WriteBoundary::new([PathBuf::from("./artifacts/run-1"), PathBuf::from("./workspace/run-1")])
+    }
+
+    #[test]
+    fn a_path_inside_is_permitted() {
+        let b = boundary();
+        assert!(b.permits(Path::new("artifacts/run-1/report.md")));
+        assert!(b.permits(Path::new("./artifacts/run-1/queries/01.py")));
+        assert!(b.permits(Path::new("workspace/run-1/scratch.json")));
+    }
+
+    #[test]
+    fn traversal_and_siblings_are_refused() {
+        let b = boundary();
+        // The obvious escape.
+        assert!(!b.permits(Path::new("artifacts/run-1/../../etc/passwd")));
+        // And the one that looks like the allowed directory without being under it.
+        assert!(!b.permits(Path::new("artifacts/run-10/report.md")));
+        assert!(!b.permits(Path::new("live/gleif/CATALOG.md")));
+        assert!(b.check(Path::new("/tmp/elsewhere")).is_err());
+    }
+
+    #[test]
+    fn a_path_that_does_not_exist_is_still_checkable() {
+        // The whole reason for folding `..` textually: nothing here is on disk, and
+        // `canonicalize` would fail rather than answer.
+        let b = boundary();
+        assert!(b.permits(Path::new("artifacts/run-1/not/created/yet.md")));
+    }
+}

--- a/examples/company_analysis/src/guard.rs
+++ b/examples/company_analysis/src/guard.rs
@@ -50,7 +50,7 @@ impl WriteBoundary {
 /// it fails on a path that does not exist yet, and the paths being checked are mostly
 /// files a run is about to create. Resolving textually also means a `..` cannot escape
 /// by pointing through a symlink the check never sees.
-fn normalize(p: &Path) -> PathBuf {
+pub fn normalize(p: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for c in p.components() {
         match c {

--- a/examples/company_analysis/src/main.rs
+++ b/examples/company_analysis/src/main.rs
@@ -1,0 +1,627 @@
+//! Ask a question about a company, get an answer with its sources attached.
+//!
+//! ```sh
+//! cargo run -p company_analysis -- --preset entity-profile --company "Samsung Electronics"
+//! cargo run -p company_analysis -- --task "Who owns Alphabet's subsidiaries?"
+//! ```
+//!
+//! The registries are not copied here. Each is a [`cortex::fs::FileSystem`] answered by
+//! its API and mounted, so a `read` is a request and a listing is what the registry says
+//! now. The built-in file tools are the only interface the agent gets.
+
+mod apifs;
+mod edgar;
+mod gleif;
+mod guard;
+mod prompt;
+
+use std::path::{Path, PathBuf};
+
+use ailoy::{
+    agent::AgentBuilder,
+    console::Console,
+    lang_model::get_lm_providers_mut,
+    message::{Message, Part, Role, TokenUsage},
+};
+use anyhow::{Context, Result, bail};
+use futures::StreamExt;
+
+use crate::{
+    edgar::EdgarFs,
+    gleif::GleifFs,
+    guard::WriteBoundary,
+    prompt::{Paths, Preset},
+};
+
+const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-5";
+
+/// Commands run on the host. The mounts being read-only is the stores' doing, not this
+/// process's, and everything outside them is covered by [`WriteBoundary`] after the
+/// fact rather than before.
+const CONSOLE_PROGRAM: &str = "cortex-local-console";
+
+/// What the mountpoint says about itself, written beside the two mounts.
+///
+/// Each store serves its own catalogue at its own root, but the instruction sends the
+/// agent to the catalogue above them, and that path is a plain directory — the one
+/// place in this tree that no store answers for.
+const LIVE_CATALOG: &str = r#"# Two registries, mounted side by side
+
+    gleif/     the Global LEI Index — legal entities, and who owns whom
+    edgar/     SEC filings — US registrants, their disclosures and XBRL facts
+
+Each has its own `CATALOG.md`. Read the one for the registry you need: they do not
+share a path grammar by accident, but they do differ in what a search gives back.
+
+## There is no reliable key between them
+
+GLEIF's identifier is the LEI and EDGAR's is the CIK, and neither registry carries the
+other's. `submissions.json` has an `lei` field that is almost always null — fifteen
+registrants sampled across the ticker list had it empty, every one. EIN does not bridge
+either, because GLEIF records whatever the local registration authority issued, which
+for a US entity is a state filing number or an SEC series id rather than the EIN.
+
+So crossing between them means **matching on a name**, and a name match is a candidate
+rather than a fact. Legal-form suffixes differ, holding companies share words with
+their subsidiaries, and funds are named after the companies they track — a search for
+NVIDIA returns a fund before it returns the manufacturer. Confirm a match against
+something else (country, address, registration date) and say in the report that the two
+records were joined by name.
+
+## What neither covers
+
+Financial statements for a non-US company, sanctions, litigation, news. A question that
+needs those has no answer here, and saying so is the answer.
+"#;
+
+struct Args {
+    task: Option<String>,
+    preset: Option<Preset>,
+    company: Option<String>,
+    since: Option<PathBuf>,
+    out: PathBuf,
+    workspace: PathBuf,
+    model: String,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut a = Args {
+        task: None,
+        preset: None,
+        company: None,
+        since: None,
+        out: PathBuf::from("./artifacts"),
+        workspace: PathBuf::from("./workspace"),
+        model: DEFAULT_MODEL.to_string(),
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let mut value = || {
+            it.next()
+                .ok_or_else(|| anyhow::anyhow!("{flag} needs a value"))
+        };
+        match flag.as_str() {
+            "--task" => a.task = Some(value()?),
+            "--task-file" => {
+                let p = value()?;
+                a.task = Some(std::fs::read_to_string(&p).with_context(|| format!("read {p}"))?);
+            }
+            "--preset" => {
+                let v = value()?;
+                a.preset = Some(Preset::parse(&v).ok_or_else(|| {
+                    anyhow::anyhow!("unknown preset '{v}' (one of: {})", Preset::ALL.join(", "))
+                })?);
+            }
+            "--company" => a.company = Some(value()?),
+            "--since" => a.since = Some(PathBuf::from(value()?)),
+            "--out" => a.out = PathBuf::from(value()?),
+            "--workspace" => a.workspace = PathBuf::from(value()?),
+            "--model" => a.model = value()?,
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => bail!("unknown argument '{other}' (see --help)"),
+        }
+    }
+    if a.task.is_none() && a.preset.is_none() {
+        bail!("one of --task or --preset is required (see --help)");
+    }
+    if a.preset.is_some() && a.company.is_none() {
+        bail!("a preset needs --company");
+    }
+    Ok(a)
+}
+
+fn print_help() {
+    println!(
+        "\
+company_analysis — an agent over two mounted company registries
+
+  --task <sentence>    a question in your own words
+  --task-file <path>   the same, read from a file
+  --preset <name>      {presets}
+  --company <name>     the subject, required by every preset
+  --since <findings>   a previous run's findings.json; the report then covers changes
+  --out <path>         default ./artifacts
+  --workspace <path>   default ./workspace
+  --model <id>         default {DEFAULT_MODEL}
+
+Environment:
+  ANTHROPIC_API_KEY      or whichever key the chosen model's provider wants
+  SEC_USER_AGENT         required: SEC answers 403 to a User-Agent naming no contact,
+                         e.g. 'company-analysis you@example.com'
+  AILOY_CORTEX_CONSOLE   path to the console server binary, if it is not on PATH
+
+Mounting needs a libfuse provider at build time; see the README.",
+        presets = Preset::ALL.join(" | "),
+    );
+}
+
+/// `1787539333-alphabet-entity-profile`. Unique per run, so the epoch goes in front.
+/// Seconds rather than a date because a date needs a formatting crate and this does not.
+fn run_slug(args: &Args) -> String {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let label = args
+        .preset
+        .map(|p| p.slug().to_string())
+        .unwrap_or_else(|| "adhoc".to_string());
+    match args.company.as_deref().map(slugify).filter(|s| !s.is_empty()) {
+        Some(c) => format!("{stamp}-{c}-{label}"),
+        None => format!("{stamp}-{label}"),
+    }
+}
+
+/// Non-alphanumerics become `-`, and runs of them collapse to one.
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            out.extend(c.to_lowercase());
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+/// Token usage across the run.
+///
+/// Anthropic-shaped APIs report the whole conversation as each call's `input_tokens`,
+/// so the sum is not a count of distinct tokens — it is what was billed. How large the
+/// conversation grew is a separate question, which `peak_input` answers.
+#[derive(Default)]
+struct Usage {
+    calls: usize,
+    input: u64,
+    output: u64,
+    cache_read: u64,
+    cache_write: u64,
+    peak_input: u64,
+}
+
+impl Usage {
+    fn add(&mut self, u: Option<&TokenUsage>) {
+        let Some(u) = u else { return };
+        self.calls += 1;
+        self.input += u.input_tokens;
+        self.output += u.output_tokens;
+        self.cache_read += u.cache_read_input_tokens.unwrap_or(0);
+        self.cache_write += u.cache_creation_input_tokens.unwrap_or(0);
+        self.peak_input = self.peak_input.max(u.input_tokens);
+    }
+}
+
+impl std::fmt::Display for Usage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.calls == 0 {
+            return f.write_str("tokens: unknown (the provider reported no usage)");
+        }
+        write!(
+            f,
+            "tokens ({} calls): in {} / out {}",
+            self.calls,
+            thousands(self.input),
+            thousands(self.output)
+        )?;
+        if self.cache_read > 0 || self.cache_write > 0 {
+            write!(
+                f,
+                " / cache read {} / cache write {}",
+                thousands(self.cache_read),
+                thousands(self.cache_write)
+            )?;
+        }
+        write!(
+            f,
+            "\n  largest context {} (the conversation at its last call)",
+            thousands(self.peak_input)
+        )
+    }
+}
+
+/// `1234567` → `1,234,567`.
+fn thousands(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// The guards and the stores behind them. Dropping this unmounts both.
+struct Live {
+    _mounts: (cortex::fs::FuseTMount, cortex::fs::FuseTMount),
+    gleif: std::sync::Arc<GleifFs>,
+    edgar: std::sync::Arc<EdgarFs>,
+}
+
+/// Mount the two registries under `at`.
+///
+/// Two mounts rather than one router: a mount point is what a kernel already uses to
+/// join trees, so dispatching on the first path segment would be code for something the
+/// OS does. The cost is that `at` itself stays an ordinary directory — writes there are
+/// caught by [`WriteBoundary`] rather than refused, which is a narrower claim than the
+/// mounts make about themselves, and the run summary says so.
+/// Where the registries are mounted, deliberately outside the working tree.
+///
+/// A file here is a paid request and anything that walks a directory opens every file in
+/// it, so an editor or terminal indexing the project spends hundreds of requests that no
+/// command asked for. Not a flag: a mountpoint a caller could put back under a watched
+/// directory is that cost waiting to return.
+fn mountpoint() -> PathBuf {
+    std::env::temp_dir().join("ailoy-company-analysis")
+}
+
+fn mount_live(at: &Path) -> Result<Live> {
+    let gleif_dir = at.join("gleif");
+    let edgar_dir = at.join("edgar");
+    std::fs::create_dir_all(&gleif_dir)?;
+    std::fs::create_dir_all(&edgar_dir)?;
+    std::fs::write(at.join("CATALOG.md"), LIVE_CATALOG)?;
+
+    // Required rather than defaulted: SEC answers 403 with an HTML page to a
+    // `User-Agent` that names no contact, and a default would only move the failure to
+    // the first read — where it arrives as a JSON syntax error rather than as this.
+    let ua = std::env::var("SEC_USER_AGENT").map_err(|_| {
+        anyhow::anyhow!(
+            "SEC_USER_AGENT is required. SEC refuses a User-Agent that names no contact.\n\
+             Example: SEC_USER_AGENT='company-analysis you@example.com'"
+        )
+    })?;
+
+    let gleif = std::sync::Arc::new(GleifFs::new());
+    let edgar = std::sync::Arc::new(EdgarFs::new(&ua));
+    let mounts = (
+        cortex::fs::FuseTMount::try_new(gleif.clone(), &gleif_dir)
+            .with_context(|| format!("mounting {}", gleif_dir.display()))?,
+        cortex::fs::FuseTMount::try_new(edgar.clone(), &edgar_dir)
+            .with_context(|| format!("mounting {}", edgar_dir.display()))?,
+    );
+    Ok(Live {
+        _mounts: mounts,
+        gleif,
+        edgar,
+    })
+}
+
+/// Built-in tools do not run without a console server.
+///
+/// The binary lives in the `cortex` checkout rather than on `PATH`, so its location can
+/// be named. No mount is declared here: this server takes its own working directory as
+/// the session's, and that is already the tree.
+async fn console() -> Result<Console> {
+    let program =
+        std::env::var("AILOY_CORTEX_CONSOLE").unwrap_or_else(|_| CONSOLE_PROGRAM.to_string());
+    let mut console = Console::builder()
+        .stdio_client(&[&program])
+        .build()
+        .await
+        .with_context(|| {
+            format!(
+                "could not start the console server '{program}'. Build it in the cortex \
+                 checkout with `cargo build -p {CONSOLE_PROGRAM}` and point \
+                 $AILOY_CORTEX_CONSOLE at the binary."
+            )
+        })?;
+    console.start().await.context("starting the console")?;
+    Ok(console)
+}
+
+/// Fail before assembly rather than at the first call, where the cause is harder to see.
+fn ensure_provider(model: &str) -> Result<()> {
+    let providers = get_lm_providers_mut();
+    let default = providers
+        .get("default")
+        .expect("the default provider always exists");
+    if default.get(model).is_some() {
+        return Ok(());
+    }
+    bail!(
+        "no provider is registered for model '{model}'. Set the API key its provider \
+         reads (ANTHROPIC_API_KEY for anthropic/*) in the repository's .env or the \
+         environment."
+    )
+}
+
+fn build_task(args: &Args) -> Result<String> {
+    let mut task = match (&args.task, args.preset) {
+        (Some(t), _) => t.clone(),
+        (None, Some(p)) => p.task(args.company.as_deref().unwrap_or("")),
+        (None, None) => unreachable!("parse_args rejects this"),
+    };
+    if let Some(since) = &args.since {
+        let prev = std::fs::read_to_string(since)
+            .with_context(|| format!("reading the previous findings {}", since.display()))?;
+        task.push_str("\n\n# The previous run's findings — report what changed\n\n```json\n");
+        task.push_str(&prev);
+        task.push_str("\n```\n");
+    }
+    Ok(task)
+}
+
+fn list_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            out.extend(list_files(&p));
+        } else {
+            out.push(p);
+        }
+    }
+    out.sort();
+    out
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // The crate reads `.env` only under `#[cfg(test)]`, so a run has to ask.
+    dotenvy::dotenv().ok();
+    let args = parse_args()?;
+    ensure_provider(&args.model)?;
+
+    // Only what the run writes. The console's root is a place to stand rather than a
+    // confinement, so the read-only mounts are reachable from outside it — see
+    // [`mountpoint`].
+    let tree = std::env::current_dir()?.canonicalize()?;
+    for (label, path) in [("--out", &args.out), ("--workspace", &args.workspace)] {
+        if !tree.join(path).starts_with(&tree) {
+            bail!(
+                "{label} {} is outside the session tree {}",
+                path.display(),
+                tree.display()
+            );
+        }
+    }
+
+    let mountpoint = mountpoint();
+    std::fs::create_dir_all(&mountpoint)?;
+    // Held to the end of `main`: the guard is the mount, and dropping it unmounts.
+    let live = mount_live(&mountpoint)?;
+
+    let slug = run_slug(&args);
+    let artifacts_dir = args.out.join(&slug);
+    let workspace_dir = args.workspace.join(&slug);
+    std::fs::create_dir_all(&artifacts_dir)?;
+    std::fs::create_dir_all(&workspace_dir)?;
+
+    let boundary = WriteBoundary::new([artifacts_dir.clone(), workspace_dir.clone()]);
+    boundary.check(&artifacts_dir.join("report.md"))?;
+
+    let task = build_task(&args)?;
+    let paths = Paths {
+        data: &mountpoint.to_string_lossy(),
+        workspace: &args.workspace.to_string_lossy(),
+        artifacts: &args.out.to_string_lossy(),
+    };
+    let instruction = prompt::instruction(&paths, args.preset, &slug);
+
+    let mut agent = AgentBuilder::new(&args.model)
+        .instruction(instruction)
+        .system_tools()
+        .python_repl_tool()
+        .console(console().await?)
+        .build()
+        .context("assembling the agent")?;
+
+    println!("model    {}", args.model);
+    println!("console  {CONSOLE_PROGRAM} (on the host — writes outside the mounts are detected, not refused)");
+    println!("mounts   {}/{{gleif,edgar}}", mountpoint.display());
+    println!("tree     {}", tree.display());
+    println!("run      {slug}\n");
+
+    let mut turns = 0usize;
+    let mut tool_calls = 0usize;
+    // Requests already billed, so each call can be charged for its own.
+    let mut spent = (0usize, 0usize);
+    let mut usage = Usage::default();
+    // The loop ends the moment a finish reason is not a tool call. When nothing was
+    // produced, this is the only clue as to why.
+    let mut last_finish = None;
+    let mut stream = agent.run(Message::new(Role::User).with_contents([Part::text(task)]));
+    while let Some(output) = stream.next().await {
+        let output = output?;
+        turns += 1;
+        if output.message.role == Role::Assistant {
+            last_finish = Some(format!("{:?}", output.finish_reason));
+        }
+        for part in &output.message.contents {
+            if let Part::Text { text } = part {
+                if output.message.role == Role::Assistant {
+                    println!("{text}");
+                }
+            }
+        }
+        if let Some(calls) = output.message.tool_calls.as_ref() {
+            for c in calls {
+                let ailoy::message::Part::Function { function: f, .. } = c else {
+                    continue;
+                };
+                // The id names nothing the reader needs and crowds out the arguments.
+                let args = f
+                    .arguments
+                    .as_object()
+                    .map(|o| {
+                        o.iter()
+                            .map(|(k, v)| match v.as_str() {
+                                Some(t) => format!("{k}={t}"),
+                                None => format!("{k}={v:?}"),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("  ")
+                    })
+                    .unwrap_or_else(|| format!("{:?}", f.arguments));
+                let one = args.replace('\n', " ⏎ ");
+                let shown = match one.char_indices().nth(200) {
+                    Some((i, _)) => format!("{}…", &one[..i]),
+                    None => one,
+                };
+                // Charged per call, so the cost lands on the command that caused it.
+                let (g, e) = (live.gleif.calls(), live.edgar.calls());
+                let (dg, de) = (g - spent.0, e - spent.1);
+                spent = (g, e);
+                let cost = match (dg, de) {
+                    (0, 0) => String::new(),
+                    (a, 0) => format!(" [gleif +{a}]"),
+                    (0, b) => format!(" [edgar +{b}]"),
+                    (a, b) => format!(" [gleif +{a} edgar +{b}]"),
+                };
+                println!("  → {:<12} {shown}{cost}", f.name);
+            }
+        }
+        tool_calls += output.message.tool_calls.as_ref().map_or(0, |c| c.len());
+        usage.add(output.usage.as_ref());
+    }
+    drop(stream);
+
+    let written = list_files(&artifacts_dir);
+    println!("\n--- run summary ---");
+    println!("turns {turns} / tool calls {tool_calls}");
+    println!("{usage}");
+    println!(
+        "requests  gleif {} / edgar {}",
+        live.gleif.calls(),
+        live.edgar.calls()
+    );
+    // A total says a run was expensive; this says what it bought.
+    for (store, rows) in [
+        ("gleif", live.gleif.breakdown()),
+        ("edgar", live.edgar.breakdown()),
+    ] {
+        if rows.is_empty() {
+            continue;
+        }
+        let detail: Vec<String> = rows.iter().map(|(k, n)| format!("{k} ×{n}")).collect();
+        println!("  {store:<6}  {}", detail.join(", "));
+        let (hot, distinct) = match store {
+            "gleif" => (live.gleif.hot_keys(3), live.gleif.distinct_keys()),
+            _ => (live.edgar.hot_keys(3), live.edgar.distinct_keys()),
+        };
+        println!("          {distinct} distinct paths; heaviest:");
+        for (k, n) in hot {
+            println!("            {n:>4} × {k}");
+        }
+    }
+    println!(
+        "finish    {}",
+        last_finish.as_deref().unwrap_or("(no assistant message)")
+    );
+    println!("artifacts {}:", written.len());
+    for p in &written {
+        println!("  {}", p.display());
+    }
+
+    let escaped: Vec<_> = written.iter().filter(|p| !boundary.permits(p)).collect();
+    if !escaped.is_empty() {
+        println!("write boundary: **violated** {escaped:?}");
+        bail!("a write left the allowed directories");
+    }
+
+    // Not "did anything appear" but "did the report appear". A run that left query
+    // files and stopped is not a run that answered.
+    if !written
+        .iter()
+        .any(|p| p.file_name().is_some_and(|n| n == "report.md"))
+    {
+        bail!(
+            "no report.md ({} artifacts, finish {}). `Length` means the cap was hit; \
+             `Stop` means the turn ended on a promise to write rather than a write.",
+            written.len(),
+            last_finish.as_deref().unwrap_or("?")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_collapses_runs_and_keeps_letters() {
+        assert_eq!(slugify("Acme Materials Co., Ltd."), "acme-materials-co-ltd");
+        // GLEIF records a legal name in its own script, so a company argument often is
+        // not Latin. Dropping those characters would leave runs named after their
+        // punctuation.
+        assert_eq!(slugify("金河化学工业有限公司"), "金河化学工业有限公司");
+        assert_eq!(slugify("株式会社 柏商事"), "株式会社-柏商事");
+        assert_eq!(slugify("---"), "");
+    }
+
+    #[test]
+    fn thousands_groups_from_the_right() {
+        for (n, want) in [
+            (0, "0"),
+            (7, "7"),
+            (100, "100"),
+            (1_000, "1,000"),
+            (1_234_567, "1,234,567"),
+        ] {
+            assert_eq!(thousands(n), want, "{n}");
+        }
+    }
+
+    #[test]
+    fn usage_sums_what_was_billed_and_tracks_the_peak() {
+        let mut u = Usage::default();
+        u.add(Some(&TokenUsage {
+            input_tokens: 1_000,
+            output_tokens: 50,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(900),
+        }));
+        u.add(Some(&TokenUsage {
+            input_tokens: 12_345,
+            output_tokens: 60,
+            cache_creation_input_tokens: Some(11),
+            cache_read_input_tokens: None,
+        }));
+        u.add(None); // a tool result carries no usage and is not a call
+        assert_eq!(u.calls, 2);
+        assert_eq!(u.input, 13_345);
+        assert_eq!(u.output, 110);
+        assert_eq!(u.cache_read, 900);
+        assert_eq!(u.cache_write, 11);
+        // Not the sum: the conversation was this big once, not thirteen thousand times.
+        assert_eq!(u.peak_input, 12_345);
+        assert!(u.to_string().contains("13,345"));
+    }
+
+    #[test]
+    fn a_missing_key_names_the_variable() {
+        // The message has to say which variable, or a first run stalls on guesswork.
+        let e = ensure_provider("nosuchprovider/model").unwrap_err().to_string();
+        assert!(e.contains("ANTHROPIC_API_KEY"), "{e}");
+    }
+}

--- a/examples/company_analysis/src/main.rs
+++ b/examples/company_analysis/src/main.rs
@@ -272,10 +272,10 @@ struct Live {
 /// mounts make about themselves, and the run summary says so.
 /// Where the registries are mounted, deliberately outside the working tree.
 ///
-/// A file here is a paid request and anything that walks a directory opens every file in
-/// it, so an editor or terminal indexing the project spends hundreds of requests that no
-/// command asked for. Not a flag: a mountpoint a caller could put back under a watched
-/// directory is that cost waiting to return.
+/// Not for the request cost — no directory in either store can be walked into, so an
+/// editor or an indexer finds only the two notes written here. For the mount itself: a
+/// signal does not run destructors, so a killed run leaves one behind, and a stale mount
+/// inside the repository stops anything that walks it. `git status` is one of those.
 fn mountpoint() -> PathBuf {
     std::env::temp_dir().join("ailoy-company-analysis")
 }

--- a/examples/company_analysis/src/main.rs
+++ b/examples/company_analysis/src/main.rs
@@ -369,18 +369,60 @@ fn build_task(args: &Args) -> Result<String> {
 
 fn list_files(dir: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
+    walk(dir, &[], &mut out);
+    out.sort();
+    out
+}
+
+/// Every file under `dir`, except below anything in `skip`.
+///
+/// `skip` is not an optimisation. Two of its entries are the mountpoints, and walking
+/// one of those is a request per registrant — the boundary would pay the registries to
+/// tell it what it already knows, that they refuse writes.
+fn walk(dir: &Path, skip: &[PathBuf], out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return out;
+        return;
     };
     for e in entries.flatten() {
         let p = e.path();
+        if skip.iter().any(|s| p == *s) {
+            continue;
+        }
         if p.is_dir() {
-            out.extend(list_files(&p));
+            walk(&p, skip, out);
         } else {
             out.push(p);
         }
     }
+}
+
+/// Files the run wrote that the boundary does not allow.
+///
+/// Everything the session can reach and touched since `since`, minus what the boundary
+/// permits. Modification time is what separates a run's writes from the tree it was
+/// dropped into; without it every source file in the repository would read as a
+/// violation.
+fn writes_outside(
+    roots: &[PathBuf],
+    skip: &[PathBuf],
+    since: std::time::SystemTime,
+    boundary: &WriteBoundary,
+) -> Vec<PathBuf> {
+    let mut seen = Vec::new();
+    for r in roots {
+        walk(r, skip, &mut seen);
+    }
+    let mut out: Vec<PathBuf> = seen
+        .into_iter()
+        .filter(|p| !boundary.permits(p))
+        .filter(|p| {
+            std::fs::metadata(p)
+                .and_then(|m| m.modified())
+                .is_ok_and(|m| m >= since)
+        })
+        .collect();
     out.sort();
+    out.dedup();
     out
 }
 
@@ -396,7 +438,9 @@ async fn main() -> Result<()> {
     // [`mountpoint`].
     let tree = std::env::current_dir()?.canonicalize()?;
     for (label, path) in [("--out", &args.out), ("--workspace", &args.workspace)] {
-        if !tree.join(path).starts_with(&tree) {
+        // Folded first: `join` leaves `..` in place and `starts_with` compares
+        // components, so `../../etc` would otherwise read as inside the tree.
+        if !guard::normalize(&tree.join(path)).starts_with(&tree) {
             bail!(
                 "{label} {} is outside the session tree {}",
                 path.display(),
@@ -440,6 +484,10 @@ async fn main() -> Result<()> {
     println!("mounts   {}/{{gleif,edgar}}", mountpoint.display());
     println!("tree     {}", tree.display());
     println!("run      {slug}\n");
+
+    // Everything the boundary will judge is what appeared after this point. Taken after
+    // the mounts and the run's own directories, so neither reads as a violation.
+    let started = std::time::SystemTime::now();
 
     let mut turns = 0usize;
     let mut tool_calls = 0usize;
@@ -542,9 +590,20 @@ async fn main() -> Result<()> {
         println!("  {}", p.display());
     }
 
-    let escaped: Vec<_> = written.iter().filter(|p| !boundary.permits(p)).collect();
+    // Not `written`: those come from the artifacts directory, which the boundary allows
+    // by construction, so checking them could only ever pass. What is worth checking is
+    // the rest of what the session could reach.
+    let escaped = writes_outside(
+        &[tree.clone(), mountpoint.clone()],
+        &[mountpoint.join("gleif"), mountpoint.join("edgar")],
+        started,
+        &boundary,
+    );
     if !escaped.is_empty() {
-        println!("write boundary: **violated** {escaped:?}");
+        println!("write boundary: **violated**");
+        for p in &escaped {
+            println!("  {}", p.display());
+        }
         bail!("a write left the allowed directories");
     }
 
@@ -566,6 +625,50 @@ async fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// `--out ../../etc` has to be refused. `join` leaves `..` in the path and
+    /// `starts_with` compares components, so without folding it reads as inside.
+    #[test]
+    fn a_relative_escape_is_outside_the_tree() {
+        let tree = PathBuf::from("/home/u/proj");
+        for p in ["../../etc", "./a/../../..", "a/../../b"] {
+            assert!(
+                !guard::normalize(&tree.join(p)).starts_with(&tree),
+                "{p} passed as inside"
+            );
+        }
+        for p in ["artifacts", "./artifacts/run-1", "a/../artifacts"] {
+            assert!(guard::normalize(&tree.join(p)).starts_with(&tree), "{p}");
+        }
+    }
+
+    /// A file written outside the allowed directories has to be reported. The check
+    /// used to run over the artifacts directory alone, which the boundary allows by
+    /// construction, so it could only ever pass.
+    #[test]
+    fn a_write_outside_the_allowed_directories_is_seen() {
+        let root = std::env::temp_dir().join(format!("ailoy-boundary-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let allowed = root.join("artifacts/run-1");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let boundary = WriteBoundary::new([allowed.clone()]);
+
+        let started = std::time::SystemTime::now();
+        std::fs::write(allowed.join("report.md"), "ok").unwrap();
+        std::fs::write(root.join("src/patched.rs"), "not ok").unwrap();
+
+        let escaped = writes_outside(&[root.clone()], &[], started, &boundary);
+        assert_eq!(escaped, vec![root.join("src/patched.rs")]);
+
+        // A file the run did not touch is not its doing.
+        let old = writes_outside(&[root.clone()], &[], std::time::SystemTime::now(), &boundary);
+        assert!(old.is_empty(), "{old:?}");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     use super::*;
 
     #[test]

--- a/examples/company_analysis/src/prompt.rs
+++ b/examples/company_analysis/src/prompt.rs
@@ -1,0 +1,260 @@
+//! The system instruction and the preset questions.
+//!
+//! Policy only. What the data looks like, how the paths are spelled and where the
+//! traps are belongs in the `CATALOG.md` each store serves, because the store is what
+//! knows — and because an instruction that repeated it would go stale the moment an
+//! API changed while the tree kept telling the truth.
+//!
+//! The line between the two is not "detail". It is: does this hold whatever the
+//! registries do today?
+
+use std::fmt;
+
+pub struct Paths<'a> {
+    pub data: &'a str,
+    pub workspace: &'a str,
+    pub artifacts: &'a str,
+}
+
+/// The questions this example ships with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Preset {
+    /// Who is this company, according to the registries themselves.
+    EntityProfile,
+    /// One company across both registries: do they agree, and where do they not.
+    CrossRegistry,
+    /// Who owns whom, as far as the disclosed relationships reach.
+    OwnershipTree,
+}
+
+impl Preset {
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "entity-profile" => Self::EntityProfile,
+            "cross-registry" => Self::CrossRegistry,
+            "ownership-tree" => Self::OwnershipTree,
+            _ => return None,
+        })
+    }
+
+    pub const ALL: [&'static str; 3] = ["entity-profile", "cross-registry", "ownership-tree"];
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::EntityProfile => "entity-profile",
+            Self::CrossRegistry => "cross-registry",
+            Self::OwnershipTree => "ownership-tree",
+        }
+    }
+
+    pub fn task(self, company: &str) -> String {
+        match self {
+            Self::EntityProfile => format!(
+                "Profile {company} from the registries: what the entity is, where it is \
+                 registered, what identifiers name it, and what it discloses about itself."
+            ),
+            Self::CrossRegistry => format!(
+                "Find {company} in both registries and compare what each says. Report where \
+                 they agree, where they differ, and how confident the match between the two \
+                 records is."
+            ),
+            Self::OwnershipTree => format!(
+                "Starting from {company}, follow the disclosed ownership relationships as far \
+                 as they go. Report the shape of the group and where the disclosure stops."
+            ),
+        }
+    }
+
+    /// The body of the report. Summary, limits and next steps are common to all three
+    /// and live in the instruction instead.
+    fn body_sections(self) -> &'static [&'static str] {
+        match self {
+            Self::EntityProfile => &[
+                "The entity",
+                "Identifiers and where each comes from",
+                "Registration and status",
+                "What the filings say",
+            ],
+            Self::CrossRegistry => &[
+                "The two records",
+                "How they were matched, and how sure that is",
+                "Where they agree",
+                "Where they disagree",
+            ],
+            Self::OwnershipTree => &[
+                "The group as disclosed",
+                "Direction of each relationship",
+                "Where the tree stops",
+                "What the shape does not tell you",
+            ],
+        }
+    }
+}
+
+impl fmt::Display for Preset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.slug())
+    }
+}
+
+/// The system instruction.
+pub fn instruction(paths: &Paths<'_>, preset: Option<Preset>, run_slug: &str) -> String {
+    let Paths {
+        data,
+        workspace,
+        artifacts,
+    } = paths;
+
+    let mut s = format!(
+        "\
+You are an analyst answering questions about companies from public registries.
+
+# Where you are
+
+- `{data}/` — the registries, mounted. **Read-only, and live: every file you open is a
+  request going out.** Nothing here is stored, so what you read is what the registry
+  says now.
+- `{workspace}/{run_slug}/` — scratch. Yours.
+- `{artifacts}/{run_slug}/` — the deliverables. Write nowhere else.
+
+# Start here
+
+**Read `{data}/CATALOG.md` first, then the `CATALOG.md` of whichever registry you
+need.** They describe how their paths are spelled, what can be listed and what cannot,
+and which mistakes cost a request for nothing. Guessing a path instead is how a run
+spends its budget on `ENOENT`.
+
+A directory that lists little is not a directory with little in it. Where a listing
+cannot be complete, the tree says so in a `_README.md` beside it — read that before
+concluding something is missing.
+
+Use `python_repl` for anything you compute. `read`, `glob`, `grep` and `shell` are for
+finding your way around.
+
+# Working method
+
+**Narrow before you fetch.** Descending a query costs nothing; opening its results
+costs a request. A narrower question is cheaper than paging through a broad one, and
+usually a better answer too.
+
+**Confirm identifiers, do not recall them.** If you already believe you know a
+company's number, check it against the tree anyway. A wrong identifier does not fail —
+it answers, with somebody else's record.
+
+**Write as you go.** Put the skeleton of `report.md` down before the first query and
+fill each section as its evidence lands. A run that saves everything for the end can
+lose everything at the end.
+
+**Say what you did, in the same turn.** If you write that you are about to produce
+something, call the tool that produces it now rather than ending the turn.
+
+# Rules
+
+**Cite.** Every figure carries the path it came from. A sentence you cannot source does
+not go in.
+
+**Absent is not zero.** Registries disagree about coverage; a field one of them lacks
+is not a fact about the company. Say the data does not carry it.
+
+**A name match is a candidate.** These registries share no reliable key, so crossing
+between them usually means matching on a name — and names collide, funds are named
+after the companies they track, and legal-form suffixes differ. Present such a match as
+`possible match — needs confirmation` and say what you checked it against.
+
+**Do not resolve ambiguity by picking.** If two entities could be the one asked about,
+report both and what separates them.
+
+**State the basis.** Different registries, dates and jurisdictions do not belong in one
+column without a note saying which is which.
+
+**Show the arithmetic.** If you score or rank something, the weights and the steps go
+in the report with it.
+
+# Deliverables
+
+Under `{artifacts}/{run_slug}/`:
+
+- `report.md` — for a person to read
+- `evidence.md` — each claim against the path that supports it, written from the mount
+  root down and without the `{data}` prefix, which is where this machine happens to
+  have put the mounts and means nothing to a reader elsewhere
+- `findings.json` — for a machine, schema below
+- `queries/` — the scripts you actually ran, as `01-*.py`
+
+`report.md` opens with a **Summary** of three to five lines that answers the question on
+its own, and closes with **Data limits** — coverage gaps, unconfirmed matches, anything
+a registry declined to say — and **Next steps**.
+"
+    );
+
+    if let Some(p) = preset {
+        s.push_str("\nBetween those, the body:\n\n");
+        for (i, sec) in p.body_sections().iter().enumerate() {
+            s.push_str(&format!("{}. {}\n", i + 1, sec));
+        }
+    } else {
+        s.push_str("\nBetween those, a body organised to fit the question.\n");
+    }
+
+    s.push_str(
+        "\n`findings.json` has a fixed schema, so two runs can be compared:\n\
+         `{ \"run_id\", \"task\", \"entities\": [], \
+         \"findings\": [{ \"severity\", \"statement\", \"evidence\": [], \"confidence\" }], \
+         \"data_gaps\": [] }`\n",
+    );
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths() -> Paths<'static> {
+        Paths {
+            data: "./live",
+            workspace: "./workspace",
+            artifacts: "./artifacts",
+        }
+    }
+
+    #[test]
+    fn presets_round_trip() {
+        for slug in Preset::ALL {
+            let p = Preset::parse(slug).expect(slug);
+            assert_eq!(p.slug(), slug);
+            assert!(!p.task("Acme").is_empty());
+        }
+        assert!(Preset::parse("nope").is_none());
+    }
+
+    #[test]
+    fn the_instruction_carries_policy_and_not_the_map() {
+        let s = instruction(&paths(), Some(Preset::OwnershipTree), "run-1");
+        assert!(s.contains("./live/CATALOG.md"));
+        assert!(s.contains("./artifacts/run-1/"));
+        assert!(s.contains("Read-only"));
+        assert!(s.contains("possible match — needs confirmation"));
+        assert!(s.contains("Write as you go"));
+
+        // Path grammar, field names and per-registry quirks belong to the stores, which
+        // serve them and can keep them true. Repeating any of it here would make the
+        // instruction a second source that drifts.
+        for leak in [
+            "by-lei", "by-cik", "by-ticker", "pages/", "ownedBy", "entity.legalAddress",
+            "submissions.json", "cik_str", "facts.json",
+        ] {
+            assert!(!s.contains(leak), "instruction spells out the tree: {leak}");
+        }
+    }
+
+    #[test]
+    fn each_preset_asks_for_its_own_body() {
+        let profile = instruction(&paths(), Some(Preset::EntityProfile), "run-1");
+        let cross = instruction(&paths(), Some(Preset::CrossRegistry), "run-1");
+        assert!(profile.contains("Registration and status"));
+        assert!(cross.contains("Where they disagree"));
+        assert!(!profile.contains("Where they disagree"));
+        assert!(!cross.contains("Registration and status"));
+    }
+}

--- a/examples/company_analysis/src/prompt.rs
+++ b/examples/company_analysis/src/prompt.rs
@@ -241,7 +241,7 @@ mod tests {
         // serve them and can keep them true. Repeating any of it here would make the
         // instruction a second source that drifts.
         for leak in [
-            "by-lei", "by-cik", "by-ticker", "pages/", "ownedBy", "entity.legalAddress",
+            "by-lei", "by-cik", "pages/", "ownedBy", "entity.legalAddress",
             "submissions.json", "cik_str", "facts.json",
         ] {
             assert!(!s.contains(leak), "instruction spells out the tree: {leak}");


### PR DESCRIPTION
## Description

> Details in [`examples/company_analysis/README.md`](https://github.com/brekkylab/ailoy/pull/446/changes#diff-5fe93a5f7820daeba2317fa63c1630e43c469064f9c40e97eb686b9765a5aef6);
> the decisions and the measurements behind them are in `examples/company_analysis/docs/design.html`.
> What follows is the short version.

Adds `examples/company_analysis` — an agent that answers a question about a company
against two public registries and cites the path behind every claim.

The point of the example is *how* the registries are reached. GLEIF and SEC EDGAR are
each a `cortex::fs::FileSystem` mounted over FUSE, so the agent's only interface is the
built-in file tools — no bespoke search tool, no client library. A `read` is an API call
and a listing is what the registry says at that moment; nothing is copied or stored.

A path is a query:

```
gleif/search/entity.legalAddress.country/KR/entity.status/ACTIVE/pages/
    filter[entity.legalAddress.country]=KR&filter[entity.status]=ACTIVE
```

Three rules shaped the tree:

- **Files cost, directories don't.** A directory read asks for every entry's size, and a
  document's size is unknowable without fetching it, so every fetchable document is
  wrapped in a directory of its own. Listing them flat cost 742 requests in one run.
- **Narrowing is free.** The filter fields are known locally, so descending a query
  sends nothing; the first request happens when `pages` is opened. Pinned by an offline
  test that walks a four-deep query and asserts the request count is zero.
- **Where a listing cannot be complete, it says so.** `by-lei` has no index to build one
  from, and `by-cik` would be a million zero-padded numbers nobody can read a company out
  of. Answering empty would read as "nothing here", so each holds a `_README.md` saying
  how to address one and where an identifier comes from.

## Verifying

```sh
cargo test -p company_analysis                                    # offline, 37 tests
SEC_USER_AGENT='...' cargo test -p company_analysis -- --ignored --test-threads=1
```

> [!NOTE]
> `--test-threads=1` is a workaround, not a property of the example: two mounts whose
> lifetimes overlap deadlock when they unmount. **That is a cortex-side issue and a fix is
> [in progress](https://github.com/brekkylab/cortex/tree/fuse-teardown)**; the flag can come off once it lands.

A live run (`--preset cross-registry --company NVIDIA`) resolves NVIDIA in both
registries in 32 tool calls and 8 requests, with every request attributed to the call
that caused it.
