### PR TITLE
memory applied

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -5,6 +5,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     agent::{Agent, AgentSpec, AgentState, ContextManager},
+    memory::Memory,
     message::Message,
     tool::{ToolDesc, WebSearchEngineKind},
 };
@@ -55,6 +56,8 @@ pub struct AgentBuilder {
 
     console: Option<Arc<Mutex<Option<Console>>>>,
 
+    memory: Option<Memory>,
+
     context_manager: Option<ContextManager>,
 }
 
@@ -69,6 +72,7 @@ impl AgentBuilder {
             agent_provider: "default".to_string(),
             history: Vec::new(),
             console: None,
+            memory: None,
             context_manager: None,
         }
     }
@@ -155,6 +159,25 @@ impl AgentBuilder {
         self
     }
 
+    /// Let this agent remember into `memory`.
+    ///
+    /// Which brings the `mem_search` and `mem_insert` tools with it: an agent that was
+    /// given a memory can recall from it and write to it, and one that was not has
+    /// neither tool. Nothing else has to be listed — these two are not spec tools,
+    /// because which store is a value this one agent holds rather than a name in the
+    /// [`ToolProvider`](crate::tool::ToolProvider).
+    ///
+    /// The store is expected to exist: `mem init` makes one. A file that is not there is
+    /// reported by the first memory tool call rather than by [`build`](Self::build),
+    /// since finding out means running a command on the console.
+    ///
+    /// Runs on the same console as every other tool, so an agent with a memory wants a
+    /// [`console`](Self::console) too — a memory tool without one fails saying so.
+    pub fn memory(mut self, memory: Memory) -> Self {
+        self.memory = Some(memory);
+        self
+    }
+
     /// Set the context window management spec.
     pub fn context_manager(mut self, spec: ContextManager) -> Self {
         self.context_manager = Some(spec);
@@ -191,12 +214,16 @@ impl AgentBuilder {
             agent_provider,
             history,
             console,
+            memory,
             context_manager,
         } = self;
 
         let mut state = AgentState::new();
         if let Some(c) = console {
             state = state.with_console_slot(c);
+        }
+        if let Some(m) = memory {
+            state = state.with_memory(m);
         }
         if !history.is_empty() {
             state = state.with_history(history);
@@ -367,5 +394,25 @@ mod tests {
         let history = agent.get_history();
         assert_eq!(history.len(), 2);
         assert_eq!(system_text(&agent).as_deref(), Some("stored instruction"));
+    }
+
+    /// `memory()` lands on the state, which is what the agent's constructor reads to
+    /// decide whether it hands out the memory tools.
+    #[tokio::test]
+    async fn test_builder_memory_is_applied() {
+        use crate::memory::Memory;
+
+        ensure_dummy_provider();
+        let agent = AgentBuilder::new(TEST_MODEL)
+            .agent_provider(TEST_PROVIDER_NAME)
+            .memory(Memory::new("/work/notes.sqlite"))
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            agent.state.memory,
+            Some(Memory::new("/work/notes.sqlite")),
+            "the memory the builder was given is the one on the state"
+        );
     }
 }

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -173,8 +173,8 @@ impl AgentBuilder {
     ///
     /// Runs on the same console as every other tool, so an agent with a memory wants a
     /// [`console`](Self::console) too — a memory tool without one fails saying so.
-    pub fn memory(mut self, memory: Memory) -> Self {
-        self.memory = Some(memory);
+    pub fn memory(mut self, memory: impl Into<Memory>) -> Self {
+        self.memory = Some(memory.into());
         self
     }
 
@@ -414,5 +414,20 @@ mod tests {
             Some(Memory::new("/work/notes.sqlite")),
             "the memory the builder was given is the one on the state"
         );
+    }
+
+    /// A path names a store, so it can be handed in as one and lands as the same value.
+    #[tokio::test]
+    async fn test_builder_memory_takes_a_path() {
+        use crate::memory::Memory;
+
+        ensure_dummy_provider();
+        let agent = AgentBuilder::new(TEST_MODEL)
+            .agent_provider(TEST_PROVIDER_NAME)
+            .memory(std::path::Path::new("/work/notes.sqlite"))
+            .build()
+            .unwrap();
+
+        assert_eq!(agent.state.memory, Some(Memory::new("/work/notes.sqlite")));
     }
 }

--- a/src/agent/rt.rs
+++ b/src/agent/rt.rs
@@ -9,7 +9,13 @@ use crate::{
     },
     lang_model::{LangModel, LangModelOptions},
     message::{Delta as _, FinishReason, Message, MessageDeltaOutput, MessageOutput, Part, Role},
-    tool::{ToolDesc, ToolFunc, get_tool_providers, r#impl::get_web_search_tool_factory},
+    tool::{
+        ToolDesc, ToolFunc, get_tool_providers,
+        r#impl::{
+            get_mem_insert_tool_desc, get_mem_insert_tool_func, get_mem_search_tool_desc,
+            get_mem_search_tool_func, get_web_search_tool_factory,
+        },
+    },
 };
 
 /// An agent that drives a language model through multi-turn, tool-augmented conversations.
@@ -133,6 +139,27 @@ impl Agent {
             );
             tool_descs.push(desc);
             tools.insert(tool_name, func);
+        }
+
+        // An agent given a memory gets the two tools for it, and one without a memory has
+        // no such tools to be told about. They are not resolved from the ToolProvider like
+        // the tools above, for the reason `tool::impl::memory` gives: which store is not a
+        // name in a registry but a `Memory` this one agent was handed, so the func has to
+        // be built here where that value is.
+        //
+        // Nothing is added to the instruction. What the model is told about remembering is
+        // the tool descriptions, until a prompt says more.
+        if let Some(memory) = state.memory.clone() {
+            for (desc, func) in [
+                (
+                    get_mem_search_tool_desc(),
+                    get_mem_search_tool_func(memory.clone()),
+                ),
+                (get_mem_insert_tool_desc(), get_mem_insert_tool_func(memory)),
+            ] {
+                tools.insert(desc.name.clone(), func);
+                tool_descs.push(desc);
+            }
         }
 
         // Build the system message from the instruction.
@@ -657,6 +684,7 @@ mod tests {
         agent::{AgentCard, AgentProvider, AgentSpec, ContextManager, get_agent_providers_mut},
         datatype::Value,
         lang_model::{LangModelProvider, get_lm_providers_mut},
+        memory::Memory,
         message::{Message, Part, PartDelta, Role},
         suppress_panics, to_value,
         tool::{ToolDescBuilder, ToolProvider, get_tool_providers_mut},
@@ -695,6 +723,27 @@ mod tests {
     fn default_test_provider() -> &'static str {
         refresh_default_lang_models();
         "default"
+    }
+
+    /// A model nothing calls, and a provider with a made-up key behind it — for the
+    /// tests that only construct an agent and look at what it was built with.
+    const DUMMY_MODEL: &str = "openai/gpt-4o-mini";
+
+    fn dummy_provider(name: &'static str) -> &'static str {
+        let mut lmps = get_lm_providers_mut();
+        if !lmps.contains_key(name) {
+            let mut lmp = LangModelProvider::new();
+            lmp.insert(
+                DUMMY_MODEL.into(),
+                LangModelProvider::openai("dummy".into()),
+            );
+            lmps.insert(name.to_string(), lmp);
+        }
+        drop(lmps);
+        get_agent_providers_mut()
+            .entry(name.to_string())
+            .or_insert_with(|| AgentProvider::new(name, "default"));
+        name
     }
 
     // ── tests ─────────────────────────────────────────────────────────────────
@@ -1296,5 +1345,37 @@ mod tests {
             state.console.lock().await.is_none(),
             "a fresh state has no console, and nothing fills it in"
         );
+    }
+
+    /// A memory on the state is the two memory tools on the agent — no spec entry, and
+    /// nothing registered in the ToolProvider.
+    #[tokio::test]
+    async fn test_memory_brings_its_two_tools() {
+        let provider = dummy_provider("agent_rt_memory_tests");
+        let state = AgentState::new().with_memory(Memory::new("/work/notes.sqlite"));
+        let agent =
+            Agent::try_with_provider_and_state(AgentSpec::new(DUMMY_MODEL), provider, state)
+                .unwrap();
+
+        let names: Vec<&str> = agent.tool_descs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, ["mem_search", "mem_insert"]);
+        assert!(agent.tools.contains_key("mem_search"));
+        assert!(agent.tools.contains_key("mem_insert"));
+    }
+
+    /// And an agent with no memory is told of no such tools, rather than being given two
+    /// that would fail on a store it does not have.
+    #[tokio::test]
+    async fn test_no_memory_means_no_memory_tools() {
+        let provider = dummy_provider("agent_rt_memory_tests");
+        let agent = Agent::try_with_provider_and_state(
+            AgentSpec::new(DUMMY_MODEL),
+            provider,
+            AgentState::new(),
+        )
+        .unwrap();
+
+        assert!(agent.tool_descs.is_empty(), "{:?}", agent.tool_descs);
+        assert!(agent.tools.is_empty());
     }
 }

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cortex::console::Console;
 use tokio::sync::Mutex;
 
-use crate::message::Message;
+use crate::{memory::Memory, message::Message};
 
 pub struct AgentState {
     pub history: Vec<Message>,
@@ -23,6 +23,18 @@ pub struct AgentState {
     /// spelled across concurrent tool futures.
     pub console: Arc<Mutex<Option<Console>>>,
 
+    /// The memory store this agent remembers into, if it has one.
+    ///
+    /// `None` is an agent that does not remember: it is given no memory tools, and
+    /// nothing is written down when the conversation ends. Which store — and whether
+    /// there is one at all — is the caller's decision, the same way the console is, so
+    /// nothing here fills this in either.
+    ///
+    /// A [`Memory`] is a path and not a handle, so this is cheap to clone into the
+    /// memory tools at construction and safe to share with a sub-agent that should
+    /// remember into the same store.
+    pub memory: Option<Memory>,
+
     /// Token count from the most recent model API call; used to decide when to truncate history.
     pub last_input_tokens: Option<u64>,
 }
@@ -38,6 +50,7 @@ impl AgentState {
         Self {
             history: Vec::new(),
             console: Arc::new(Mutex::new(None)),
+            memory: None,
             last_input_tokens: None,
         }
     }
@@ -57,6 +70,16 @@ impl AgentState {
     /// rather than given one of its own.
     pub fn with_console_slot(mut self, console: Arc<Mutex<Option<Console>>>) -> Self {
         self.console = console;
+        self
+    }
+
+    /// Remember into `memory`, which brings the `mem_search` and `mem_insert` tools with
+    /// it — see [`Agent::try_with_provider_and_state`](crate::agent::Agent::try_with_provider_and_state).
+    ///
+    /// The store is expected to exist already: `mem init` makes one, and an agent that
+    /// was pointed at a file that is not there hears so from its first memory tool call.
+    pub fn with_memory(mut self, memory: Memory) -> Self {
+        self.memory = Some(memory);
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod console;
 pub mod datatype;
 pub mod lang_model;
 pub(crate) mod macros;
+pub mod memory;
 pub mod message;
 pub mod tool;
 pub(crate) mod util;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -13,6 +13,8 @@
 //! so a mistyped name cannot become an empty store that answers every search with
 //! nothing, and a wrapper that quietly created one would undo that.
 
+use std::path::{Path, PathBuf};
+
 use crate::console::Console;
 
 /// One memory store, named by the file it is.
@@ -164,6 +166,39 @@ impl Memory {
             .filter(|line| !line.trim().is_empty())
             .map(|line| line.to_string())
             .collect())
+    }
+}
+
+/// A store named by a `String`, which is the name a `Memory` already is.
+impl From<String> for Memory {
+    fn from(memfile: String) -> Self {
+        Self::new(memfile)
+    }
+}
+
+/// The same for a borrowed name, since a path written in the call is the common way to
+/// name a store.
+impl From<&str> for Memory {
+    fn from(memfile: &str) -> Self {
+        Self::new(memfile)
+    }
+}
+
+/// A store named by a `PathBuf`, for callers that built the path rather than wrote it.
+///
+/// The path is spelled with [`Path::to_string_lossy`], because what is passed on is an
+/// argument to `mem` and argv here is `String`. A path that is not UTF-8 therefore names
+/// a store the far end will not find, and says so on the first command rather than here.
+impl From<PathBuf> for Memory {
+    fn from(memfile: PathBuf) -> Self {
+        Self::new(memfile.to_string_lossy().into_owned())
+    }
+}
+
+/// The same for a borrowed path.
+impl From<&Path> for Memory {
+    fn from(memfile: &Path) -> Self {
+        Self::new(memfile.to_string_lossy().into_owned())
     }
 }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,0 +1,330 @@
+//! Memories, as `mem` keeps them.
+//!
+//! A memory store is one file — the same file `mem init` makes — and reading or writing it
+//! is a command run on a [`Console`]. That is the whole of what this module is: `mem`
+//! already holds the store, so nothing here opens a database, links `rusqlite`, or knows
+//! what a row looks like. It spells one command line and reads the lines that come back.
+//!
+//! Which means the store has to be reachable from the console it is handed: `mem` is a
+//! name on the far end's `PATH` — attached by the console server or delegated to it —
+//! and the memory file is a path the far end can open, not one this process resolves.
+//!
+//! Bringing a store into being is not here. `mem init` is a command of its own precisely
+//! so a mistyped name cannot become an empty store that answers every search with
+//! nothing, and a wrapper that quietly created one would undo that.
+
+use crate::console::Console;
+
+/// One memory store, named by the file it is.
+///
+/// A path and nothing else. There is no handle to hold: `mem` opens the file per command
+/// and closes it again, so this stays cheap to clone and safe to hand to two callers —
+/// what serializes access to the store is the console lock, the same as for any other
+/// command an agent runs.
+///
+/// Which console it runs on is not here either, and is passed per call. An
+/// [`Agent`](crate::agent::Agent) holding a memory holds a console slot separately, and
+/// binding the two here would be a second answer to which console a tool runs in.
+///
+/// ```rust,no_run
+/// # use ailoy::memory::Memory;
+/// # async fn f(console: &mut ailoy::console::Console) -> anyhow::Result<()> {
+/// let memory = Memory::new("/work/notes.sqlite");
+/// memory.insert(console, ["User switched to oat milk"]).await?;
+/// let found = memory.search(console, "what does the user drink?").await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Memory {
+    memfile: String,
+}
+
+impl Memory {
+    /// The store at `memfile`, which `mem init` is expected to have made already.
+    ///
+    /// Nothing is checked here — a path is a path until a command is run with it, and the
+    /// console that would answer whether the file is there is not one of the arguments.
+    /// A store that is not there is heard from the first [`search`](Self::search) or
+    /// [`insert`](Self::insert).
+    pub fn new(memfile: impl Into<String>) -> Self {
+        Self {
+            memfile: memfile.into(),
+        }
+    }
+
+    /// The store, spelled as the caller spelled it.
+    pub fn memfile(&self) -> &str {
+        &self.memfile
+    }
+
+    /// The memories nearest `query`, nearest first.
+    ///
+    /// `mem search <memfile> <query>` on the console, and its stdout split into lines: one
+    /// memory per line, as `mem` prints them. Nothing near the query is an empty `Vec`
+    /// rather than an error — the store was read and holds nothing near this, which is an
+    /// answer.
+    ///
+    /// The argv goes to [`Console::exec`] as three arguments, so no shell sees them and
+    /// neither the path nor the query needs quoting or escaping.
+    ///
+    /// # Errors
+    ///
+    /// A store that is not there, a file that is not a store, and a `mem` the console
+    /// cannot run are all errors here: `mem` says which on stderr and exits non-zero, and
+    /// that sentence is what comes back. So is a console that could not carry the call at
+    /// all.
+    pub async fn search(
+        &self,
+        console: &mut Console,
+        query: impl AsRef<str>,
+    ) -> anyhow::Result<Vec<String>> {
+        self.run(console, "search", [query.as_ref()]).await
+    }
+
+    /// Write `memories` into the store, and hear back the ones it now holds.
+    ///
+    /// `mem insert <memfile> <memories>...` — one memory per argument, because argv is
+    /// already a list and a separator inside one argument would be a memory nobody could
+    /// write. What is handed in is what the store holds, word for word: nothing here
+    /// shortens, splits or rephrases it, and nothing reads it. The deciding is the
+    /// caller's and has already happened by the time this is called.
+    ///
+    /// It does not deduplicate, either. Told the same thing twice the store holds it
+    /// twice — two callers writing one sentence about different things is a case no
+    /// comparison of text could tell from a repeat.
+    ///
+    /// Nothing to write is a no-op and an empty `Vec`, which is the answer a caller with
+    /// an empty list wants rather than a case it has to check for before it can call at
+    /// all.
+    ///
+    /// # Errors
+    ///
+    /// A store that is not there is one, and nothing is created on the way past — `mem
+    /// init` makes a store. So is a memory that is nothing but whitespace: `mem` refuses
+    /// the whole line rather than dropping it from a list that would then look complete,
+    /// so either every memory here is written or none is.
+    pub async fn insert(
+        &self,
+        console: &mut Console,
+        memories: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> anyhow::Result<Vec<String>> {
+        let memories: Vec<String> = memories
+            .into_iter()
+            .map(|m| m.as_ref().to_string())
+            .collect();
+
+        // An empty list still goes to `mem`, which answers it with nothing and a zero.
+        // Short-circuiting here would be a second answer to that question, and one that
+        // stops saying whether the store was even there.
+        self.run(console, "insert", &memories).await
+    }
+
+    /// One `mem` command against this store, and the lines it answered with.
+    ///
+    /// Both commands above are the same shape — a subcommand, the store, then what the
+    /// subcommand takes — and both answer in the same one: memories, one per line. So how
+    /// a refusal is read and how output becomes memories is written once, here.
+    async fn run(
+        &self,
+        console: &mut Console,
+        subcommand: &str,
+        rest: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> anyhow::Result<Vec<String>> {
+        let memfile = &self.memfile;
+
+        let mut argv = vec!["mem".to_string(), subcommand.to_string(), memfile.clone()];
+        argv.extend(rest.into_iter().map(|arg| arg.as_ref().to_string()));
+
+        // No timeout: these are reads and writes of one local file, and what would make
+        // one slow is a store large enough that the caller still wants the answer.
+        let result = console
+            .exec(&argv, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("`mem {subcommand} {memfile}` could not be run: {e}"))?;
+
+        if result.code != 0 {
+            // `mem` names the store it refused on and why, which is the sentence worth
+            // passing on. Its exit code carries nothing this caller can act on beyond the
+            // failure itself — the command either happened or it did not.
+            let said = String::from_utf8_lossy(&result.stderr);
+            let said = said.trim();
+            anyhow::bail!(if said.is_empty() {
+                format!("`mem {subcommand} {memfile}` failed (exit {})", result.code)
+            } else {
+                said.to_string()
+            });
+        }
+
+        // A memory is a line, and a command answering with nothing is no lines at all.
+        // Blank lines are dropped rather than returned as empty memories: `mem` refuses
+        // to store one, so a blank line here is the trailing newline and not a memory.
+        Ok(String::from_utf8_lossy(&result.stdout)
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| line.to_string())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_console;
+
+    /// An empty store, made through the same console the test then uses — so what is
+    /// asserted is a store `mem` wrote, not a fixture that resembles one.
+    async fn store(console: &mut Console) -> Memory {
+        let dir = tempfile::tempdir().unwrap();
+        // Leaked rather than dropped: the file has to outlive this function, and the
+        // directory goes when the test process does.
+        let path = dir
+            .keep()
+            .join("notes.sqlite")
+            .to_string_lossy()
+            .to_string();
+
+        let init = console.exec(["mem", "init", &path], None).await.unwrap();
+        assert_eq!(init.code, 0, "{}", String::from_utf8_lossy(&init.stderr));
+
+        Memory::new(path)
+    }
+
+    /// A store with memories in it, put there by `mem` itself rather than by
+    /// [`Memory::insert`] — so a search test that fails is a search that failed.
+    async fn filled(console: &mut Console, memories: &[&str]) -> Memory {
+        let memory = store(console).await;
+
+        let mut argv = vec![
+            "mem".to_string(),
+            "insert".to_string(),
+            memory.memfile().to_string(),
+        ];
+        argv.extend(memories.iter().map(|m| m.to_string()));
+        let insert = console.exec(&argv, None).await.unwrap();
+        assert_eq!(
+            insert.code,
+            0,
+            "{}",
+            String::from_utf8_lossy(&insert.stderr)
+        );
+
+        memory
+    }
+
+    /// A store that was never made, for the tests about what that answers with.
+    fn missing() -> Memory {
+        let dir = tempfile::tempdir().unwrap();
+        Memory::new(
+            dir.keep()
+                .join("missing.sqlite")
+                .to_string_lossy()
+                .to_string(),
+        )
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_search_finds_the_nearest_memory() {
+        let mut console = test_console().await;
+        let memory = filled(
+            &mut console,
+            &["User drinks tea", "User switched to oat milk"],
+        )
+        .await;
+
+        let found = memory.search(&mut console, "oat milk").await.unwrap();
+        assert_eq!(found, ["User switched to oat milk"]);
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_search_with_nothing_near_is_empty() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &["User drinks tea"]).await;
+
+        let found = memory.search(&mut console, "almond").await.unwrap();
+        assert!(found.is_empty(), "nothing near the query: {found:?}");
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_search_on_a_store_that_is_not_there_is_an_error() {
+        let mut console = test_console().await;
+        let memory = missing();
+
+        let e = memory
+            .search(&mut console, "oat milk")
+            .await
+            .expect_err("there is no such store");
+        assert!(e.to_string().contains(memory.memfile()), "{e}");
+    }
+
+    /// What was written comes back, in the order it was given — and is in the store, not
+    /// merely echoed: asked for straight after, it is there.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_insert_writes_what_it_was_given() {
+        let mut console = test_console().await;
+        let memory = store(&mut console).await;
+
+        let written = memory
+            .insert(
+                &mut console,
+                ["User switched to oat milk", "User drinks tea"],
+            )
+            .await
+            .unwrap();
+        assert_eq!(written, ["User switched to oat milk", "User drinks tea"]);
+
+        let found = memory.search(&mut console, "oat milk").await.unwrap();
+        assert_eq!(found, ["User switched to oat milk"]);
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_insert_with_nothing_to_write_writes_nothing() {
+        let mut console = test_console().await;
+        let memory = store(&mut console).await;
+
+        let written = memory
+            .insert(&mut console, Vec::<String>::new())
+            .await
+            .unwrap();
+        assert!(written.is_empty(), "no memories, so no lines: {written:?}");
+    }
+
+    /// One unusable memory fails the line rather than being dropped from a list that then
+    /// looks complete — and the store is left as it was.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_insert_refuses_an_empty_memory() {
+        let mut console = test_console().await;
+        let memory = store(&mut console).await;
+
+        memory
+            .insert(&mut console, ["User drinks tea", "   "])
+            .await
+            .expect_err("a memory is a statement, and the second is empty");
+
+        let found = memory.search(&mut console, "tea").await.unwrap();
+        assert!(found.is_empty(), "nothing was written: {found:?}");
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_insert_into_a_store_that_is_not_there_is_an_error() {
+        let mut console = test_console().await;
+        let memory = missing();
+
+        let e = memory
+            .insert(&mut console, ["User drinks tea"])
+            .await
+            .expect_err("there is no such store");
+        assert!(e.to_string().contains(memory.memfile()), "{e}");
+        assert!(
+            !std::path::Path::new(memory.memfile()).exists(),
+            "a failed insert made nothing"
+        );
+    }
+}

--- a/src/tool/impl/memory.rs
+++ b/src/tool/impl/memory.rs
@@ -1,0 +1,365 @@
+//! `mem_search` and `mem_insert` — an agent's own memory, as two tools.
+//!
+//! # Why these are not built-ins
+//!
+//! Every tool in [`builtins`](super::builtins) is registered by name in a
+//! [`ToolProvider`](crate::tool::ToolProvider) and resolved from an
+//! [`AgentSpec`](crate::agent::AgentSpec), which works because the spec carries
+//! everything the tool needs. These two need one thing more: *which* store, and that is
+//! not a name in a registry — it is a [`Memory`] a caller handed to one agent.
+//!
+//! So the store is captured in the closure rather than asked for in the arguments. The
+//! model never names a memory file, cannot name a different one, and does not have to be
+//! told in the prompt which one is its own. An agent that was given a memory gets these
+//! two tools for it; one that was not, does not — see
+//! [`Agent::try_with_provider_and_state`](crate::agent::Agent::try_with_provider_and_state).
+
+use crate::{
+    memory::Memory,
+    tool::{ToolDesc, ToolDescBuilder, ToolFunc},
+};
+
+/// How many memories a search answers with when the caller does not say.
+///
+/// `mem`'s own default is the same number. Spelled here because it goes in the
+/// description the model reads, and a description that disagreed with the command would
+/// be worse than none.
+const DEFAULT_LIMIT: i64 = 10;
+
+pub fn get_mem_search_tool_desc() -> ToolDesc {
+    ToolDescBuilder::new("mem_search")
+        .description(concat!(
+            "Recall what you have written down about this user and your past work with them. ",
+            "Answers with the stored memories nearest the query, nearest first — this is a ",
+            "similarity search over remembered statements, not a substring match, so ask it ",
+            "in words rather than in a pattern. ",
+            "No memory near the query is an empty list: the store was read and holds nothing ",
+            "about this. Which store is searched is fixed; there is no path to give.",
+        ))
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "What to recall, as a question or a phrase (e.g. 'what does the user drink?')"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "How many memories to answer with (default 10).",
+                    "minimum": 1,
+                    "default": DEFAULT_LIMIT
+                }
+            },
+            "required": ["query"]
+        }))
+        .build()
+}
+
+/// The `mem_search` tool for `memory`.
+///
+/// One store per tool, captured here — see the module docs for why the model is not asked
+/// for a path.
+pub fn get_mem_search_tool_func(memory: Memory) -> ToolFunc {
+    crate::tool_func!(async |args: Value, console: &mut Console| -> Value
+        with [memory = memory.clone()]
+    {
+        let Some(query) = args.pointer("/query").and_then(|v| v.as_str()) else {
+            return crate::to_value!({
+                "error": "missing required parameter: query",
+                "phase": "validation",
+            });
+        };
+        let limit = args
+            .pointer("/limit")
+            .and_then(|v| v.as_integer())
+            .map(|n| n.max(1))
+            .unwrap_or(DEFAULT_LIMIT) as usize;
+
+        let found = match memory.search(console, query).await {
+            Ok(found) => found,
+            Err(e) => {
+                return crate::to_value!({
+                    "error": format!("{e}"),
+                    "phase": "io",
+                });
+            }
+        };
+
+        // Bounded here rather than by `mem -n`: the limit is the model's to raise and the
+        // store answers in nearest-first order either way, so taking the front of the
+        // answer is the same list a smaller `-n` would have returned.
+        let count = found.len().min(limit);
+        crate::to_value!({
+            "memories": crate::datatype::Value::array(found.into_iter().take(limit)),
+            "count": count as i64,
+        })
+    })
+}
+
+pub fn get_mem_insert_tool_desc() -> ToolDesc {
+    ToolDescBuilder::new("mem_insert")
+        .description(concat!(
+            "Write down something worth remembering after this conversation ends — a ",
+            "preference, a decision, a fact about the user or their project. ",
+            "Each memory is stored word for word, so write one that will still make sense ",
+            "read on its own months from now: a whole statement rather than a fragment, ",
+            "with the subject named instead of 'they' or 'it'. ",
+            "Nothing is rewritten or summarized on the way in, and nothing is ",
+            "de-duplicated — deciding what is worth keeping is yours. ",
+            "Which store is written is fixed; there is no path to give.",
+        ))
+        .parameters(crate::to_value!({
+            "type": "object",
+            "properties": {
+                "memories": {
+                    "type": "array",
+                    "description": "The memories to store, one statement per item (e.g. 'The user prefers oat milk in coffee').",
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["memories"]
+        }))
+        .build()
+}
+
+/// The `mem_insert` tool for `memory`.
+pub fn get_mem_insert_tool_func(memory: Memory) -> ToolFunc {
+    crate::tool_func!(async |args: Value, console: &mut Console| -> Value
+        with [memory = memory.clone()]
+    {
+        // An array, and only an array. A bare string would be one memory and is tempting
+        // to accept, but a model that meant two and wrote them into one string would have
+        // that stored as a single memory, word for word — which is exactly what this tool
+        // promises and exactly the wrong result. The refusal names the shape instead.
+        let Some(memories) = args.pointer("/memories").and_then(|v| v.as_array()) else {
+            return crate::to_value!({
+                "error": "missing required parameter: memories (an array of strings)",
+                "phase": "validation",
+            });
+        };
+
+        let mut texts: Vec<String> = Vec::with_capacity(memories.len());
+        for memory in memories {
+            let Some(text) = memory.as_str() else {
+                return crate::to_value!({
+                    "error": "every entry in memories must be a string",
+                    "phase": "validation",
+                });
+            };
+            texts.push(text.to_string());
+        }
+
+        let written = match memory.insert(console, &texts).await {
+            Ok(written) => written,
+            Err(e) => {
+                return crate::to_value!({
+                    "error": format!("{e}"),
+                    "phase": "io",
+                });
+            }
+        };
+
+        crate::to_value!({
+            "stored": crate::datatype::Value::array(written.clone()),
+            "count": written.len() as i64,
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+
+    use super::*;
+    use crate::{console::Console, datatype::Value, message::Message, test_console, to_value};
+
+    /// A store with memories in it, made and filled by `mem` itself.
+    async fn filled(console: &mut Console, memories: &[&str]) -> Memory {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .keep()
+            .join("notes.sqlite")
+            .to_string_lossy()
+            .to_string();
+
+        let init = console.exec(["mem", "init", &path], None).await.unwrap();
+        assert_eq!(init.code, 0, "{}", String::from_utf8_lossy(&init.stderr));
+
+        if !memories.is_empty() {
+            let mut argv = vec!["mem".to_string(), "insert".to_string(), path.clone()];
+            argv.extend(memories.iter().map(|m| m.to_string()));
+            let insert = console.exec(&argv, None).await.unwrap();
+            assert_eq!(
+                insert.code,
+                0,
+                "{}",
+                String::from_utf8_lossy(&insert.stderr)
+            );
+        }
+
+        Memory::new(path)
+    }
+
+    /// One call of a tool, as the agent makes it.
+    async fn call(func: &ToolFunc, args: Value, console: &mut Console) -> Message {
+        func.call(args, "1", console).next().await.unwrap().message
+    }
+
+    fn value(msg: &Message) -> Value {
+        msg.contents[0].as_value().unwrap().clone()
+    }
+
+    fn strings(value: &Value, at: &str) -> Vec<String> {
+        value
+            .pointer(at)
+            .and_then(|v| v.as_array())
+            .expect("an array")
+            .iter()
+            .map(|v| v.as_str().expect("a string").to_string())
+            .collect()
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_search_tool_answers_with_the_nearest_memory() {
+        let mut console = test_console().await;
+        let memory = filled(
+            &mut console,
+            &["User drinks tea", "User switched to oat milk"],
+        )
+        .await;
+        let func = get_mem_search_tool_func(memory);
+
+        let out = value(&call(&func, to_value!({ "query": "oat milk" }), &mut console).await);
+        assert_eq!(strings(&out, "/memories"), ["User switched to oat milk"]);
+        assert_eq!(out.pointer("/count").unwrap().as_integer().unwrap(), 1);
+    }
+
+    /// The bound the model asked for is the bound it gets.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_search_tool_honors_limit() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &["User drinks tea", "User drinks coffee"]).await;
+        let func = get_mem_search_tool_func(memory);
+
+        let out = value(
+            &call(
+                &func,
+                to_value!({ "query": "what does the user drink", "limit": 1 }),
+                &mut console,
+            )
+            .await,
+        );
+        assert_eq!(strings(&out, "/memories").len(), 1);
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_search_tool_with_nothing_near_is_an_empty_list() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &["User drinks tea"]).await;
+        let func = get_mem_search_tool_func(memory);
+
+        let out = value(&call(&func, to_value!({ "query": "almond" }), &mut console).await);
+        assert!(strings(&out, "/memories").is_empty(), "{out:?}");
+        assert_eq!(out.pointer("/count").unwrap().as_integer().unwrap(), 0);
+    }
+
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_search_tool_without_a_query_is_a_validation_error() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &[]).await;
+        let func = get_mem_search_tool_func(memory);
+
+        let out = value(&call(&func, to_value!({}), &mut console).await);
+        assert_eq!(
+            out.pointer("/phase").unwrap().as_str().unwrap(),
+            "validation"
+        );
+    }
+
+    /// Written by the tool, and read back by the other one: the pair works on one store.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_insert_tool_writes_what_it_was_given() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &[]).await;
+        let insert = get_mem_insert_tool_func(memory.clone());
+        let search = get_mem_search_tool_func(memory);
+
+        let out = value(
+            &call(
+                &insert,
+                to_value!({ "memories": ["User switched to oat milk", "User drinks tea"] }),
+                &mut console,
+            )
+            .await,
+        );
+        assert_eq!(
+            strings(&out, "/stored"),
+            ["User switched to oat milk", "User drinks tea"]
+        );
+
+        let found = value(&call(&search, to_value!({ "query": "oat milk" }), &mut console).await);
+        assert_eq!(strings(&found, "/memories"), ["User switched to oat milk"]);
+    }
+
+    /// A single string is not one memory here — the shape is named in the refusal rather
+    /// than guessed at, because a guess would store two statements as one.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_insert_tool_refuses_a_bare_string() {
+        let mut console = test_console().await;
+        let memory = filled(&mut console, &[]).await;
+        let func = get_mem_insert_tool_func(memory);
+
+        let out = value(
+            &call(
+                &func,
+                to_value!({ "memories": "User drinks tea" }),
+                &mut console,
+            )
+            .await,
+        );
+        assert_eq!(
+            out.pointer("/phase").unwrap().as_str().unwrap(),
+            "validation"
+        );
+    }
+
+    /// A store that is not there is `mem`'s sentence, arriving as an `io` failure the
+    /// model can read rather than as a tool that returned nothing.
+    #[test_with::executable(mem)]
+    #[tokio::test]
+    async fn test_mem_insert_tool_reports_a_missing_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("missing.sqlite")
+            .to_string_lossy()
+            .to_string();
+
+        let mut console = test_console().await;
+        let func = get_mem_insert_tool_func(Memory::new(&path));
+
+        let out = value(
+            &call(
+                &func,
+                to_value!({ "memories": ["User drinks tea"] }),
+                &mut console,
+            )
+            .await,
+        );
+        assert_eq!(out.pointer("/phase").unwrap().as_str().unwrap(), "io");
+        assert!(
+            out.pointer("/error")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .contains(&path),
+            "{out:?}"
+        );
+    }
+}

--- a/src/tool/impl/mod.rs
+++ b/src/tool/impl/mod.rs
@@ -1,6 +1,8 @@
 // mod a2a;
 mod builtins;
+mod memory;
 
 // pub(crate) use a2a::{get_a2a_tool_desc, get_a2a_tool_func};
 pub use builtins::WebSearchEngineKind;
 pub(crate) use builtins::*;
+pub(crate) use memory::*;


### PR DESCRIPTION
This is a simple PoC demonstrating how mem can be attached to Ailoy.

Probably it does not work properly yet.

Unlike exposing `mem-search` as a tool(used in here), Claude Code and Hermes Agent perform a `mem search` before the agent starts and append the retrieved memories to the system message.

This part has not been implemented yet and should be added in the future.